### PR TITLE
Slice 1: State restore, agent thread analysis, and M4 summary renderer

### DIFF
--- a/tools/ci/load_previous_triage_state.py
+++ b/tools/ci/load_previous_triage_state.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Restore triage state from the latest successful triage workflow artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.guarded import run_guarded_gh
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Restore triage state from prior successful workflow run.")
+    parser.add_argument("--repo", default="tenstorrent/tt-metal")
+    parser.add_argument("--workflow", default="triage-ci.yaml")
+    parser.add_argument("--artifact-name", default="triage-state")
+    parser.add_argument("--state-path", default="build_ci/triage_state/ci_triage_state.json")
+    parser.add_argument("--max-runs", type=int, default=20)
+    return parser.parse_args()
+
+
+def first_state_file(root: Path) -> Path | None:
+    matches = sorted(root.rglob("ci_triage_state.json"))
+    return matches[0] if matches else None
+
+
+def main() -> int:
+    args = parse_args()
+    current_run_id = os.environ.get("GITHUB_RUN_ID", "")
+
+    try:
+        runs = run_guarded_gh(
+            [
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                args.repo,
+                "--workflow",
+                args.workflow,
+                "--status",
+                "completed",
+                "--limit",
+                str(args.max_runs),
+                "--json",
+                "databaseId,conclusion",
+            ]
+        )
+    except RuntimeError:
+        print(json.dumps({"restored": False, "reason": "run_list_failed"}))
+        return 0
+
+    payload = json.loads(runs.stdout or "[]")
+    if not isinstance(payload, list):
+        print(json.dumps({"restored": False, "reason": "invalid_run_list_payload"}))
+        return 0
+    candidate_ids: list[int] = []
+    for run_info in payload:
+        if not isinstance(run_info, dict):
+            continue
+        run_id = run_info.get("databaseId")
+        conclusion = str(run_info.get("conclusion", ""))
+        if not isinstance(run_id, int):
+            continue
+        if conclusion != "success":
+            continue
+        if current_run_id and str(run_id) == current_run_id:
+            continue
+        candidate_ids.append(run_id)
+
+    state_path = Path(args.state_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    if state_path.exists():
+        print(json.dumps({"restored": False, "reason": "state_already_present", "path": str(state_path)}))
+        return 0
+
+    for run_id in candidate_ids:
+        with tempfile.TemporaryDirectory(prefix="triage-state-") as tmpdir:
+            download = run_guarded_gh(
+                [
+                    "gh",
+                    "run",
+                    "download",
+                    "--repo",
+                    args.repo,
+                    str(run_id),
+                    "--name",
+                    args.artifact_name,
+                    "--dir",
+                    tmpdir,
+                ],
+                check=False,
+            )
+            if download.returncode != 0:
+                continue
+            state_file = first_state_file(Path(tmpdir))
+            if state_file is None:
+                continue
+            shutil.copy2(state_file, state_path)
+            print(json.dumps({"restored": True, "from_run_id": run_id, "path": str(state_path)}))
+            return 0
+
+    print(json.dumps({"restored": False, "reason": "no_prior_state_found", "path": str(state_path)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_m4_summary.py
+++ b/tools/ci/render_m4_summary.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Render M4 issue/slack result JSON as markdown summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def render_summary(data: dict[str, Any]) -> str:
+    created = data.get("created", [])
+    skipped = data.get("skipped", [])
+    lines: list[str] = []
+    lines.append("")
+    lines.append("# M4 Issue + Slack Summary")
+    lines.append("")
+    lines.append(f"- Candidates total: {data.get('candidate_count', 0)}")
+    lines.append(f"- Candidates processed: {data.get('processed_count', 0)}")
+    lines.append(f"- Fresh agent calls: {data.get('fresh_agent_calls', 0)}")
+    lines.append(f"- Fresh agent reviews: {data.get('fresh_agent_reviews', 0)}")
+    lines.append(f"- Issues created: {len(created) if isinstance(created, list) else 0}")
+    lines.append(f"- Skipped: {len(skipped) if isinstance(skipped, list) else 0}")
+    if isinstance(created, list) and created:
+        lines.append("")
+        lines.append("## Created")
+        for item in created:
+            if not isinstance(item, dict):
+                continue
+            issue_url = item.get("issue_url", "(missing issue url)")
+            workflow_name = item.get("workflow_name", "")
+            job_name = item.get("job_name", "")
+            lines.append(f"- {issue_url} | {workflow_name} / {job_name}")
+            decision = item.get("agent_decision", {})
+            if isinstance(decision, dict):
+                signature = str(decision.get("signature", "")).strip()
+                reason = str(decision.get("reason", "")).strip()
+                if signature:
+                    if len(signature) > 160:
+                        signature = signature[:160] + "..."
+                    lines.append(f"  - Why issue was created: deterministic signature `{signature}`")
+                elif reason:
+                    if len(reason) > 220:
+                        reason = reason[:220] + "..."
+                    lines.append(f"  - Why issue was created: {reason}")
+            owner_selection = item.get("owner_selection", {})
+            if isinstance(owner_selection, dict):
+                selected = owner_selection.get("selected_owner_count", 0)
+                candidates = owner_selection.get("candidate_owner_count", 0)
+                source_counts = owner_selection.get("source_counts", {})
+                if isinstance(source_counts, dict):
+                    lines.append(
+                        "  - Why people were pinged: "
+                        f"selected {selected} of {candidates} candidates from "
+                        f"codeowners={source_counts.get('codeowners', 0)}, "
+                        f"commit_history={source_counts.get('commit_history', 0)}, "
+                        f"auto_triage={source_counts.get('auto_triage', 0)}, "
+                        f"job_owners={source_counts.get('job_owners', 0)}"
+                    )
+            unresolved = item.get("unresolved_owner_handles", [])
+            if isinstance(unresolved, list) and unresolved:
+                redacted = ", ".join(f"@{h}" for h in unresolved[:8])
+                lines.append(f"  - Unresolved GitHub handles: {redacted}")
+            auto_triage_selection = item.get("auto_triage_selection", {})
+            if isinstance(auto_triage_selection, dict):
+                if auto_triage_selection.get("used") and auto_triage_selection.get("permalinks"):
+                    permalink = str(auto_triage_selection.get("permalinks", [""])[0]).strip()
+                    if permalink:
+                        lines.append(f"  - Auto-triage evidence used: {permalink}")
+                else:
+                    reason = str(auto_triage_selection.get("reason", "")).strip() or "no relevant matches"
+                    lines.append(f"  - Auto-triage evidence not used: {reason}")
+    if isinstance(skipped, list) and skipped:
+        lines.append("")
+        lines.append("## Top skip reasons")
+        counts: dict[str, int] = {}
+        for item in skipped:
+            if isinstance(item, dict):
+                reason = str(item.get("reason", "unknown"))
+            else:
+                reason = "unknown"
+            counts[reason] = counts.get(reason, 0) + 1
+        for reason, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:10]:
+            lines.append(f"- {reason}: {count}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render M4 markdown summary from JSON output.")
+    parser.add_argument("--input-json", required=True, help="Path to m4_issue_and_slack_result.json")
+    args = parser.parse_args()
+    path = Path(args.input_json)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("Expected JSON object payload")
+    print(render_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/slack_thread_agent_analysis.py
+++ b/tools/ci/slack_thread_agent_analysis.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Agent-driven Slack thread analysis helpers for CI triage flows."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.markers import parse_json_after_marker  # noqa: F401 – re-exported
+from tools.ci.common.run_helper import run
+
+FINAL_MARKER = "===FINAL_THREAD_ANALYSIS_JSON==="
+
+
+def analyze_thread_with_agent(
+    *,
+    top_level_text: str,
+    thread_replies: list[dict[str, Any]],
+    bot_user_ids: set[str] | None = None,
+    hold_hours_after_progress: float = 24.0,
+    include_owner_claim: bool = False,
+    model: str = "auto",
+) -> dict[str, Any]:
+    curated_replies: list[dict[str, str]] = []
+    for reply in thread_replies[-20:]:
+        if not isinstance(reply, dict):
+            continue
+        curated_replies.append(
+            {
+                "ts": str(reply.get("ts", "")).strip(),
+                "user": str(reply.get("user", "")).strip(),
+                "text": str(reply.get("text", "")).strip()[:1200],
+            }
+        )
+
+    payload = {
+        "top_level_text": top_level_text[:2000],
+        "thread_replies": curated_replies,
+        "bot_user_ids": sorted(bot_user_ids or set()),
+        "hold_hours_after_progress": float(max(0.0, hold_hours_after_progress)),
+        "include_owner_claim": bool(include_owner_claim),
+    }
+    prompt = (
+        "You are analyzing a CI triage Slack thread.\n"
+        "Token-efficiency rule: do one short pass and output only final JSON contract.\n"
+        "Rules:\n"
+        "- Use only provided text, do not invent context.\n"
+        "- progress_state must be one of: resolved_signal, fix_in_progress, blocked, investigating, no_progress.\n"
+        "- defer_disable=true only when there is a high-confidence active progress signal within hold window.\n"
+        "- fix_request_requested=true only when someone explicitly asks agent/bot to create or draft a fix.\n"
+        "- If include_owner_claim=true, detect explicit self-ownership from non-bot replies; otherwise return false/empty.\n"
+        "At end print marker exactly on its own line:\n"
+        f"{FINAL_MARKER}\n"
+        "Then print only JSON object:\n"
+        "{\n"
+        '  "progress_state": "resolved_signal|fix_in_progress|blocked|investigating|no_progress",\n'
+        '  "confidence": "high|medium|low",\n'
+        '  "defer_disable": true,\n'
+        '  "progress_reason": "short reason",\n'
+        '  "fix_request_requested": false,\n'
+        '  "fix_request_reason": "short reason",\n'
+        '  "owner_claimed": false,\n'
+        '  "owner_slack_user_id": "",\n'
+        '  "owner_claim_reason": "short reason"\n'
+        "}\n\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=True)}\n"
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model and model != "auto":
+        cmd.extend(["--model", model])
+    proc = run(cmd)
+    parsed = parse_json_after_marker(proc.stdout or "", FINAL_MARKER)
+    return {
+        "progress_state": str(parsed.get("progress_state", "no_progress")).strip() or "no_progress",
+        "confidence": str(parsed.get("confidence", "low")).strip() or "low",
+        "defer_disable": bool(parsed.get("defer_disable", False)),
+        "progress_reason": str(parsed.get("progress_reason", "unspecified")).strip() or "unspecified",
+        "fix_request_requested": bool(parsed.get("fix_request_requested", False)),
+        "fix_request_reason": str(parsed.get("fix_request_reason", "unspecified")).strip() or "unspecified",
+        "owner_claimed": bool(parsed.get("owner_claimed", False)),
+        "owner_slack_user_id": str(parsed.get("owner_slack_user_id", "")).strip(),
+        "owner_claim_reason": str(parsed.get("owner_claim_reason", "unspecified")).strip() or "unspecified",
+    }


### PR DESCRIPTION
## Summary

- Add `load_previous_triage_state.py` for restoring triage state from GitHub Actions artifacts
- Add `slack_thread_agent_analysis.py` for AI-powered Slack thread classification using the agent CLI
- Add `render_m4_summary.py` for generating formatted M4 issue summaries from triage data

## Context

This is **Slice 1 / Tier 2** of the CI triage autonomy port. Stacked on Slice 0 (foundation). Independent of Slice 2 (Slack ingestion).

## Dependencies

- Slice 0 (`tools/ci/common/guarded`, `tools/ci/common/markers`, `tools/ci/common/run_helper`)

## Test plan

- [x] All modules import successfully against foundation
- [x] All 51 foundation tests still pass
- [ ] Review state loading and agent analysis logic


Made with [Cursor](https://cursor.com)