### PR TITLE
Fix YAML parse error breaking slack-report-auto-triage action

### DIFF
--- a/.github/actions/slack-report-auto-triage/action.yml
+++ b/.github/actions/slack-report-auto-triage/action.yml
@@ -40,7 +40,8 @@ runs:
         SLACK_TS: ${{ inputs.slack_ts }}
         CHANNEL_ID: ${{ inputs.channel_id }}
         JOB_NAME: ${{ inputs.job_name }}
-      run: bash "${{ github.action_path }}/scripts/fetch_job_owner.sh" || echo "Warning: Job owner extraction failed (non-fatal), continuing without JOB OWNER field"
+      run: |
+        bash "${{ github.action_path }}/scripts/fetch_job_owner.sh" || echo "Warning: Job owner extraction failed (non-fatal), continuing without JOB OWNER field"
 
     - name: Build Slack payload
       id: build


### PR DESCRIPTION
## Summary

- **Emergency fix**: The `slack-report-auto-triage` composite action fails to load on every auto-triage run with:
  ```
  Mapping values are not allowed in this context (Line: 43, Col: 88)
  ```
- **Root cause**: The single-line `run:` on line 43 contains `(non-fatal), continuing` — the `: ` after the closing paren is parsed by GitHub Actions' YAML engine as a mapping key-value separator, which is invalid inside a scalar value.
- **Fix**: Switch from inline `run:` to block scalar `run: |` so the entire command is treated as a literal string.

## Introduced by

PR #434 (port-refactoring-29) condensed the fetch_job_owner step from a multi-line `run: |` block to a single-line `run:`, which exposed the colon to the YAML parser.

## Test plan

- [ ] Merge to main and re-run any auto-triage dispatch — the action should load without YAML errors.


Made with [Cursor](https://cursor.com)