### PR TITLE
PR #19: Extract result_comparator.sh module

### DIFF
--- a/.github/actions/auto-triage/auto_triage/modules/retry/result_comparator.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/retry/result_comparator.sh
@@ -1,10 +1,16 @@
 #!/bin/bash
 #
-# result_comparator.sh - Compare retry vs original errors and determine result type
+# result_comparator.sh - Compare retry vs original errors using Copilot (LLM)
+#
+# Uses Copilot to compare error messages. Expects original_error.txt and
+# retry_error.txt in data_dir (written by caller). Copilot writes
+# error_comparison.json with same_failure, retry_error_extracted.
 #
 # Provides:
-#   compare_errors(original_error, retry_error) -> similarity_score (0-100)
-#   determine_retry_result(original_status, retry_status, error_similarity) -> result_type
+#   run_copilot_error_comparison(root, data_dir) -> 0 on success
+#   get_same_failure_from_comparison(comparison_file) -> "true"|"false"
+#   get_retry_error_extracted(comparison_file) -> extracted error text
+#   determine_retry_result(retry_status, same_failure) -> result_type
 #
 # Result types: passed, failed_same, failed_different
 # Uses lib/common.sh
@@ -22,98 +28,96 @@ _LIB_DIR="${_MODULE_DIR}/../../lib"
 # shellcheck source=../../lib/common.sh
 [ -f "${_LIB_DIR}/common.sh" ] && source "${_LIB_DIR}/common.sh"
 
-# Threshold above which errors are considered "same"
-RESULT_COMPARATOR_SAME_THRESHOLD="${RESULT_COMPARATOR_SAME_THRESHOLD:-70}"
-
 # ==============================================================================
-# Normalize error text for comparison (lowercase, collapse whitespace)
-# ==============================================================================
-_result_comparator_normalize() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | tr -s ' \t\n\r' ' ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
-}
-
-# ==============================================================================
-# Extract significant words (alphanumeric, underscores, hyphens)
-# ==============================================================================
-_result_comparator_words() {
-    echo "$1" | tr -cs '[:alnum:]_-' '\n' | grep -v '^$' | sort -u
-}
-
-# ==============================================================================
-# compare_errors(original_error, retry_error) -> similarity_score (0-100)
+# run_copilot_error_comparison(root, data_dir) -> 0 on success, 1 on failure
 #
-# Heuristic comparison using substring containment and word overlap.
-# For LLM-based comparison, the caller can use a different path (e.g. Copilot)
-# and pass the result into determine_retry_result.
+# Invokes Copilot with compare_errors_instructions.txt. Expects
+# original_error.txt and retry_error.txt to exist in data_dir.
+# Writes error_comparison.json to data_dir on success.
 # ==============================================================================
