### PR TITLE
PR #9: Extract single_commit.sh module (Phase 3 - Commit Data)

### DIFF
--- a/.github/actions/auto-triage/auto_triage/download_data_for_single_commit.sh
+++ b/.github/actions/auto-triage/auto_triage/download_data_for_single_commit.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-
+#
 # Utility script: download metadata for a single commit using the same
 # schema as download_data_between_commits_batch.sh.
 #
@@ -8,33 +8,28 @@
 #
 # If output_file is omitted, it defaults to auto_triage/data/commit_info.json
 # and the entry is appended to the JSON array (creating it as [] if needed).
+#
 
 set -euo pipefail
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=modules/commit_data/single_commit.sh
+source "$SCRIPT_DIR/modules/commit_data/single_commit.sh"
 
 if [ $# -lt 1 ]; then
-  echo -e "${RED}Error: Missing required arguments${NC}" >&2
-  echo "Usage: $0 <commit_sha> [output_file]" >&2
-  exit 1
+    log_error "Missing required arguments"
+    echo "Usage: $0 <commit_sha> [output_file]" >&2
+    exit 1
 fi
 
 COMMIT_SHA="$1"
 OUTPUT_FILE="${2:-auto_triage/data/commit_info.json}"
 
 if ! git rev-parse --verify "$COMMIT_SHA" >/dev/null 2>&1; then
-  echo -e "${RED}Error: commit '$COMMIT_SHA' not found${NC}" >&2
-  exit 1
-fi
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-BATCH_SCRIPT="${SCRIPT_DIR}/download_data_between_commits_batch.sh"
-
-if [ ! -x "$BATCH_SCRIPT" ]; then
-  echo -e "${RED}Error: helper script '$BATCH_SCRIPT' is missing or not executable${NC}" >&2
-  exit 1
+    log_error "commit '$COMMIT_SHA' not found"
+    exit 1
 fi
 
 OUTPUT_DIR="$(dirname "$OUTPUT_FILE")"
@@ -42,8 +37,8 @@ mkdir -p "$OUTPUT_DIR"
 
 # Ensure the output file exists and is a JSON array before appending.
 if [ ! -f "$OUTPUT_FILE" ]; then
-  echo "[]" > "$OUTPUT_FILE"
+    echo "[]" > "$OUTPUT_FILE"
 fi
 
-echo -e "${GREEN}Downloading metadata for single commit ${COMMIT_SHA}${NC}"
-"$BATCH_SCRIPT" "$COMMIT_SHA" "$COMMIT_SHA" 0 "$OUTPUT_FILE"
+log_success "Downloading metadata for single commit ${COMMIT_SHA}"
+download_single_commit "$COMMIT_SHA" "$OUTPUT_FILE"

--- a/.github/actions/auto-triage/auto_triage/modules/commit_data/single_commit.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/commit_data/single_commit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# single_commit.sh - Download metadata for a single commit
+#
+# Provides download_single_commit(commit_sha, output_file).
+# Reuses batch_downloader logic (batch of 1).
+#
+# Usage: source this file, then call download_single_commit
+#
+
+if [ -n "${_SINGLE_COMMIT_LOADED:-}" ]; then
+    return 0
+fi
+_SINGLE_COMMIT_LOADED=1
+
+_SC_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=batch_downloader.sh
+source "$_SC_DIR/batch_downloader.sh"
+
+# Download commit metadata for a single commit.
+# Appends one entry to output_file (same schema as batch_downloader).
+#
+#   download_single_commit "abc123" "auto_triage/data/commit_info.json"
+#
+download_single_commit() {
+    local commit_sha="$1"
+    local output_file="${2:-auto_triage/data/commit_info.json}"
+
+    if [ -z "$commit_sha" ]; then
+        echo "single_commit: commit_sha is required" >&2
+        return 1
+    fi
+
+    # Reuse batch_downloader: single commit = batch of 1 (start=end, batch_idx=0)
+    download_commit_batch "$commit_sha" "$commit_sha" 0 "$output_file"
+}

--- a/.github/actions/auto-triage/auto_triage/tests/modules/commit_data/single_commit_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/modules/commit_data/single_commit_test.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+#
+# Tests for modules/commit_data/single_commit.sh
+#
+# Tests single commit download using a mock gh CLI.
+#
+# Run: cd .github/actions/auto-triage/auto_triage && ./tests/modules/commit_data/single_commit_test.sh
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+
+source "$SCRIPT_DIR/../../lib/test_harness.sh"
+export AUTO_TRIAGE_ROOT="$ROOT_DIR"
+
+# -- create mock gh CLI --------------------------------------------------------
+MOCK_DIR=$(mktemp -d)
+cleanup() { rm -rf "$MOCK_DIR"; }
+trap cleanup EXIT
+
+cat > "$MOCK_DIR/gh" <<'MOCKSCRIPT'
+#!/bin/bash
+endpoint=""
+method="GET"
+jq_expr=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        api)        shift; continue ;;
+        --method)   method="$2"; shift 2; continue ;;
+        --jq)       jq_expr="$2"; shift 2; continue ;;
+        -H)         shift 2; continue ;;
+        -i)         shift; continue ;;
+        *)          endpoint="$1"; shift ;;
+    esac
+done
+
+case "$endpoint" in
+    users/*)
+        echo '{"login":"'$(echo "$endpoint" | sed 's|users/||')'","name":"Test User"}' ;;
+    orgs/tenstorrent/members/*)
+        echo '{}' ;;  # 200 = member
+    repos/tenstorrent/tt-metal/pulls/*/reviews)
+        echo '[{"user":{"login":"approver1"},"state":"APPROVED"},{"user":{"login":"copilot-pull-request-reviewer"},"body":"## Pull Request Overview\n\nSingle commit overview.\n\n### Reviewed Changes"}]' ;;
+    repos/tenstorrent/tt-metal/pulls/*)
+        pr_num=$(echo "$endpoint" | sed 's|.*pulls/||' | sed 's|/.*||')
+        echo '{"title":"Single Commit PR","html_url":"https://github.com/tenstorrent/tt-metal/pull/'$pr_num'","body":"","user":{"login":"pr-author"}}' ;;
+    repos/tenstorrent/tt-metal/commits/*)
+        sha=$(echo "$endpoint" | sed 's|.*commits/||')
+        echo '{"sha":"'$sha'","author":{"login":"commit-author"},"commit":{"author":{"name":"Commit Author"}}}' ;;
+    *)
+        echo '{"message":"Not Found"}'
+        exit 1 ;;
+esac
+MOCKSCRIPT
+chmod +x "$MOCK_DIR/gh"
+export PATH="$MOCK_DIR:$PATH"
+
+# -- create temp git repo ------------------------------------------------------
+GIT_DIR=$(mktemp -d)
+trap "rm -rf $MOCK_DIR $GIT_DIR" EXIT
+cd "$GIT_DIR"
+git init -q
+git config user.email "test@test.com"
+git config user.name "Test"
+echo "first" > f && git add f && git commit -q -m "first"
+echo "second" > g && git add g && git commit -q -m "Merge (#99) from feature branch"
+SINGLE_COMMIT=$(git rev-parse HEAD)
+
+# -- source module -------------------------------------------------------------
+# shellcheck source=../../../modules/commit_data/single_commit.sh
+source "$ROOT_DIR/modules/commit_data/single_commit.sh"
+
+echo "=== modules/commit_data/single_commit.sh ==="
+
+# -- download_single_commit exists ----------------------------------------------
+assert "download_single_commit is defined" type download_single_commit &>/dev/null
+
+# -- run single commit download -------------------------------------------------
+OUTPUT_JSON="$GIT_DIR/out.json"
+download_single_commit "$SINGLE_COMMIT" "$OUTPUT_JSON"
+
+assert "output file created" [ -f "$OUTPUT_JSON" ]
+count=$(jq 'length' "$OUTPUT_JSON")
+assert_eq "one commit entry" "$count" "1"
+
+entry=$(jq '.[0]' "$OUTPUT_JSON")
+assert_eq "commit_short present" "$(echo "$entry" | jq -r '.commit_short')" "${SINGLE_COMMIT:0:8}"
+assert_eq "pr_number" "$(echo "$entry" | jq -r '.pr_number')" "99"
+assert_eq "pr_title" "$(echo "$entry" | jq -r '.pr_title')" "Single Commit PR"
+overview=$(echo "$entry" | jq -r '.copilot_overview')
+assert "copilot_overview contains expected text" echo "$overview" | grep -q "Single commit overview"
+assert "authors array" [ "$(echo "$entry" | jq -r '.authors | length')" -ge 1 ]
+assert "approvers array" [ "$(echo "$entry" | jq -r '.approvers | length')" -ge 1 ]
+
+# -- invalid commit fails (empty sha) -------------------------------------------
+assert_fails "empty commit_sha" download_single_commit "" "$OUTPUT_JSON"
+
+test_summary


### PR DESCRIPTION
## Summary

Extracts `single_commit.sh` module and refactors `download_data_for_single_commit.sh` to use it, per the auto-triage refactoring plan Phase 3 (Commit Data).

## Changes

### New: `modules/commit_data/single_commit.sh`
- Adds `download_single_commit(commit_sha, output_file)` function
- Reuses `batch_downloader` logic by calling `download_commit_batch(sha, sha, 0, output)` (single commit = batch of 1)

### Updated: `download_data_for_single_commit.sh`
- Sources `lib/common.sh` and `modules/commit_data/single_commit.sh`
- Replaces hardcoded colors with `log_error` and `log_success`
- Calls `download_single_commit()` instead of `download_data_between_commits_batch.sh`

### New: `tests/modules/commit_data/single_commit_test.sh`
- Unit tests with mock gh CLI
- Verifies output JSON schema (commit_short, pr_number, pr_title, authors, approvers, copilot_overview)
- Tests empty commit_sha fails

## Merge criteria
- [x] All tests pass (lib + batch_downloader + single_commit)
- [x] `download_data_for_single_commit.sh` produces identical behavior
- [x] No changes to existing callers

## Plan reference
Refactoring plan Phase 3, PR #9.

Made with [Cursor](https://cursor.com)