### PR TITLE
Fix Case 4 Slack format when LLM emits "Case 4" label

### DIFF
--- a/.github/actions/auto-triage/auto_triage/sanitize_slack_message.py
+++ b/.github/actions/auto-triage/auto_triage/sanitize_slack_message.py
@@ -63,6 +63,19 @@ def require_string(value, path, allow_empty=False):
     return value
 
 
+def normalize_case_value(value):
+    """
+    Canonicalize case labels to "1".."5".
+    Assumes there is a single relevant case digit in the string
+    (e.g. "4" or "Case 4").
+    """
+    normalized = require_string(value, "case")
+    digits = re.findall(r"[1-5]", normalized)
+    if not digits:
+        raise ValueError("case must contain one of: 1, 2, 3, 4, 5")
+    return digits[0]
+
+
 def normalize_identity_fields(person: dict) -> None:
     """Trim whitespace and strip leading @ for names/logins/slack IDs."""
     if "name" in person and person["name"] is not None:
@@ -165,7 +178,11 @@ def validate_commit(commit, index):
 
 def validate_payload(payload):
     require_type(payload, dict, "root")
-    for key in ("case", "scenario", "failure_message", "slack_message"):
+    if "case" not in payload:
+        raise ValueError("Field 'case' is required at the top level")
+    payload["case"] = normalize_case_value(payload["case"])
+
+    for key in ("scenario", "failure_message", "slack_message"):
         if key not in payload:
             raise ValueError(f"Field '{key}' is required at the top level")
         require_string(payload[key], key)


### PR DESCRIPTION
## Problem
When the LLM sets `"case": "Case 4"` instead of `"case": "4"`, the Slack formatter did not treat it as Case 4 and fell back to the verbose `*COMMITS:*` block (HASH / AUTHOR / APPROVERS / CONFIDENCE spam).

## Fix
- **`sanitize_slack_message.py`**: Canonicalize `case` to a single digit `"1"`–`"5"` by extracting the first matching digit from the string (e.g. `"Case 4"` → `"4"`).
- **`slack_message.jq`**: Unchanged from main’s exact `case == "4"` / `case == "5"` checks; sanitized JSON now matches those expectations.

## Verification
- `bash .github/actions/slack-report-auto-triage/tests/slack_report/payload_builder_test.sh`
- Manual: run sanitizer on a payload with `.case = "Case 4"` and confirm output `.case` is `"4"`.

## Related
Fixes noisy Slack for runs such as [tt-metal#23439839411](https://github.com/tenstorrent/tt-metal/actions/runs/23439839411) and [tt-metal#23416893310](https://github.com/tenstorrent/tt-metal/actions/runs/23416893310) where artifacts showed `"case": "Case 4"`.

Made with [Cursor](https://cursor.com)