-compare_errors() {
-    local orig="${1:-}"
-    local retry="${2:-}"
+run_copilot_error_comparison() {
+    local root="${1:-}"
+    local data_dir="${2:-}"
 
-    if [ -z "$orig" ] || [ -z "$retry" ]; then
-        echo "0"
+    if [ -z "$root" ] || [ -z "$data_dir" ]; then
+        log_error "run_copilot_error_comparison: root and data_dir required"
+        return 1
+    fi
+
+    local instructions_path="${root}/compare_errors_instructions.txt"
+    if [ ! -f "$instructions_path" ]; then
+        log_error "compare_errors_instructions.txt not found at ${instructions_path}"
+        return 1
+    fi
+
+    if [ ! -f "${data_dir}/original_error.txt" ] || [ ! -f "${data_dir}/retry_error.txt" ]; then
+        log_error "run_copilot_error_comparison: original_error.txt and retry_error.txt must exist in data_dir"
+        return 1
+    fi
+
+    local compare_prompt
+    compare_prompt=$(printf 'You are operating in a CI environment. Compare two error messages and determine if they represent the same failure.\n\n%s' "$(cat "$instructions_path")")
+
+    # Ensure COPILOT_GITHUB_TOKEN is set (Copilot uses it for GitHub context)
+    if [ -z "${COPILOT_GITHUB_TOKEN:-}" ]; then
+        export COPILOT_GITHUB_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+    fi
+
+    # Export for mock copilot (tests can inject a script that reads this)
+    export RESULT_COMPARATOR_DATA_DIR="$data_dir"
+
+    local saved_pwd
+    saved_pwd=$(pwd)
+    cd "$root" || return 1
+    copilot -p "$compare_prompt" --allow-all-tools 2>/dev/null || true
+    cd "$saved_pwd" || true
+
+    if [ -f "${data_dir}/error_comparison.json" ]; then
         return 0
     fi
-
-    local orig_norm retry_norm
-    orig_norm=$(_result_comparator_normalize "$orig")
-    retry_norm=$(_result_comparator_normalize "$retry")
-
-    # Substring: if one contains the other (longer contains shorter), high score
-    if [ ${#orig_norm} -gt ${#retry_norm} ]; then
-        if [[ "$orig_norm" == *"$retry_norm"* ]] && [ ${#retry_norm} -gt 20 ]; then
-            echo "85"
-            return 0
-        fi
-    else
-        if [[ "$retry_norm" == *"$orig_norm"* ]] && [ ${#orig_norm} -gt 20 ]; then
-            echo "85"
-            return 0
-        fi
-    fi
-
-    # Word overlap: Jaccard-like = |intersection| / min(|a|, |b|) * 100
-    local orig_words retry_words common
-    orig_words=$(_result_comparator_words "$orig_norm")
-    retry_words=$(_result_comparator_words "$retry_norm")
-
-    common=$(comm -12 <(echo "$orig_words") <(echo "$retry_words") 2>/dev/null | wc -l | tr -d ' ')
-    local count_orig count_retry
-    count_orig=$(echo "$orig_words" | wc -l | tr -d ' ')
-    count_retry=$(echo "$retry_words" | wc -l | tr -d ' ')
-
-    if [ "$count_orig" -eq 0 ] || [ "$count_retry" -eq 0 ]; then
-        echo "0"
-        return 0
-    fi
-
-    local min_count
-    min_count=$(( count_orig < count_retry ? count_orig : count_retry ))
-    local score
-    score=$(( common * 100 / min_count ))
-    [ $score -gt 100 ] && score=100
-    echo "$score"
+    log_warn "Copilot did not produce error_comparison.json; assuming different failures"
+    return 1
 }
 
 # ==============================================================================
-# determine_retry_result(original_status, retry_status, error_similarity) -> result_type
+# get_same_failure_from_comparison(comparison_file) -> "true"|"false"
+# ==============================================================================
+get_same_failure_from_comparison() {
+    local file="${1:-}"
+    if [ -z "$file" ] || [ ! -f "$file" ]; then
+        echo "false"
+        return 0
+    fi
+    jq -r '.same_failure // false' "$file" 2>/dev/null || echo "false"
+}
+
+# ==============================================================================
+# get_retry_error_extracted(comparison_file) -> extracted error text (or "")
+# ==============================================================================
+get_retry_error_extracted() {
+    local file="${1:-}"
+    if [ -z "$file" ] || [ ! -f "$file" ]; then
+        echo ""
+        return 0
+    fi
+    jq -r '.retry_error_extracted // ""' "$file" 2>/dev/null || echo ""
+}
+
+# ==============================================================================
+# determine_retry_result(retry_status, same_failure) -> result_type
 #
 # Returns: passed | failed_same | failed_different
 # ==============================================================================
 determine_retry_result() {
-    local original_status="${1:-}"
-    local retry_status="${2:-}"
-    local error_similarity="${3:-0}"
+    local retry_status="${1:-}"
+    local same_failure="${2:-false}"
 
-    # Retry passed -> non-deterministic
     if [ "$retry_status" = "success" ]; then
         echo "passed"
         return 0
     fi
 
-    # Retry failed: use similarity to decide same vs different
-    local threshold="${RESULT_COMPARATOR_SAME_THRESHOLD:-70}"
-    if [ "$error_similarity" -ge "$threshold" ]; then
+    if [ "$same_failure" = "true" ]; then
         echo "failed_same"
     else
         echo "failed_different"

--- a/.github/actions/auto-triage/auto_triage/tests/modules/retry/result_comparator_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/modules/retry/result_comparator_test.sh
@@ -2,8 +2,8 @@
 #
 # Unit tests for modules/retry/result_comparator.sh
 #
+# Uses a mock copilot CLI to avoid invoking real Copilot.
 # Run: bash tests/modules/retry/result_comparator_test.sh
-# Or:  cd .github/actions/auto-triage/auto_triage && ./tests/modules/retry/result_comparator_test.sh
 #
 
 set -euo pipefail
@@ -13,64 +13,65 @@ AT_ROOT="$REPO_ROOT/.github/actions/auto-triage/auto_triage"
 source "$REPO_ROOT/testing_lib_files/test_harness.sh"
 export AUTO_TRIAGE_ROOT="$AT_ROOT"
 
+# -- create mock copilot ------------------------------------------------------
+MOCK_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR"' EXIT
+cat > "$MOCK_DIR/copilot" <<'MOCK'
+#!/bin/bash
+# When RESULT_COMPARATOR_DATA_DIR is set (by run_copilot_error_comparison),
+# write a known error_comparison.json for testing.
+if [ -n "${RESULT_COMPARATOR_DATA_DIR:-}" ] && [ -d "${RESULT_COMPARATOR_DATA_DIR}" ]; then
+    echo '{"same_failure": true, "retry_error_extracted": "Mock extracted error"}' \
+        > "${RESULT_COMPARATOR_DATA_DIR}/error_comparison.json"
+fi
+exit 0
+MOCK
+chmod +x "$MOCK_DIR/copilot"
+export PATH="$MOCK_DIR:$PATH"
+
 source "$AT_ROOT/modules/retry/result_comparator.sh"
 
 echo "=== modules/retry/result_comparator.sh ==="
 
-# -- compare_errors -----------------------------------------------------------
-# Empty inputs -> 0
-score=$(compare_errors "" "something")
-assert_eq "compare_errors: empty original returns 0" "$score" "0"
-score=$(compare_errors "something" "")
-assert_eq "compare_errors: empty retry returns 0" "$score" "0"
+# -- get_same_failure_from_comparison ------------------------------------------
+assert_eq "get_same_failure: missing file" "$(get_same_failure_from_comparison "")" "false"
+assert_eq "get_same_failure: nonexistent file" "$(get_same_failure_from_comparison /nonexistent)" "false"
 
-# Identical errors -> high score (substring/containment returns 85)
-orig="FAILED tests/ttnn/test_ops.py::test_reduce_max - AssertionError: max mismatch"
-score=$(compare_errors "$orig" "$orig")
-assert_eq "compare_errors: identical errors score high" "$score" "85"
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$MOCK_DIR" "$TMP_DIR"' EXIT
+echo '{"same_failure": true}' > "$TMP_DIR/same.json"
+echo '{"same_failure": false}' > "$TMP_DIR/diff.json"
+echo '{}' > "$TMP_DIR/empty.json"
 
-# Substring containment -> high score
-short="AssertionError: max mismatch expected=0.0"
-long="FAILED tests/ttnn/test_ops.py::test_reduce_max - AssertionError: max mismatch expected=0.0 actual=0.125"
-score=$(compare_errors "$short" "$long")
-assert_eq "compare_errors: substring containment returns 85" "$score" "85"
+assert_eq "get_same_failure: same" "$(get_same_failure_from_comparison "$TMP_DIR/same.json")" "true"
+assert_eq "get_same_failure: different" "$(get_same_failure_from_comparison "$TMP_DIR/diff.json")" "false"
+assert_eq "get_same_failure: empty json defaults false" "$(get_same_failure_from_comparison "$TMP_DIR/empty.json")" "false"
 
-# Different errors -> low score (no overlap)
-orig="AssertionError in test_reduce_max: max mismatch"
-retry="TimeoutError: Job exceeded maximum runtime of 3600 seconds"
-score=$(compare_errors "$orig" "$retry")
-assert_eq "compare_errors: different errors score low" "$score" "0"
+# -- get_retry_error_extracted --------------------------------------------------
+echo '{"retry_error_extracted": "AssertionError: max mismatch"}' > "$TMP_DIR/with_extracted.json"
+assert_eq "get_retry_error_extracted: has value" "$(get_retry_error_extracted "$TMP_DIR/with_extracted.json")" "AssertionError: max mismatch"
+assert_eq "get_retry_error_extracted: missing file" "$(get_retry_error_extracted "")" ""
 
-# Similar errors (same test name, overlapping words) -> moderate-high
-orig="FAILED test_ops::test_reduce_max AssertionError max mismatch"
-retry="FAILED test_ops::test_reduce_max AssertionError expected 0.0 got 0.125"
-score=$(compare_errors "$orig" "$retry")
-# Word overlap: shared words -> score ~60-70; must be at least 40
-assert_eq "compare_errors: similar errors score moderate" "$([ "$score" -ge 40 ] && echo pass || echo fail)" "pass"
+# -- determine_retry_result ----------------------------------------------------
+assert_eq "determine_retry_result: retry success -> passed" "$(determine_retry_result "success" "true")" "passed"
+assert_eq "determine_retry_result: retry success ignores same_failure" "$(determine_retry_result "success" "false")" "passed"
+assert_eq "determine_retry_result: failed + same -> failed_same" "$(determine_retry_result "failure" "true")" "failed_same"
+assert_eq "determine_retry_result: failed + different -> failed_different" "$(determine_retry_result "failure" "false")" "failed_different"
+assert_eq "determine_retry_result: default same_failure false" "$(determine_retry_result "failure" "")" "failed_different"
 
-# -- determine_retry_result ---------------------------------------------------
-# Retry passed -> passed
-result=$(determine_retry_result "failure" "success" "0")
-assert_eq "determine_retry_result: retry success -> passed" "$result" "passed"
+# -- run_copilot_error_comparison (with mock) ----------------------------------
+mkdir -p "$TMP_DIR/root/auto_triage/data"
+echo "original error" > "$TMP_DIR/root/auto_triage/data/original_error.txt"
+echo "retry error" > "$TMP_DIR/root/auto_triage/data/retry_error.txt"
+mkdir -p "$TMP_DIR/root"
+echo "Fake instructions for Copilot" > "$TMP_DIR/root/compare_errors_instructions.txt"
 
-# Retry failed, high similarity -> failed_same
-result=$(determine_retry_result "failure" "failure" "85")
-assert_eq "determine_retry_result: high similarity -> failed_same" "$result" "failed_same"
-
-# Retry failed, low similarity -> failed_different
-result=$(determine_retry_result "failure" "failure" "20")
-assert_eq "determine_retry_result: low similarity -> failed_different" "$result" "failed_different"
-
-# Boundary: exactly at threshold (70) -> failed_same
-result=$(determine_retry_result "failure" "failure" "70")
-assert_eq "determine_retry_result: threshold 70 -> failed_same" "$result" "failed_same"
-
-# Just below threshold -> failed_different
-result=$(determine_retry_result "failure" "failure" "69")
-assert_eq "determine_retry_result: below threshold -> failed_different" "$result" "failed_different"
-
-# Custom threshold via env
-RESULT_COMPARATOR_SAME_THRESHOLD=50 result=$(determine_retry_result "failure" "failure" "55")
-assert_eq "determine_retry_result: custom threshold 50, score 55 -> failed_same" "$result" "failed_same"
+run_copilot_error_comparison "$TMP_DIR/root" "$TMP_DIR/root/auto_triage/data" || true
+comparison_file="$TMP_DIR/root/auto_triage/data/error_comparison.json"
+assert_eq "run_copilot_error_comparison: produces error_comparison.json" "$([ -f "$comparison_file" ] && echo "exists" || echo "missing")" "exists"
+same=$(get_same_failure_from_comparison "$TMP_DIR/root/auto_triage/data/error_comparison.json")
+assert_eq "run_copilot_error_comparison: mock writes same_failure=true" "$same" "true"
+extracted=$(get_retry_error_extracted "$TMP_DIR/root/auto_triage/data/error_comparison.json")
+assert_eq "run_copilot_error_comparison: mock writes retry_error_extracted" "$extracted" "Mock extracted error"
 
 test_summary


### PR DESCRIPTION
## Summary
Extracts the result comparison logic into a reusable module per the auto-triage refactoring plan. **Uses Copilot (LLM)** to compare errors—not heuristic string matching.

## Changes
- **Create** `modules/retry/result_comparator.sh`:
  - `run_copilot_error_comparison(root, data_dir)` — invokes Copilot with compare_errors_instructions.txt; expects `original_error.txt` and `retry_error.txt` in data_dir; Copilot writes `error_comparison.json` with `same_failure`, `retry_error_extracted`
  - `get_same_failure_from_comparison(comparison_file)` → `"true"` | `"false"`
  - `get_retry_error_extracted(comparison_file)` → extracted error text
  - `determine_retry_result(retry_status, same_failure)` → `passed` | `failed_same` | `failed_different`
  - Uses lib/common.sh; requires copilot CLI and compare_errors_instructions.txt

- **Create** `tests/modules/retry/result_comparator_test.sh`:
  - Mock copilot to write known error_comparison.json
  - Tests for parsing helpers and determine_retry_result

## Merge Criteria (from plan)
- [x] All tests pass
- [x] No changes to retry_on_deterministic.sh