### PR TITLE
Add cutoff commit argument plumbing

### DIFF
--- a/.github/actions/auto-triage/action.yml
+++ b/.github/actions/auto-triage/action.yml
@@ -80,11 +80,11 @@ runs:
         fi
         ./modules/boundaries/find_boundaries.sh \
           "${{ inputs.workflow-name }}" \
-          "${{ inputs.job-name }}"
+          "${{ inputs.job-name }}" \
+          "${{ inputs.cutoff-commit }}"
       env:
         GH_TOKEN: ${{ github.token }}
         GITHUB_TOKEN: ${{ github.token }}
-        CUTOFF_COMMIT: ${{ inputs.cutoff-commit }}
 
     - name: Download Slack directory
       if: inputs.slack-test-only != 'true'

--- a/.github/actions/auto-triage/auto_triage/modules/boundaries/find_boundaries.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/boundaries/find_boundaries.sh
@@ -15,11 +15,9 @@ source "$_MOD_FB_DIR/workflow_finder.sh"
 # shellcheck source=run_processor.sh
 source "$_MOD_FB_DIR/run_processor.sh"
 
-CUTOFF_COMMIT="${CUTOFF_COMMIT:-}"
-
 if [ $# -lt 2 ]; then
     log_error "Missing required arguments"
-    echo "Usage: $0 <workflow_name> <subjob_name>"
+    echo "Usage: $0 <workflow_name> <subjob_name> [cutoff_commit]"
     echo ""
     echo "Examples:"
     echo "  $0 single-card-demo-tests yolov5x-N150-func"
@@ -29,6 +27,7 @@ fi
 
 WORKFLOW_NAME="$1"
 SUBJOB_NAME="$2"
+CUTOFF_COMMIT="${3:-${CUTOFF_COMMIT:-}}"
 
 # normalize_hyphens(text) -> normalized string (Unicode dashes replaced with ASCII '-')
 # Replaces Unicode dash characters with ASCII hyphen via Python.


### PR DESCRIPTION
## Summary
- pass `cutoff-commit` from the composite action into `find_boundaries.sh` as an explicit optional argument
- keep environment fallback support in `find_boundaries.sh` for compatibility
- update usage text to document the optional cutoff argument

## Test plan
- [x] Confirm action YAML passes three args to `find_boundaries.sh`
- [x] Confirm script accepts optional third arg and still works without it
- [ ] Trigger workflow_dispatch run with and without `cutoff_commit`

Made with [Cursor](https://cursor.com)