### PR TITLE
Switch confidence display to qualitative labels (medium/high/low)

### DIFF
--- a/.github/actions/auto-triage/action.yml
+++ b/.github/actions/auto-triage/action.yml
@@ -302,7 +302,7 @@ runs:
 
     - name: Send Slack notification
       if: always() && inputs.send-slack-message == 'true'
-      uses: tenstorrent/tt-auto-triage/.github/actions/slack-report-auto-triage@ebanerjee/changing-wording-of-slack-messages
+      uses: tenstorrent/tt-auto-triage/.github/actions/slack-report-auto-triage@main
       with:
         # slack_webhook_url is no longer used, using env.SLACK_BOT_TOKEN and env.SLACK_CHANNEL_ID instead inside the action
         channel_id: ${{ env.SLACK_CHANNEL_ID }}


### PR DESCRIPTION
Replaces numeric confidence scores (e.g. 98/100) with qualitative labels:
- 100 → high confidence
- 96-99 → medium confidence  
- else → low confidence

Also updates the auto-triage action to call slack-report-auto-triage from the same branch so the change takes effect when testing before merge.

Made with [Cursor](https://cursor.com)