### PR TITLE
Slice 2: Slack ingestion, enrichment, and thread signal analysis

### DIFF
--- a/tools/ci/enrich_slack_with_issue_status.py
+++ b/tools/ci/enrich_slack_with_issue_status.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Enrich exported Slack thread JSON with GitHub issue closure booleans."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+ISSUE_URL_RE = re.compile(r"https://github\.com/([^/\s]+)/([^/\s]+)/issues/(\d+)")
+SUPPORTED_ISSUE_REPOS = {"tenstorrent/tt-metal", "ebanerjeeTT/issue_dump"}
+
+
+def fetch_issue(repo_slug: str, issue_number: int, github_token: str | None) -> dict[str, Any]:
+    url = f"https://api.github.com/repos/{repo_slug}/issues/{issue_number}"
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "User-Agent": "tt-metal-triage-ci",
+    }
+    if github_token:
+        headers["Authorization"] = f"Bearer {github_token}"
+    req = urllib.request.Request(url, headers=headers)
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Add issue_closed booleans to Slack export JSON.")
+    parser.add_argument("--input", required=True, help="Input Slack export JSON path")
+    parser.add_argument("--output", required=True, help="Output enriched JSON path")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    github_token = os.environ.get("ISSUE_REPO_GITHUB_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    with open(args.input, encoding="utf-8") as f:
+        payload = json.load(f)
+
+    messages = payload.get("messages", [])
+    issue_refs: set[tuple[str, int]] = set()
+    for msg in messages:
+        for owner, repo, issue_num in ISSUE_URL_RE.findall(str(msg.get("text", ""))):
+            repo_slug = f"{owner}/{repo}"
+            if repo_slug in SUPPORTED_ISSUE_REPOS:
+                issue_refs.add((repo_slug, int(issue_num)))
+
+    issue_state_map: dict[tuple[str, int], dict[str, Any]] = {}
+    failures: dict[tuple[str, int], str] = {}
+    for repo_slug, n in sorted(issue_refs, key=lambda x: (x[0], x[1])):
+        try:
+            issue = fetch_issue(repo_slug, n, github_token)
+            issue_state_map[(repo_slug, n)] = {
+                "repo": repo_slug,
+                "state": issue.get("state"),
+                "closed": issue.get("state") == "closed",
+                "url": issue.get("html_url"),
+                "title": issue.get("title"),
+            }
+        except urllib.error.HTTPError as exc:
+            failures[(repo_slug, n)] = f"http_error_{exc.code}"
+        except Exception as exc:  # noqa: BLE001
+            failures[(repo_slug, n)] = str(exc)
+
+    for msg in messages:
+        refs = sorted(
+            {
+                (f"{owner}/{repo}", int(num))
+                for owner, repo, num in ISSUE_URL_RE.findall(str(msg.get("text", "")))
+                if f"{owner}/{repo}" in SUPPORTED_ISSUE_REPOS
+            },
+            key=lambda x: (x[0], x[1]),
+        )
+        refs_detail = []
+        for repo_slug, n in refs:
+            state = issue_state_map.get((repo_slug, n))
+            if state is None:
+                refs_detail.append(
+                    {
+                        "repo": repo_slug,
+                        "number": n,
+                        "url": f"https://github.com/{repo_slug}/issues/{n}",
+                        "state": "unknown",
+                        "closed": False,
+                    }
+                )
+            else:
+                refs_detail.append(
+                    {
+                        "repo": repo_slug,
+                        "number": n,
+                        "url": state["url"],
+                        "state": state["state"],
+                        "closed": state["closed"],
+                    }
+                )
+
+        msg["referenced_issue_numbers"] = [n for _, n in refs]
+        msg["referenced_issue_repos"] = sorted({repo_slug for repo_slug, _ in refs})
+        msg["referenced_issues"] = refs_detail
+        msg["issue_closed"] = any(item.get("closed", False) for item in refs_detail)
+        msg["all_referenced_issues_closed"] = bool(refs_detail) and all(
+            item.get("closed", False) for item in refs_detail
+        )
+        msg["issue_status_lookup_failed"] = any((repo_slug, n) in failures for repo_slug, n in refs)
+
+    payload["issue_enrichment"] = {
+        "github_lookup_count": len(issue_refs),
+        "github_lookup_failures": {f"{repo}#{num}": v for (repo, num), v in failures.items()},
+        "notes": "issue_closed=true means at least one referenced top-level GitHub issue is closed",
+    }
+
+    with open(args.output, "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2)
+
+    print(
+        json.dumps(
+            {
+                "messages": len(messages),
+                "issues_found": len(issue_refs),
+                "lookups_failed": len(failures),
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/export_slack_author_threads.py
+++ b/tools/ci/export_slack_author_threads.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Export top-level messages by one Slack user with nested thread replies."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.slack import slack_api_get
+from tools.ci.common.timestamps import iso_utc
+
+
+def fetch_channel_messages(token: str, channel_id: str, oldest_ts: float, latest_ts: float) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, Any] = {
+            "channel": channel_id,
+            "limit": 200,
+            "oldest": f"{oldest_ts:.6f}",
+            "latest": f"{latest_ts:.6f}",
+            "inclusive": "true",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        payload = slack_api_get(token, "conversations.history", params)
+        messages.extend(payload.get("messages", []))
+
+        cursor = payload.get("response_metadata", {}).get("next_cursor") or None
+        if not cursor:
+            break
+
+    return messages
+
+
+def fetch_thread_replies(
+    token: str, channel_id: str, thread_ts: str, oldest_ts: float, latest_ts: float
+) -> list[dict[str, Any]]:
+    replies: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, Any] = {
+            "channel": channel_id,
+            "ts": thread_ts,
+            "limit": 200,
+            "oldest": f"{oldest_ts:.6f}",
+            "latest": f"{latest_ts:.6f}",
+            "inclusive": "true",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        payload = slack_api_get(token, "conversations.replies", params)
+        batch = payload.get("messages", [])
+        # Slack includes the root message in replies; keep only replies.
+        replies.extend([m for m in batch if m.get("ts") != thread_ts])
+
+        cursor = payload.get("response_metadata", {}).get("next_cursor") or None
+        if not cursor:
+            break
+
+    replies.sort(key=lambda r: float(r.get("ts", "0")))
+    return replies
+
+
+def is_top_level(msg: dict[str, Any]) -> bool:
+    return msg.get("thread_ts") in (None, "", msg.get("ts"))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Export top-level Slack messages by one author with thread replies.")
+    parser.add_argument("--channel-id", required=True, help="Slack channel ID (e.g. C05GRJC4J4A)")
+    parser.add_argument("--author-user-id", required=True, help="Slack user ID to filter top-level messages")
+    parser.add_argument("--days", type=int, default=30, help="Lookback window in days")
+    parser.add_argument(
+        "--output",
+        default="build_ci/raw_data/slack_author_threads.json",
+        help="Output JSON file path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.days <= 0:
+        print("--days must be positive", file=sys.stderr)
+        return 2
+
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        print("SLACK_BOT_TOKEN is not set in this shell.", file=sys.stderr)
+        return 2
+
+    now_ts = time.time()
+    oldest_ts = now_ts - (args.days * 24 * 60 * 60)
+
+    all_messages = fetch_channel_messages(token, args.channel_id, oldest_ts, now_ts)
+    top_level_by_author = [m for m in all_messages if is_top_level(m) and m.get("user") == args.author_user_id]
+    top_level_by_author.sort(key=lambda m: float(m.get("ts", "0")))
+
+    exported_messages: list[dict[str, Any]] = []
+    total_replies = 0
+
+    for msg in top_level_by_author:
+        ts = msg.get("ts")
+        if not ts:
+            continue
+
+        replies = fetch_thread_replies(token, args.channel_id, ts, oldest_ts, now_ts)
+        total_replies += len(replies)
+
+        exported_messages.append(
+            {
+                "ts": ts,
+                "thread_ts": msg.get("thread_ts", ts),
+                "user": msg.get("user"),
+                "bot_id": msg.get("bot_id"),
+                "text": msg.get("text", ""),
+                "subtype": msg.get("subtype"),
+                "reply_count": msg.get("reply_count", 0),
+                "latest_reply": msg.get("latest_reply"),
+                "raw": msg,
+                "thread_replies": replies,
+            }
+        )
+
+    payload = {
+        "exported_at_utc": iso_utc(now_ts),
+        "channel_id": args.channel_id,
+        "author_user_id": args.author_user_id,
+        "window": {
+            "days": args.days,
+            "oldest_ts": f"{oldest_ts:.6f}",
+            "latest_ts": f"{now_ts:.6f}",
+            "oldest_utc": iso_utc(oldest_ts),
+            "latest_utc": iso_utc(now_ts),
+        },
+        "counts": {
+            "all_messages_in_window": len(all_messages),
+            "top_level_messages_by_author": len(exported_messages),
+            "thread_replies_total": total_replies,
+            "total_exported_items": len(exported_messages) + total_replies,
+        },
+        "messages": exported_messages,
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    print(f"Wrote Slack export to {output_path}")
+    print("Counts:", json.dumps(payload["counts"], separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/export_slack_channel.py
+++ b/tools/ci/export_slack_channel.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Export recent Slack channel activity (including thread replies) to JSON."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.slack import slack_api_get
+from tools.ci.common.timestamps import iso_utc
+
+DEFAULT_CHANNEL_ID = "C08SJ7MGESY"
+DEFAULT_DAYS = 30
+
+
+def fetch_channel_messages(token: str, channel_id: str, oldest_ts: float, latest_ts: float) -> list[dict[str, Any]]:
+    """Fetch all top-level channel messages in the requested window."""
+    messages: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, Any] = {
+            "channel": channel_id,
+            "limit": 200,
+            "oldest": f"{oldest_ts:.6f}",
+            "latest": f"{latest_ts:.6f}",
+            "inclusive": "true",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        payload = slack_api_get(token, "conversations.history", params)
+        messages.extend(payload.get("messages", []))
+
+        cursor = payload.get("response_metadata", {}).get("next_cursor") or None
+        if not cursor:
+            break
+
+    return messages
+
+
+def fetch_thread_replies(
+    token: str, channel_id: str, thread_ts: str, oldest_ts: float, latest_ts: float
+) -> list[dict[str, Any]]:
+    """Fetch replies for a thread root within the requested window."""
+    replies: list[dict[str, Any]] = []
+    cursor: str | None = None
+
+    while True:
+        params: dict[str, Any] = {
+            "channel": channel_id,
+            "ts": thread_ts,
+            "limit": 200,
+            "oldest": f"{oldest_ts:.6f}",
+            "latest": f"{latest_ts:.6f}",
+            "inclusive": "true",
+        }
+        if cursor:
+            params["cursor"] = cursor
+
+        payload = slack_api_get(token, "conversations.replies", params)
+        batch = payload.get("messages", [])
+        # Slack includes the root message in conversations.replies results.
+        replies.extend([m for m in batch if m.get("ts") != thread_ts])
+
+        cursor = payload.get("response_metadata", {}).get("next_cursor") or None
+        if not cursor:
+            break
+
+    return replies
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=("Export last N days of Slack channel messages (including thread replies) " "to JSON.")
+    )
+    parser.add_argument("--channel-id", default=DEFAULT_CHANNEL_ID, help="Slack channel ID")
+    parser.add_argument("--days", type=int, default=DEFAULT_DAYS, help="Lookback window in days")
+    parser.add_argument(
+        "--output",
+        default=f"build_ci/raw_data/slack_{DEFAULT_CHANNEL_ID}_last_{DEFAULT_DAYS}_days.json",
+        help="Output JSON file path",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.days <= 0:
+        print("--days must be positive", file=sys.stderr)
+        return 2
+
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        print("SLACK_BOT_TOKEN is not set in this shell.", file=sys.stderr)
+        return 2
+
+    now_ts = time.time()
+    oldest_ts = now_ts - (args.days * 24 * 60 * 60)
+
+    top_level_messages = fetch_channel_messages(token, args.channel_id, oldest_ts, now_ts)
+    top_level_messages.sort(key=lambda m: float(m.get("ts", "0")))
+
+    results: list[dict[str, Any]] = []
+    total_replies = 0
+
+    for msg in top_level_messages:
+        item: dict[str, Any] = {
+            "ts": msg.get("ts"),
+            "thread_ts": msg.get("thread_ts", msg.get("ts")),
+            "user": msg.get("user"),
+            "bot_id": msg.get("bot_id"),
+            "subtype": msg.get("subtype"),
+            "text": msg.get("text", ""),
+            "reply_count": msg.get("reply_count", 0),
+            "latest_reply": msg.get("latest_reply"),
+            "raw": msg,
+        }
+
+        if int(msg.get("reply_count", 0)) > 0 and msg.get("ts"):
+            replies = fetch_thread_replies(token, args.channel_id, msg["ts"], oldest_ts, now_ts)
+            replies.sort(key=lambda r: float(r.get("ts", "0")))
+            item["replies"] = replies
+            total_replies += len(replies)
+        else:
+            item["replies"] = []
+
+        results.append(item)
+
+    payload = {
+        "exported_at_utc": iso_utc(now_ts),
+        "channel_id": args.channel_id,
+        "window": {
+            "days": args.days,
+            "oldest_ts": f"{oldest_ts:.6f}",
+            "latest_ts": f"{now_ts:.6f}",
+            "oldest_utc": iso_utc(oldest_ts),
+            "latest_utc": iso_utc(now_ts),
+        },
+        "counts": {
+            "top_level_messages": len(results),
+            "thread_replies": total_replies,
+            "total_items": len(results) + total_replies,
+        },
+        "messages": results,
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    print(f"Wrote Slack export to {output_path}")
+    print(
+        "Counts:",
+        json.dumps(payload["counts"], separators=(",", ":")),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/thread_signal_analysis.py
+++ b/tools/ci/thread_signal_analysis.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Thread-signal analysis helpers for CI triage lifecycle decisions."""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+
+def _to_float_ts(value: Any) -> float | None:
+    try:
+        return float(str(value).strip())
+    except Exception:
+        return None
+
+
+def _normalize(text: str) -> str:
+    cleaned = text.lower().strip()
+    cleaned = re.sub(r"\s+", " ", cleaned)
+    return cleaned
+
+
+def _reply_texts(thread_replies: list[dict[str, Any]]) -> list[tuple[float, str]]:
+    rows: list[tuple[float, str]] = []
+    for reply in thread_replies:
+        if not isinstance(reply, dict):
+            continue
+        text = _normalize(str(reply.get("text", "")))
+        ts = _to_float_ts(reply.get("ts"))
+        if not text:
+            continue
+        rows.append((ts if ts is not None else 0.0, text))
+    rows.sort(key=lambda x: x[0], reverse=True)
+    return rows
+
+
+def classify_thread_progress(
+    *,
+    top_level_text: str,
+    thread_replies: list[dict[str, Any]],
+    now_unix: float | None = None,
+    hold_hours_after_progress: float = 24.0,
+) -> dict[str, Any]:
+    now = time.time() if now_unix is None else now_unix
+    replies = _reply_texts(thread_replies)
+    if not replies:
+        return {
+            "progress_state": "no_progress",
+            "confidence": "low",
+            "recent_progress": False,
+            "defer_disable": False,
+            "reason": "no_thread_replies",
+        }
+
+    resolved_markers = (
+        "fixed",
+        "resolved",
+        "landed",
+        "merged",
+        "closed by",
+        "issue closed",
+    )
+    in_progress_markers = (
+        "working on",
+        "looking now",
+        "investigating",
+        "wip",
+        "in progress",
+        "opening pr",
+        "will send pr",
+        "pr soon",
+        "have a fix",
+    )
+    blocked_markers = (
+        "blocked",
+        "waiting on",
+        "needs infra",
+        "needs hardware",
+        "cannot reproduce",
+    )
+    stale_noise_markers = (
+        "taking a look",
+        "will check",
+        "looking",
+    )
+
+    latest_ts, latest_text = replies[0]
+    age_hours = (now - latest_ts) / 3600.0 if latest_ts > 0 else 1e9
+    recent = age_hours <= hold_hours_after_progress
+
+    has_pr_link = "github.com/" in latest_text and "/pull/" in latest_text
+    has_issue_link = "github.com/" in latest_text and "/issues/" in latest_text
+    has_resolved = any(marker in latest_text for marker in resolved_markers)
+    has_progress = any(marker in latest_text for marker in in_progress_markers)
+    has_blocked = any(marker in latest_text for marker in blocked_markers)
+    has_noise = any(marker in latest_text for marker in stale_noise_markers)
+
+    if has_resolved and (has_pr_link or has_issue_link):
+        return {
+            "progress_state": "resolved_signal",
+            "confidence": "high",
+            "recent_progress": True,
+            "defer_disable": True,
+            "reason": "latest_reply_claims_resolution_with_link",
+            "latest_reply_age_hours": round(age_hours, 2),
+        }
+    if has_progress and (has_pr_link or recent):
+        return {
+            "progress_state": "fix_in_progress",
+            "confidence": "high" if has_pr_link else "medium",
+            "recent_progress": recent,
+            "defer_disable": recent,
+            "reason": "latest_reply_indicates_active_fix",
+            "latest_reply_age_hours": round(age_hours, 2),
+        }
+    if has_blocked:
+        return {
+            "progress_state": "blocked",
+            "confidence": "medium",
+            "recent_progress": recent,
+            "defer_disable": False,
+            "reason": "latest_reply_indicates_blocker",
+            "latest_reply_age_hours": round(age_hours, 2),
+        }
+    if has_noise:
+        return {
+            "progress_state": "investigating",
+            "confidence": "low",
+            "recent_progress": recent,
+            "defer_disable": recent and age_hours <= min(hold_hours_after_progress, 8.0),
+            "reason": "latest_reply_is_vague_progress_signal",
+            "latest_reply_age_hours": round(age_hours, 2),
+        }
+
+    # Check if any recent reply (not just latest) has strong progress.
+    for ts, text in replies[:5]:
+        age = (now - ts) / 3600.0 if ts > 0 else 1e9
+        if age > hold_hours_after_progress:
+            continue
+        if any(marker in text for marker in in_progress_markers) and ("github.com/" in text or "pr" in text):
+            return {
+                "progress_state": "fix_in_progress",
+                "confidence": "medium",
+                "recent_progress": True,
+                "defer_disable": True,
+                "reason": "recent_reply_indicates_active_fix",
+                "latest_reply_age_hours": round(age_hours, 2),
+            }
+
+    return {
+        "progress_state": "no_progress",
+        "confidence": "low",
+        "recent_progress": False,
+        "defer_disable": False,
+        "reason": "no_high_confidence_progress_signal",
+        "latest_reply_age_hours": round(age_hours, 2),
+    }
+
+
+def detect_dev_fix_request(*, top_level_text: str, thread_replies: list[dict[str, Any]]) -> dict[str, Any]:
+    corpus = [_normalize(top_level_text)]
+    corpus.extend(text for _, text in _reply_texts(thread_replies)[:12])
+    joined = "\n".join(corpus)
+    patterns = (
+        r"\b(can|could|please)\s+(you|agent|cursor)\s+(fix|patch|handle)\b",
+        r"\bauto\s*fix\b",
+        r"\bdraft\s+(a\s+)?fix\s+pr\b",
+        r"\bmake\s+a\s+pr\s+to\s+fix\b",
+    )
+    for pat in patterns:
+        if re.search(pat, joined):
+            return {"requested": True, "reason": f"matched_pattern:{pat}"}
+    return {"requested": False, "reason": "no_fix_request_signal"}

--- a/tools/tests/ci/test_slice_02_slack_ingestion.py
+++ b/tools/tests/ci/test_slice_02_slack_ingestion.py
@@ -1,0 +1,106 @@
+"""Contract tests for Slice 2: Slack data ingestion pipeline.
+
+Validates that export_slack_channel, export_slack_author_threads, and
+enrich_slack_with_issue_status correctly consume Slack/GitHub API data
+and produce the expected output schemas.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from tools.ci.export_slack_channel import fetch_channel_messages, fetch_thread_replies
+from tools.ci.export_slack_author_threads import is_top_level
+from tools.ci.enrich_slack_with_issue_status import ISSUE_URL_RE, SUPPORTED_ISSUE_REPOS
+
+
+def test_fetch_channel_messages_paginates(monkeypatch):
+    """Verify fetch_channel_messages follows cursor pagination."""
+    page1 = {
+        "ok": True,
+        "messages": [{"ts": "1.0", "text": "hello"}],
+        "response_metadata": {"next_cursor": "cursor_abc"},
+    }
+    page2 = {
+        "ok": True,
+        "messages": [{"ts": "2.0", "text": "world"}],
+        "response_metadata": {"next_cursor": ""},
+    }
+    call_count = {"n": 0}
+
+    def mock_get(token, endpoint, params, *, max_retries=5):
+        call_count["n"] += 1
+        return page1 if call_count["n"] == 1 else page2
+
+    with patch("tools.ci.export_slack_channel.slack_api_get", side_effect=mock_get):
+        msgs = fetch_channel_messages("tok", "C123", 0.0, 999.0)
+
+    assert len(msgs) == 2
+    assert msgs[0]["ts"] == "1.0"
+    assert msgs[1]["ts"] == "2.0"
+
+
+def test_fetch_thread_replies_excludes_root(monkeypatch):
+    """Verify fetch_thread_replies filters out the root message."""
+    payload = {
+        "ok": True,
+        "messages": [
+            {"ts": "1.0", "text": "root"},
+            {"ts": "1.1", "text": "reply"},
+        ],
+        "response_metadata": {},
+    }
+
+    with patch("tools.ci.export_slack_channel.slack_api_get", return_value=payload):
+        replies = fetch_thread_replies("tok", "C123", "1.0", 0.0, 999.0)
+
+    assert len(replies) == 1
+    assert replies[0]["ts"] == "1.1"
+
+
+def test_is_top_level_detects_root_vs_reply():
+    assert is_top_level({"ts": "1.0", "thread_ts": "1.0"}) is True
+    assert is_top_level({"ts": "1.0"}) is True
+    assert is_top_level({"ts": "1.1", "thread_ts": "1.0"}) is False
+
+
+def test_issue_url_regex_captures_supported_repos():
+    text = "See https://github.com/tenstorrent/tt-metal/issues/42 for details"
+    matches = ISSUE_URL_RE.findall(text)
+    assert len(matches) == 1
+    owner, repo, num = matches[0]
+    assert f"{owner}/{repo}" in SUPPORTED_ISSUE_REPOS
+    assert num == "42"
+
+
+def test_enrichment_output_schema(tmp_path):
+    """Verify enrich_slack_with_issue_status produces expected fields on messages."""
+    from tools.ci.enrich_slack_with_issue_status import main as enrich_main
+
+    input_data = {
+        "messages": [
+            {"ts": "1.0", "text": "No issues here"},
+            {"ts": "2.0", "text": "Bug https://github.com/tenstorrent/tt-metal/issues/99"},
+        ]
+    }
+    inp = tmp_path / "input.json"
+    out = tmp_path / "output.json"
+    inp.write_text(json.dumps(input_data))
+
+    with patch("tools.ci.enrich_slack_with_issue_status.fetch_issue", return_value={"state": "open", "html_url": "u", "title": "t"}):
+        import sys
+
+        old_argv = sys.argv
+        sys.argv = ["enrich", "--input", str(inp), "--output", str(out)]
+        try:
+            enrich_main()
+        finally:
+            sys.argv = old_argv
+
+    result = json.loads(out.read_text())
+    for msg in result["messages"]:
+        assert "referenced_issue_numbers" in msg
+        assert "issue_closed" in msg
+        assert "all_referenced_issues_closed" in msg

--- a/tools/tests/ci/test_thread_signal_analysis.py
+++ b/tools/tests/ci/test_thread_signal_analysis.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from tools.ci.thread_signal_analysis import classify_thread_progress, detect_dev_fix_request
+
+
+def test_classify_thread_progress_detects_high_confidence_fix_in_progress() -> None:
+    now = 2000000000.0
+    replies = [{"ts": str(now - 3600), "text": "Working on it now, PR soon: https://github.com/foo/bar/pull/123"}]
+    out = classify_thread_progress(
+        top_level_text="failure",
+        thread_replies=replies,
+        now_unix=now,
+        hold_hours_after_progress=24.0,
+    )
+    assert out["progress_state"] == "fix_in_progress"
+    assert out["defer_disable"] is True
+    assert out["confidence"] in {"high", "medium"}
+
+
+def test_classify_thread_progress_does_not_defer_for_blocked_reply() -> None:
+    now = 2000000000.0
+    replies = [{"ts": str(now - 1800), "text": "Blocked on hardware infra dependency"}]
+    out = classify_thread_progress(
+        top_level_text="failure",
+        thread_replies=replies,
+        now_unix=now,
+        hold_hours_after_progress=24.0,
+    )
+    assert out["progress_state"] == "blocked"
+    assert out["defer_disable"] is False
+
+
+def test_classify_thread_progress_ignores_old_progress_outside_hold_window() -> None:
+    now = 2000000000.0
+    replies = [{"ts": str(now - 60 * 60 * 30), "text": "working on it, PR soon"}]
+    out = classify_thread_progress(
+        top_level_text="failure",
+        thread_replies=replies,
+        now_unix=now,
+        hold_hours_after_progress=24.0,
+    )
+    assert out["defer_disable"] is False
+
+
+def test_detect_dev_fix_request_matches_explicit_request() -> None:
+    out = detect_dev_fix_request(
+        top_level_text="Incident details",
+        thread_replies=[{"ts": "1", "text": "Can agent fix this and draft a fix PR?"}],
+    )
+    assert out["requested"] is True


### PR DESCRIPTION
## Summary

- Add `export_slack_channel.py` and `export_slack_author_threads.py` for Slack channel history export
- Add `enrich_slack_with_issue_status.py` for cross-referencing Slack messages with GitHub issues
- Add `thread_signal_analysis.py` for classifying thread progress and fix-in-progress signals
- 9 tests covering pagination, thread filtering, enrichment schema, and signal heuristics

## Context

This is **Slice 2 / Tier 2** of the CI triage autonomy port. Stacked on Slice 0 (foundation). Independent of Slice 1 (state + agent analysis).

## Dependencies

- Slice 0 (`tools/ci/common/slack`, `tools/ci/common/timestamps`)

## Test plan

- [x] All 9 slice tests pass locally
- [x] All 51 foundation tests still pass
- [ ] Review Slack API interaction patterns


Made with [Cursor](https://cursor.com)