### PR TITLE
Validate cutoff_commit in boundary finder

### DIFF
--- a/.github/actions/auto-triage/auto_triage/modules/boundaries/find_boundaries.sh
+++ b/.github/actions/auto-triage/auto_triage/modules/boundaries/find_boundaries.sh
@@ -10,6 +10,8 @@ set -euo pipefail
 _MOD_FB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=../../lib/config.sh
 source "$_MOD_FB_DIR/../../lib/config.sh"
+# shellcheck source=../../lib/validation.sh
+source "$_MOD_FB_DIR/../../lib/validation.sh"
 # shellcheck source=workflow_finder.sh
 source "$_MOD_FB_DIR/workflow_finder.sh"
 # shellcheck source=run_processor.sh
@@ -28,6 +30,10 @@ fi
 WORKFLOW_NAME="$1"
 SUBJOB_NAME="$2"
 CUTOFF_COMMIT="${3:-${CUTOFF_COMMIT:-}}"
+
+if [ -n "$CUTOFF_COMMIT" ]; then
+    validate_commit_sha "$CUTOFF_COMMIT" "cutoff_commit"
+fi
 
 # normalize_hyphens(text) -> normalized string (Unicode dashes replaced with ASCII '-')
 # Replaces Unicode dash characters with ASCII hyphen via Python.


### PR DESCRIPTION
## Summary
- validate `cutoff_commit` immediately in `find_boundaries.sh` when provided
- reuse shared `lib/validation.sh` (`validate_commit_sha`) instead of inline git checks
- fail fast with a clear error when the supplied cutoff SHA is malformed or unknown

## Test plan
- [x] `cd .github/actions/auto-triage/auto_triage && bash tests/lib/validation_test.sh`
- [x] `cd .github/actions/auto-triage/auto_triage && bash tests/modules/boundaries/run_processor_test.sh`

Made with [Cursor](https://cursor.com)