### PR TITLE
Fix broken pipe in retry module, add docs link, clean up wrappers

### DIFF
--- a/.github/actions/auto-triage/auto_triage/modules/retry/retry_orchestrator.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/retry/retry_orchestrator.sh
@@ -230,7 +230,7 @@ SAME_FAILURE=$(get_same_failure_from_comparison "$COMPARISON_FILE")
 RESULT=$(determine_retry_result "$STATUS" "$SAME_FAILURE")
 
 RETRY_ERR_FOR_NOTES=$(get_retry_error_extracted "$COMPARISON_FILE")
-[ -z "$RETRY_ERR_FOR_NOTES" ] && RETRY_ERR_FOR_NOTES=$(echo "$RETRY_ERROR" | head -c 500)
+[ -z "$RETRY_ERR_FOR_NOTES" ] && RETRY_ERR_FOR_NOTES=$(head -c 500 <<< "$RETRY_ERROR")
 
 if [ "$RESULT" = "failed_same" ]; then
     jq -n --arg r "failed_same" --arg m "Same error, deterministic confirmed" '{result: $r, message: $m}' > "$RETRY_RESULT_FILE"

--- a/.github/actions/auto-triage/auto_triage/modules/retry/run_trigger.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/retry/run_trigger.sh
@@ -41,7 +41,7 @@ trigger_retry_run() {
     local response
     response=$(gh_api_post "repos/${AT_OWNER_REPO}/actions/jobs/${job_id}/rerun")
     local code
-    code=$(echo "$response" | head -1 | awk '{print $2}')
+    code=$(awk 'NR==1{print $2}' <<< "$response")
     code="${code:-000}"
 
     if [ "$code" = "201" ] || [ "$code" = "200" ]; then

--- a/.github/actions/auto-triage/auto_triage/scripts/retry_on_deterministic.sh
+++ b/.github/actions/auto-triage/auto_triage/scripts/retry_on_deterministic.sh
@@ -5,8 +5,6 @@
 # Usage: ./retry_on_deterministic.sh <job_name> <workflow_name> [slack_ts]
 #
 
-set -euo pipefail
-
 if [ $# -lt 2 ]; then
     echo "Usage: $0 <job_name> <workflow_name> [slack_ts]" >&2
     exit 1

--- a/.github/actions/auto-triage/auto_triage/scripts/run_auto_fix.sh
+++ b/.github/actions/auto-triage/auto_triage/scripts/run_auto_fix.sh
@@ -6,8 +6,6 @@
 # Exists so all scripts have a consistent entry point under scripts/.
 #
 
-set -euo pipefail
-
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 

--- a/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
+++ b/.github/actions/auto-triage/auto_triage/tests/lib/github_api_test.sh
@@ -109,7 +109,7 @@ assert_eq "get_commit_author" "$author" "testuser"
 
 # -- gh_api_post ---------------------------------------------------------------
 resp=$(gh_api_post "repos/tenstorrent/tt-metal/actions/jobs/123/rerun")
-status=$(echo "$resp" | head -1 | awk '{print $2}')
+status=$(awk 'NR==1{print $2}' <<< "$resp")
 assert_eq "gh_api_post status" "$status" "201"
 
 # -- get_check_annotations (empty) --------------------------------------------

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This repository provides two main capabilities:
    - Creates or updates GitHub issues from Slack messages
    - Generates error reports and incremental reports
 
+## Documentation
+
+For internal usage guides and runbooks, see the [Auto-Triage Confluence page](https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1794441312/How+to+Use+Auto-Triage).
+
 ## Quickstart
 
 ### Auto-Triage (Minimal Setup)


### PR DESCRIPTION
## Summary

- **Fix non-deterministic broken pipe crash in retry logic**: The `echo "$var" | head -1` pattern causes SIGPIPE under `set -euo pipefail` when the variable is multi-line. This is a **race condition** — `echo` and `head` run concurrently, and if the kernel schedules `head` to read one line and exit before `echo` finishes writing, the pipe's read end closes and `echo` gets SIGPIPE. For small API responses (~1-2KB), `echo` usually wins the race and writes everything to the 64KB pipe buffer before `head` exits, which is why retries have worked most of the time. But occasionally the scheduling goes the other way, causing a fatal crash (see [failed run #4725](https://github.com/tenstorrent/tt-metal/actions/runs/22673593277/job/65723982632) vs [successful run #4655](https://github.com/tenstorrent/tt-metal/actions/runs/22603088472/job/65489188282) — same code, different kernel scheduling luck). Replaced with here-strings (`<<<`) which avoid pipes entirely.
- **Add Confluence link**: Added link to [How to Use Auto-Triage](https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1794441312/How+to+Use+Auto-Triage) in the README.
- **Remove redundant `set -euo pipefail`** from exec-only wrapper scripts (`scripts/retry_on_deterministic.sh`, `scripts/run_auto_fix.sh`) — these just `exec` to scripts that set their own shell options, so the flag is never reached.

## Files changed

| File | Change |
|------|--------|
| `modules/retry/run_trigger.sh` | `echo \| head -1 \| awk` → `awk ... <<< "$var"` |
| `modules/retry/retry_orchestrator.sh` | `echo \| head -c 500` → `head -c 500 <<< "$var"` |
| `tests/lib/github_api_test.sh` | Same broken pipe fix in test |
| `scripts/retry_on_deterministic.sh` | Remove redundant `set -euo pipefail` (exec-only wrapper) |
| `scripts/run_auto_fix.sh` | Remove redundant `set -euo pipefail` (exec-only wrapper) |
| `README.md` | Add Confluence documentation link |

## Note on `set -euo pipefail` scope

Only removed from **exec-only wrappers** where it's provably redundant. Entry-point scripts called as subprocesses from YAML (`auto_triage.sh`, `filter_triage.sh`, `find_boundaries.sh`, etc.) still need their own `set -euo pipefail` because GitHub Actions' `shell: bash` flags (`-eo pipefail`) don't propagate to child processes spawned via `./script.sh` or `bash script.sh`.

## Test plan

- [ ] Run `test-auto-triage-lib.yml` to verify github_api_test.sh and retry module tests pass
- [ ] Trigger an auto-triage run on a Case 1/4 failure to exercise the retry path