### PR TITLE
Shift job-owner pinging to auto-triage for deterministic failures

### DIFF
--- a/.github/actions/slack-report-auto-triage/action.yml
+++ b/.github/actions/slack-report-auto-triage/action.yml
@@ -366,9 +366,9 @@ runs:
         JOB_OWNER_PING=""
         JOB_OWNER_FILE=".auto_triage/data/job_owner.json"
         if [ -f "$JOB_OWNER_FILE" ]; then
-          JOB_OWNER_PING=$(jq -r '
+          JOB_OWNER_PING=$(jq -r --arg allow "$ALLOW_PINGS" '
             [.[] | select(.name != "") |
-              if (.slack_id // "") != "" then
+              if ($allow == "true") and ((.slack_id // "") != "") then
                 if (.slack_id | startswith("S")) then
                   "<!subteam^" + .slack_id + "|@" + .name + ">"
                 else


### PR DESCRIPTION
## Summary
- Adds a new **JOB OWNER** field to auto-triage Slack messages for deterministic failures (cases 1, 2, 4). Auto-triage reads the parent regression notification thread, extracts the job owner name, resolves their Slack ID from the cached directory, and pings them.
- Capitalizes confidence labels in Slack messages (e.g., `LOW CONFIDENCE` instead of `low confidence`).
- Removes the `slack_message` free-text paragraph and top-level `RELEVANT FILES` section from Slack notifications to reduce noise (both are available in the full report).

## Context
Companion PR to [tt-metal](https://github.com/tenstorrent/tt-metal) which stops pinging job owners in the main regression notification. Together, these changes ensure owners are only pinged when their job has a deterministic failure, reducing notification spam.

## Test plan
- [x] Tested end-to-end with forced regression on test Slack channel
- [x] Verified JOB OWNER field appears with proper Slack ping for deterministic failures
- [x] Verified case 3 (infra/external) messages remain unchanged
- [ ] Merge this PR first, then merge the tt-metal companion PR

Made with [Cursor](https://cursor.com)