### PR TITLE
Slice 4: Draft PR pipeline for auto-disabling stale CI failures

### DIFF
--- a/.github/actions/auto-disable-stale-ci/action.yml
+++ b/.github/actions/auto-disable-stale-ci/action.yml
@@ -1,0 +1,138 @@
+name: "Auto Disable Stale CI Threads"
+description: "Plans stale unresolved disables with Cursor and executes deterministic PR + kickoff steps"
+inputs:
+  input-json-path:
+    description: "Path to enriched Slack JSON"
+    required: true
+  stale-hours:
+    description: "Slack age threshold in hours"
+    required: false
+    default: "32"
+  hold-hours-after-progress:
+    description: "Temporary hold window after progress signals"
+    required: false
+    default: "24"
+  max-actions:
+    description: "Max disable actions to execute in one run"
+    required: false
+    default: "3"
+  model:
+    description: "Cursor model"
+    required: false
+    default: "claude-4-sonnet"
+  dry-run:
+    description: "If true, plan only and do not push/PR"
+    required: false
+    default: "false"
+  max-attempts-per-item:
+    description: "Maximum attempts per candidate before needs_human"
+    required: false
+    default: "10"
+  extra-pr-check-workflows:
+    description: "Optional comma-separated early workflows to run after PR create (pr-gate.yaml,merge-gate.yaml)"
+    required: false
+    default: ""
+  target-pr-repo:
+    description: "Repository where auto-disable draft PRs are created"
+    required: false
+    default: "ebanerjeeTT/tt-metal"
+  target-pr-base:
+    description: "Base branch for auto-disable draft PRs"
+    required: false
+    default: "main"
+  fork-workflow-outcomes:
+    description: "JSON object of mocked workflow results in fork mode; value may be outcome string or object {outcome,error,...}"
+    required: false
+    default: "{}"
+  output-dir:
+    description: "Directory for generated artifacts"
+    required: false
+    default: "build_ci/auto_disable"
+runs:
+  using: "composite"
+  steps:
+    - name: Prepare stale unresolved candidate list
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo_root="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        mkdir -p "${{ inputs.output-dir }}"
+        python3 "$repo_root/tools/ci/select_stale_unresolved_threads.py" \
+          --input "${{ inputs.input-json-path }}" \
+          --output "${{ inputs.output-dir }}/stale_candidates.json" \
+          --stale-hours "${{ inputs.stale-hours }}" \
+          --max-candidates "${{ inputs.max-actions }}" \
+          --hold-hours-after-progress "${{ inputs.hold-hours-after-progress }}"
+
+    - name: Generate planning prompt
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo_root="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        python3 "$repo_root/tools/ci/generate_disable_actions_prompt.py" \
+          --template "${{ github.action_path }}/prompt.md" \
+          --candidates-json "${{ inputs.output-dir }}/stale_candidates.json" \
+          --output "${{ inputs.output-dir }}/disable_actions_prompt.txt" \
+          --max-actions "${{ inputs.max-actions }}"
+
+    - name: Build disable action JSON with Cursor
+      shell: bash
+      run: |
+        set -euo pipefail
+        prompt_file="${{ inputs.output-dir }}/disable_actions_prompt.txt"
+        raw_output="${{ inputs.output-dir }}/disable_actions_raw.txt"
+        actions_json="${{ inputs.output-dir }}/disable_actions.json"
+        if [ "${{ inputs.model }}" = "auto" ]; then
+          agent --trust -p "$(cat "$prompt_file")" | tee "$raw_output"
+        else
+          agent --trust --model "${{ inputs.model }}" -p "$(cat "$prompt_file")" | tee "$raw_output"
+        fi
+        python3 - <<'PY'
+        import json
+        from pathlib import Path
+
+        raw_path = Path("${{ inputs.output-dir }}/disable_actions_raw.txt")
+        json_path = Path("${{ inputs.output-dir }}/disable_actions.json")
+        marker = "===FINAL_DISABLE_ACTIONS_JSON==="
+        text = raw_path.read_text(encoding="utf-8", errors="ignore")
+        idx = text.rfind(marker)
+        if idx < 0:
+            raise SystemExit("Missing marker in agent output")
+        payload = text[idx + len(marker):].strip()
+        data = json.loads(payload)
+        if not isinstance(data, dict) or not isinstance(data.get("actions"), list):
+            raise SystemExit("Invalid JSON contract: expected object with actions[]")
+        json_path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+        print(json.dumps({"planned_actions": len(data.get("actions", []))}))
+        PY
+
+    - name: Execute disable actions
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo_root="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        echo "[triage] Restoring previous triage state artifact..."
+        python3 -u "$repo_root/tools/ci/load_previous_triage_state.py" \
+          --repo tenstorrent/tt-metal \
+          --workflow triage-ci.yaml \
+          --artifact-name triage-state \
+          --state-path build_ci/triage_state/ci_triage_state.json
+        dry=""
+        if [ "${{ inputs.dry-run }}" = "true" ]; then
+          dry="--dry-run"
+        fi
+        echo "[triage] Executing disable actions (this can take several minutes when creating PRs)..."
+        python3 -u "$repo_root/tools/ci/execute_disable_actions.py" \
+          --actions-json "${{ inputs.output-dir }}/disable_actions.json" \
+          --output-json "${{ inputs.output-dir }}/execution_result.json" \
+          --summary-md "${{ inputs.output-dir }}/summary.md" \
+          --state-json "build_ci/triage_state/ci_triage_state.json" \
+          --debug-dir "${{ inputs.output-dir }}/debug" \
+          --max-attempts-per-item "${{ inputs.max-attempts-per-item }}" \
+          --extra-pr-check-workflows "${{ inputs.extra-pr-check-workflows }}" \
+          --target-pr-repo "${{ inputs.target-pr-repo }}" \
+          --target-pr-base "${{ inputs.target-pr-base }}" \
+          --fork-workflow-outcomes '${{ inputs.fork-workflow-outcomes }}' \
+          --model "${{ inputs.model }}" \
+          $dry
+        echo "[triage] Disable action execution finished."

--- a/.github/actions/auto-disable-stale-ci/prompt.md
+++ b/.github/actions/auto-disable-stale-ci/prompt.md
@@ -1,0 +1,51 @@
+Read the JSON file at __CANDIDATES_JSON_PATH__.
+
+Task:
+- Produce a machine-readable disable action plan for stale unresolved CI Slack threads.
+- Only include entries where a disable PR should be attempted now.
+- Prioritize highest age first.
+- Cap actions to __MAX_ACTIONS__.
+- Token-efficiency rule: do this in one pass; avoid verbose reasoning and avoid unnecessary extra analysis.
+
+Decision rules:
+- Ignore any candidate where `issue_closed` is true (these should already be excluded).
+- Ignore/deprioritize any candidate where `progress_signal.defer_disable` is true.
+- If `primary_issue_number` is missing, skip unless top-level text clearly contains enough failure context.
+- During bootstrap testing, prefer `primary_issue_repo == "ebanerjeeTT/issue_dump"` when present.
+- Prefer entries with clear CI failure context and issue references.
+- If `fix_request_signal.requested` is true, include an explanatory `skipped` reason unless disable is still clearly required.
+- Keep action scope minimal and specific.
+
+Output contract:
+- Do not call tools, shell commands, or subagents.
+- At the very end, print exactly this marker on its own line:
+===FINAL_DISABLE_ACTIONS_JSON===
+- After that marker, output only JSON (no markdown) matching:
+{
+  "version": 1,
+  "actions": [
+    {
+      "source_slack_ts": "string",
+      "source_slack_permalink": "string",
+      "issue_number": 12345,
+      "issue_repo": "ebanerjeeTT/issue_dump",
+      "issue_url": "https://github.com/ebanerjeeTT/issue_dump/issues/12345",
+      "job_urls": ["optional job urls"],
+      "disable_scope_hint": "one line",
+      "branch_name_hint": "ci-disable-test-optional-slug",
+      "pr_title": "ci: disable ...",
+      "pr_body": "short body with rationale and non-closing issue ref"
+    }
+  ],
+  "skipped": [
+    {
+      "source_slack_ts": "string",
+      "reason": "short reason"
+    }
+  ]
+}
+
+Validation constraints:
+- `actions` must be deterministic and deduplicated by `source_slack_ts`.
+- `issue_number` must be an integer.
+- `pr_title` and `pr_body` should be concise.

--- a/tools/ci/execute_disable_actions.py
+++ b/tools/ci/execute_disable_actions.py
@@ -1,0 +1,1751 @@
+#!/usr/bin/env python3
+"""Execute structured stale-disable actions with deterministic git/gh steps."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import base64
+import re
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.markers import parse_agent_json_after_marker  # noqa: F401 – re-exported
+from tools.ci.common.state import (  # noqa: F401 – re-exported
+    ALLOWED_STATUS,
+    append_history,
+    empty_state,
+    load_state as _load_state_common,
+    save_state,
+)
+from tools.ci.common.timestamps import now_utc  # noqa: F401 – re-exported
+
+DEFAULT_PR_REPO = "ebanerjeeTT/tt-metal"
+DEFAULT_PR_BASE = "main"
+PRIMARY_REPO = "tenstorrent/tt-metal"
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+GUARDED_GH = [sys.executable, str(REPO_ROOT / "tools" / "ci" / "guarded_gh.py")]
+PROTECTED_AGENT_PATHS = {
+    "tools/ci/guarded_gh.py",
+    "tools/ci/execute_disable_actions.py",
+}
+DEFAULT_REQUIRED_PR_CHECK_WORKFLOWS = [
+    "all-static-checks.yaml",
+]
+OPTIONAL_EARLY_WORKFLOWS = {
+    "pr-gate.yaml",
+    "merge-gate.yaml",
+}
+ALLOWED_MOCK_WORKFLOW_OUTCOMES = {
+    "success",
+    "failure",
+    "cancelled",
+    "neutral",
+    "skipped",
+    "timed_out",
+    "action_required",
+    "stale",
+    "startup_failure",
+    "in_progress",
+    "queued",
+    "unknown",
+}
+MockWorkflowSpec = dict[str, dict[str, Any]]
+WorkflowDispatchRecord = dict[str, Any]
+
+
+def redact_secrets(text: str) -> str:
+    if not text:
+        return text
+    redacted = text
+    redacted = re.sub(r"https://x-access-token:[^@]+@github\.com/", "https://x-access-token:***@github.com/", redacted)
+    redacted = re.sub(r"AUTHORIZATION:\s*basic\s+[A-Za-z0-9+/=]+", "AUTHORIZATION: basic ***", redacted)
+    redacted = re.sub(
+        r"http\.https://github\.com/\.extraheader=AUTHORIZATION:\s*basic\s+[A-Za-z0-9+/=]+",
+        "http.https://github.com/.extraheader=AUTHORIZATION: basic ***",
+        redacted,
+    )
+    redacted = re.sub(r"\bghp_[A-Za-z0-9]+\b", "ghp_***", redacted)
+    secret_keys = (
+        "TARGET_PR_PUSH_TOKEN",
+        "GITHUB_TOKEN",
+        "ISSUE_REPO_GITHUB_TOKEN",
+        "CURSOR_API_KEY",
+    )
+    for key in secret_keys:
+        value = os.environ.get(key, "")
+        if value:
+            redacted = redacted.replace(value, "***")
+            encoded_basic = base64.b64encode(f"x-access-token:{value}".encode("utf-8")).decode("ascii")
+            redacted = redacted.replace(encoded_basic, "***")
+            encoded_raw = base64.b64encode(value.encode("utf-8")).decode("ascii")
+            redacted = redacted.replace(encoded_raw, "***")
+    return redacted
+
+
+def run(
+    cmd: list[str], *, check: bool = True, capture: bool = True, env: dict[str, str] | None = None
+) -> subprocess.CompletedProcess[str]:
+    proc_env = None
+    if env:
+        proc_env = os.environ.copy()
+        proc_env.update(env)
+    proc = subprocess.run(
+        cmd,
+        check=False,
+        text=True,
+        capture_output=capture,
+        env=proc_env,
+    )
+    if check and proc.returncode != 0:
+        stdout = redact_secrets(proc.stdout.strip() if proc.stdout else "")
+        stderr = redact_secrets(proc.stderr.strip() if proc.stderr else "")
+        cmd_string = redact_secrets(" ".join(shlex.quote(c) for c in cmd))
+        raise RuntimeError(
+            "Command failed with non-zero exit status "
+            f"{proc.returncode}: {cmd_string}\n"
+            f"stdout:\n{stdout}\n\nstderr:\n{stderr}"
+        )
+    return proc
+
+
+def run_streaming(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    heartbeat_label: str = "",
+    heartbeat_interval_sec: int = 30,
+    timeout_sec: int | None = None,
+) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.Popen(
+        cmd,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=1,
+    )
+    out_parts: list[str] = []
+    err_parts: list[str] = []
+
+    def _pump(stream: Any, sink: list[str], *, to_stderr: bool) -> None:
+        if stream is None:
+            return
+        for line in stream:
+            sink.append(line)
+            if to_stderr:
+                print(line, file=sys.stderr, end="", flush=True)
+            else:
+                print(line, end="", flush=True)
+
+    t_out = threading.Thread(target=_pump, args=(proc.stdout, out_parts), kwargs={"to_stderr": False})
+    t_err = threading.Thread(target=_pump, args=(proc.stderr, err_parts), kwargs={"to_stderr": True})
+    t_out.start()
+    t_err.start()
+    stop_heartbeat = threading.Event()
+
+    def _heartbeat() -> None:
+        if not heartbeat_label:
+            return
+        started = time.monotonic()
+        while not stop_heartbeat.wait(heartbeat_interval_sec):
+            elapsed = int(time.monotonic() - started)
+            log(f"{heartbeat_label}: still running ({elapsed}s elapsed)")
+
+    t_hb = threading.Thread(target=_heartbeat)
+    t_hb.start()
+    timed_out = False
+    if timeout_sec is None:
+        returncode = proc.wait()
+    else:
+        try:
+            returncode = proc.wait(timeout=timeout_sec)
+        except subprocess.TimeoutExpired:
+            timed_out = True
+            proc.kill()
+            returncode = 124
+    stop_heartbeat.set()
+    t_hb.join()
+    t_out.join()
+    t_err.join()
+
+    stdout = "".join(out_parts)
+    stderr = "".join(err_parts)
+    if timed_out:
+        timeout_msg = f"Command timed out after {timeout_sec}s: {' '.join(shlex.quote(c) for c in cmd)}"
+        if stderr:
+            stderr = f"{stderr.rstrip()}\n{timeout_msg}\n"
+        else:
+            stderr = timeout_msg + "\n"
+    if check and returncode != 0:
+        cmd_string = redact_secrets(" ".join(shlex.quote(c) for c in cmd))
+        raise RuntimeError(
+            "Command failed with non-zero exit status "
+            f"{returncode}: {cmd_string}\n"
+            f"stdout:\n{redact_secrets(stdout.strip())}\n\nstderr:\n{redact_secrets(stderr.strip())}"
+        )
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+
+def run_guarded_gh(tokens: list[str], *, capture: bool = True, check: bool = True) -> subprocess.CompletedProcess[str]:
+    command_str = " ".join(shlex.quote(tok) for tok in tokens)
+    return run([*GUARDED_GH, "--command", command_str], capture=capture, check=check)
+
+
+def prepare_guarded_gh_runtime_copy() -> None:
+    source = REPO_ROOT / "tools" / "ci" / "guarded_gh.py"
+    if not source.exists():
+        raise RuntimeError(f"Missing guarded gh wrapper at {source}")
+    tmp_dir = Path(tempfile.mkdtemp(prefix="guarded-gh-"))
+    runtime_script = tmp_dir / "guarded_gh_runtime.py"
+    shutil.copy2(source, runtime_script)
+    GUARDED_GH[:] = [sys.executable, str(runtime_script)]
+
+
+def slugify(text: str) -> str:
+    clean = re.sub(r"[^a-zA-Z0-9-]+", "-", text).strip("-").lower()
+    return clean[:48] if clean else "auto"
+
+
+def branch_name(action: dict[str, Any]) -> str:
+    hint = str(action.get("branch_name_hint", "")).strip()
+    if hint:
+        return slugify(hint)
+    issue = action.get("issue_number")
+    ts = str(action.get("source_slack_ts", "")).replace(".", "")
+    return f"ci-disable-test-{issue}-{ts[-8:]}"
+
+
+def branch_exists_remote(branch: str, repo_slug: str) -> bool:
+    remote_url = f"https://github.com/{repo_slug}.git"
+    check = run(["git", "ls-remote", "--heads", remote_url, f"refs/heads/{branch}"], check=False, capture=True)
+    return bool((check.stdout or "").strip())
+
+
+def base_checkout_ref(target_pr_repo: str, target_pr_base: str) -> str:
+    if target_pr_repo == PRIMARY_REPO:
+        return f"origin/{target_pr_base}"
+    remote_url = f"https://github.com/{target_pr_repo}.git"
+    local_ref = f"refs/remotes/fork-target/{target_pr_base}"
+    run(["git", "fetch", remote_url, f"{target_pr_base}:{local_ref}"], capture=True)
+    return local_ref
+
+
+def choose_branch_name(base: str, source_ts: str, attempt: int, repo_slug: str) -> str:
+    if not branch_exists_remote(base, repo_slug):
+        return base
+    ts = source_ts.replace(".", "")
+    suffix_seed = ts[-6:] if ts else "retry"
+    for idx in range(1, 50):
+        candidate = f"{base}-r{attempt}-{suffix_seed}-{idx}"
+        if not branch_exists_remote(candidate, repo_slug):
+            return candidate
+    raise RuntimeError(f"unable to allocate unique branch name from base {base!r}")
+
+
+def parse_repo_from_pr_url(pr_url: str) -> str:
+    m = re.search(r"github\.com/([^/]+/[^/]+)/pull/\d+", pr_url)
+    return m.group(1) if m else ""
+
+
+def ensure_no_duplicate_open_pr(source_ts: str, pr_repo: str) -> str | None:
+    marker = f"Auto-disable-source-ts: {source_ts}"
+    prs = run_guarded_gh(["gh", "pr", "list", "--repo", pr_repo, "--state", "open", "--json", "number,url,body"])
+    items = json.loads(prs.stdout)
+    for pr in items:
+        if marker in (pr.get("body") or ""):
+            return pr.get("url")
+    return None
+
+
+def is_pr_open(pr_url: str, default_repo: str) -> bool:
+    pr_number = parse_pr_number(pr_url)
+    if pr_number <= 0:
+        return False
+    pr_repo = parse_repo_from_pr_url(pr_url) or default_repo
+    viewed = run_guarded_gh(
+        ["gh", "pr", "view", "--repo", pr_repo, str(pr_number), "--json", "state"],
+        check=False,
+    )
+    if viewed.returncode != 0:
+        return False
+    try:
+        payload = json.loads(viewed.stdout or "{}")
+    except json.JSONDecodeError:
+        return False
+    return str(payload.get("state", "")).upper() == "OPEN"
+
+
+def load_disable_command_spec() -> str:
+    fallback_spec = """# CI Disable Test (Automation Mode)
+
+## Purpose
+Apply the smallest safe CI-only disable for a failing signal, but do not perform git/gh operations.
+
+## Input
+- Required: one GitHub issue URL/number in ebanerjeeTT/issue_dump during testing, or in tenstorrent/tt-metal after production promotion.
+- Optional: one or more job URLs for stronger evidence.
+
+## Hard Constraints
+- You may read files and edit files in this repository.
+- You may use gh only for read operations needed to inspect issue/run context and logs.
+- Do not create branches.
+- Do not run git add, git commit, git push, or gh pr create.
+- Do not dispatch workflows.
+
+## Procedure
+1. Resolve issue/job context from provided input.
+2. Download and inspect failed logs in build_ci/disabling.
+3. Identify the narrowest disable scope that is supported by evidence.
+4. Apply only minimal code/workflow edits needed to disable the failing target.
+5. Add a TODO comment near the disable with non-closing issue reference.
+6. Clean transient logs from build_ci/disabling.
+
+## Required Final Output
+At the end of your response, print this exact marker on its own line:
+===FINAL_DISABLE_EDIT_SUMMARY===
+
+After the marker, print only compact JSON with this schema:
+{
+  "issue_number": 0,
+  "disable_scope": "short description",
+  "files_modified": ["path1", "path2"],
+  "notes": "optional short note"
+}
+"""
+    command_path = Path(".cursor/commands/ci/ci-disable-test-ci.md")
+    if not command_path.exists():
+        return fallback_spec
+    return command_path.read_text(encoding="utf-8")
+
+
+def safe_slug(text: str) -> str:
+    clean = re.sub(r"[^a-zA-Z0-9._-]+", "_", text).strip("._-")
+    return clean or "item"
+
+
+def write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def run_disable_editor(action: dict[str, Any], issue_url: str, model: str) -> tuple[dict[str, Any], dict[str, Any]]:
+    issue_number = int(action["issue_number"])
+    log(f"disable_editor: start issue #{issue_number} with model={model}")
+    job_urls = action.get("job_urls", [])
+    if not isinstance(job_urls, list):
+        job_urls = []
+    job_urls = [str(u).strip() for u in job_urls if str(u).strip()]
+    scope_hint = str(action.get("disable_scope_hint", "")).strip()
+    slack_link = str(action.get("source_slack_permalink", "")).strip()
+
+    command_spec = load_disable_command_spec()
+    prompt = (
+        "Use the following command specification exactly:\n\n"
+        f"{command_spec}\n\n"
+        f"Input issue: {issue_url}\n"
+        + (f"Evidence job URLs: {', '.join(job_urls)}\n" if job_urls else "")
+        + (f"Disable scope hint: {scope_hint}\n" if scope_hint else "")
+        + (f"Source Slack: {slack_link}\n" if slack_link else "")
+        + "Treat the provided job URLs and disable scope hint as sufficient evidence to proceed.\n"
+        + "Do not refuse solely because external URLs are inaccessible in CI.\n"
+        + "If evidence is weak, make no code edits and explain in JSON summary.\n"
+        + "You must emit the marker and JSON contract from the command specification."
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    result = run_streaming(cmd, heartbeat_label=f"disable_editor issue #{issue_number}")
+    debug: dict[str, Any] = {
+        "used_retry": False,
+        "primary_stdout": result.stdout,
+        "primary_stderr": result.stderr,
+    }
+    try:
+        summary = parse_agent_json_after_marker(result.stdout, "===FINAL_DISABLE_EDIT_SUMMARY===")
+        log(f"disable_editor: parsed summary on primary response for issue #{issue_number}")
+        return summary, debug
+    except Exception as exc:
+        log(f"disable_editor: primary parse failed for issue #{issue_number}; retrying summary-only response")
+        debug["primary_parse_error"] = str(exc)
+        # Retry with a strict summary-only prompt in case the main run omitted marker formatting.
+        retry_prompt = (
+            "Output only the required marker and compact JSON summary.\n"
+            "Do not run tools and do not edit files.\n"
+            "Use marker: ===FINAL_DISABLE_EDIT_SUMMARY===\n"
+            f"Set issue_number to {issue_number} and provide a concise disable_scope/notes."
+        )
+        retry_cmd = ["agent", "--trust", "-p", retry_prompt]
+        if model != "auto":
+            retry_cmd[1:1] = ["--model", model]
+        retry = run_streaming(retry_cmd, heartbeat_label=f"disable_editor retry issue #{issue_number}")
+        debug["used_retry"] = True
+        debug["retry_stdout"] = retry.stdout
+        debug["retry_stderr"] = retry.stderr
+        summary = parse_agent_json_after_marker(retry.stdout, "===FINAL_DISABLE_EDIT_SUMMARY===")
+        log(f"disable_editor: parsed summary on retry for issue #{issue_number}")
+        return summary, debug
+
+
+def invoke_kickoff_agent(pr_url: str, model: str) -> str:
+    prompt = (
+        "Follow .cursor/commands/ci/ci-kickoff-workflows.md exactly.\n"
+        f"Input PR URL: {pr_url}\n"
+        "Automatically proceed end-to-end without asking for additional confirmation."
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    result = run_streaming(
+        cmd,
+        check=False,
+        heartbeat_label=f"kickoff_agent for {pr_url}",
+        timeout_sec=300,
+    )
+    if result.returncode == 124:
+        log(f"kickoff_agent: timed out after 300s for {pr_url}; continuing without blocking")
+    elif result.returncode != 0:
+        log(f"kickoff_agent: exited non-zero ({result.returncode}) for {pr_url}; continuing")
+    combined = ((result.stdout or "") + "\n" + (result.stderr or "")).strip()
+    return combined[-2000:]
+
+
+def parse_first_url(text: str) -> str:
+    for line in (text or "").splitlines():
+        candidate = line.strip()
+        if candidate.startswith("http://") or candidate.startswith("https://"):
+            return candidate
+    return ""
+
+
+def parse_extra_workflows(raw: str) -> list[str]:
+    workflows: list[str] = []
+    for entry in (raw or "").split(","):
+        workflow = entry.strip()
+        if not workflow:
+            continue
+        if workflow not in OPTIONAL_EARLY_WORKFLOWS:
+            raise ValueError(f"unsupported extra workflow {workflow!r}; allowed: {sorted(OPTIONAL_EARLY_WORKFLOWS)}")
+        workflows.append(workflow)
+    return workflows
+
+
+def parse_mock_workflow_outcomes(raw: str) -> MockWorkflowSpec:
+    text = (raw or "").strip()
+    if not text:
+        return {}
+    try:
+        parsed = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"invalid --fork-workflow-outcomes JSON: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("--fork-workflow-outcomes must be a JSON object")
+    outcomes: MockWorkflowSpec = {}
+    for key, value in parsed.items():
+        workflow = str(key).strip()
+        if not workflow:
+            continue
+        outcome = ""
+        error = ""
+        details: dict[str, Any] = {}
+        if isinstance(value, dict):
+            outcome = str(value.get("outcome", "")).strip().lower()
+            error = str(value.get("error", "")).strip()
+            details = {str(k): v for k, v in value.items() if str(k) not in {"outcome", "error"}}
+        else:
+            outcome = str(value).strip().lower()
+        if outcome not in ALLOWED_MOCK_WORKFLOW_OUTCOMES:
+            raise ValueError(
+                f"unsupported mock outcome {outcome!r} for {workflow!r}; "
+                f"allowed: {sorted(ALLOWED_MOCK_WORKFLOW_OUTCOMES)}"
+            )
+        outcomes[workflow] = {"outcome": outcome, "error": error, "details": details}
+    return outcomes
+
+
+def dispatch_required_pr_check_workflows(
+    branch: str,
+    workflows: list[str],
+    pr_repo: str,
+    *,
+    simulate_only: bool,
+    mock_outcomes: MockWorkflowSpec,
+) -> tuple[dict[str, str], list[WorkflowDispatchRecord]]:
+    runs: dict[str, str] = {}
+    records: list[WorkflowDispatchRecord] = []
+    for workflow in workflows:
+        if simulate_only:
+            spec = mock_outcomes.get(workflow, {"outcome": "unknown", "error": "", "details": {}})
+            outcome = str(spec.get("outcome", "unknown"))
+            error = str(spec.get("error", "")).strip()
+            details = spec.get("details", {})
+            details_suffix = f" details={json.dumps(details, sort_keys=True)}" if details else ""
+            runs[workflow] = f"(fork-mode simulated outcome: {outcome}" + (f"; error: {error}" if error else "") + ")"
+            records.append(
+                {
+                    "workflow": workflow,
+                    "run_url": runs[workflow],
+                    "outcome": outcome,
+                    "error": error,
+                    "details": details if isinstance(details, dict) else {},
+                }
+            )
+            log(
+                f"dispatch: fork-mode would trigger workflow {workflow} for branch {branch} "
+                f"(mock outcome={outcome}{'; error=' + error if error else ''}{details_suffix})"
+            )
+        else:
+            log(f"dispatch: triggering workflow {workflow} for branch {branch}")
+            dispatched = run_guarded_gh(["gh", "workflow", "run", workflow, "--repo", pr_repo, "--ref", branch])
+            runs[workflow] = parse_first_url(dispatched.stdout)
+            if runs[workflow]:
+                log(f"dispatch: workflow {workflow} run URL {runs[workflow]}")
+            else:
+                log(f"dispatch: workflow {workflow} dispatched (run URL not returned)")
+            records.append(
+                {
+                    "workflow": workflow,
+                    "run_url": runs[workflow],
+                    "outcome": "queued",
+                    "error": "",
+                    "details": {},
+                }
+            )
+    return runs, records
+
+
+def git_changed_files() -> list[str]:
+    out = run(["git", "status", "--porcelain"], capture=True).stdout.strip().splitlines()
+    files: list[str] = []
+    for line in out:
+        if len(line) > 3:
+            files.append(line[3:])
+    return files
+
+
+def git_head_sha() -> str:
+    return run(["git", "rev-parse", "HEAD"], capture=True).stdout.strip()
+
+
+def has_issue_reference_in_working_diff(*, issue_number: int, issue_url: str) -> bool:
+    diff = run(["git", "diff", "--unified=0"], capture=True).stdout
+    needles = {
+        issue_url.strip(),
+        f"/issues/{issue_number}",
+        f"#{issue_number}",
+    }
+    for line in diff.splitlines():
+        if not line.startswith("+") or line.startswith("+++"):
+            continue
+        if any(needle and needle in line for needle in needles):
+            return True
+    return False
+
+
+def log(message: str) -> None:
+    print(f"[{now_utc()}] {message}", flush=True)
+
+
+def state_key_for_ts(source_ts: str) -> str:
+    return f"slack_ts:{source_ts}"
+
+
+def parse_pr_number(pr_url: str) -> int:
+    m = re.search(r"/pull/(\d+)", pr_url)
+    if not m:
+        return 0
+    return int(m.group(1))
+
+
+def parse_run_id_from_url(url: str) -> int:
+    m = re.search(r"/actions/runs/(\d+)", url)
+    if not m:
+        return 0
+    return int(m.group(1))
+
+
+def record_last_kickoff_runs(item: dict[str, Any], dispatch_records: list[WorkflowDispatchRecord]) -> None:
+    entries: list[dict[str, Any]] = []
+    for rec in dispatch_records:
+        workflow = str(rec.get("workflow", "")).strip()
+        if not workflow:
+            continue
+        run_url = str(rec.get("run_url", "")).strip()
+        entries.append(
+            {
+                "workflow": workflow,
+                "run_id": parse_run_id_from_url(run_url),
+                "url": run_url,
+                "conclusion": str(rec.get("outcome", "unknown")).strip() or "unknown",
+            }
+        )
+    item["last_kickoff_runs"] = entries
+
+
+def is_failure_outcome(outcome: str) -> bool:
+    normalized = outcome.strip().lower()
+    return normalized in {"failure", "timed_out", "cancelled", "action_required", "startup_failure", "stale"}
+
+
+def detect_new_failure_signal(dispatch_records: list[WorkflowDispatchRecord]) -> dict[str, Any] | None:
+    for rec in dispatch_records:
+        outcome = str(rec.get("outcome", "")).strip().lower()
+        if not is_failure_outcome(outcome):
+            continue
+        details = rec.get("details", {})
+        if not isinstance(details, dict):
+            details = {}
+        target = ""
+        for key in (
+            "new_failure_target",
+            "test_target",
+            "target",
+            "disable_scope_hint",
+            "failing_test",
+            "job_name",
+        ):
+            value = details.get(key)
+            if value is None:
+                continue
+            text = str(value).strip()
+            if text:
+                target = text
+                break
+        error = str(rec.get("error", "")).strip()
+        if target or error:
+            return {
+                "workflow": str(rec.get("workflow", "")).strip(),
+                "outcome": outcome,
+                "error": error,
+                "details": details,
+                "target": target,
+            }
+    return None
+
+
+def build_failure_signature(failure_signal: dict[str, Any]) -> str:
+    workflow = str(failure_signal.get("workflow", "")).strip().lower()
+    target = str(failure_signal.get("target", "")).strip().lower()
+    error = str(failure_signal.get("error", "")).strip().lower()
+    details = failure_signal.get("details", {})
+    detail_tokens: list[str] = []
+    if isinstance(details, dict):
+        for key in ("new_failure_target", "test_target", "target", "failing_test", "job_name"):
+            value = details.get(key)
+            if value:
+                detail_tokens.append(f"{key}={str(value).strip().lower()}")
+    material = " | ".join([workflow, target, error, " ; ".join(sorted(detail_tokens))]).strip()
+    return material
+
+
+def evaluate_resume_failure_confirmation(
+    *,
+    item: dict[str, Any],
+    failure_signal: dict[str, Any],
+) -> dict[str, str]:
+    signature = build_failure_signature(failure_signal)
+    pending_signature = str(item.get("pending_new_failure_signature", "")).strip()
+    pending_count = int(item.get("pending_new_failure_count", 0) or 0)
+    if not signature:
+        return {"decision": "escalate", "reason": "empty_failure_signature", "signature": ""}
+
+    if not pending_signature:
+        item["pending_new_failure_signature"] = signature
+        item["pending_new_failure_count"] = 1
+        return {"decision": "wait", "reason": "first_new_failure_signature_observed", "signature": signature}
+
+    if pending_signature == signature:
+        item["pending_new_failure_count"] = pending_count + 1
+        if int(item["pending_new_failure_count"]) >= 2:
+            return {"decision": "proceed", "reason": "confirmed_new_failure_signature_twice", "signature": signature}
+        return {"decision": "wait", "reason": "awaiting_second_matching_failure", "signature": signature}
+
+    # Signature changed between confirmation attempts -> treat as non-deterministic.
+    item["pending_new_failure_signature"] = signature
+    item["pending_new_failure_count"] = 1
+    return {"decision": "escalate", "reason": "new_failure_signature_mismatch", "signature": signature}
+
+
+def resolve_existing_pr_branch(item: dict[str, Any], pr_url: str, pr_repo: str) -> str:
+    disable_pr = item.get("disable_pr")
+    if isinstance(disable_pr, dict):
+        branch = str(disable_pr.get("branch", "")).strip()
+        if branch:
+            return branch
+    pr_number = parse_pr_number(pr_url)
+    if pr_number <= 0:
+        raise RuntimeError(f"unable to parse PR number from URL: {pr_url}")
+    viewed = run_guarded_gh(["gh", "pr", "view", "--repo", pr_repo, str(pr_number), "--json", "headRefName,headRefOid"])
+    payload = json.loads(viewed.stdout or "{}")
+    branch = str(payload.get("headRefName", "")).strip()
+    if not branch:
+        raise RuntimeError(f"unable to resolve headRefName for PR {pr_url}")
+    if isinstance(disable_pr, dict):
+        disable_pr["branch"] = branch
+        disable_pr["head_sha"] = str(payload.get("headRefOid", "")).strip()
+    return branch
+
+
+def checkout_branch_from_target_repo(branch: str, target_pr_repo: str) -> None:
+    remote_url = f"https://github.com/{target_pr_repo}.git"
+    local_ref = f"refs/remotes/fork-target/{branch}"
+    run(["git", "fetch", remote_url, f"{branch}:{local_ref}"], capture=True)
+    run(["git", "checkout", "-B", branch, local_ref], capture=True)
+
+
+def augment_action_for_resume(
+    action: dict[str, Any],
+    *,
+    pr_url: str,
+    failure_signal: dict[str, Any],
+) -> dict[str, Any]:
+    merged = dict(action)
+    target = str(failure_signal.get("target", "")).strip()
+    error = str(failure_signal.get("error", "")).strip()
+    workflow = str(failure_signal.get("workflow", "")).strip()
+    detail_parts: list[str] = [f"Resume existing PR: {pr_url}"]
+    if workflow:
+        detail_parts.append(f"workflow={workflow}")
+    if target:
+        detail_parts.append(f"new_failure_target={target}")
+    if error:
+        detail_parts.append(f"error={error}")
+    details = failure_signal.get("details", {})
+    if isinstance(details, dict) and details:
+        detail_parts.append(f"details={json.dumps(details, sort_keys=True)}")
+    prefix = " | ".join(detail_parts)
+    existing_hint = str(merged.get("disable_scope_hint", "")).strip()
+    merged["disable_scope_hint"] = (prefix + (" | " + existing_hint if existing_hint else "")).strip()
+    job_urls = merged.get("job_urls")
+    if not isinstance(job_urls, list):
+        job_urls = []
+    if isinstance(details, dict):
+        maybe_urls: list[str] = []
+        single_url = details.get("job_url") or details.get("run_url") or details.get("log_url")
+        if single_url:
+            maybe_urls.append(str(single_url))
+        if isinstance(details.get("job_urls"), list):
+            maybe_urls.extend(str(v) for v in details["job_urls"])
+        for url in maybe_urls:
+            cleaned = url.strip()
+            if cleaned and cleaned not in job_urls:
+                job_urls.append(cleaned)
+    merged["job_urls"] = job_urls
+    return merged
+
+
+def post_triggered_workflows_comment(pr_url: str, runs: dict[str, str], pr_repo: str) -> None:
+    pr_number = parse_pr_number(pr_url)
+    if pr_number <= 0 or not runs:
+        return
+    lines = [
+        "Auto-triage triggered these workflows:",
+        "",
+    ]
+    for workflow, run_url in sorted(runs.items()):
+        if run_url:
+            lines.append(f"- `{workflow}`: {run_url}")
+        else:
+            lines.append(f"- `{workflow}`: dispatched (run URL unavailable)")
+    body = "\n".join(lines).strip()
+    run_guarded_gh(
+        [
+            "gh",
+            "pr",
+            "comment",
+            "--repo",
+            pr_repo,
+            str(pr_number),
+            "--body",
+            body,
+        ]
+    )
+
+
+def post_pr_update_changelog_comment(
+    *,
+    pr_url: str,
+    pr_repo: str,
+    issue_number: int,
+    changed_files: list[str],
+    disable_edit_summary: dict[str, Any],
+) -> None:
+    pr_number = parse_pr_number(pr_url)
+    if pr_number <= 0:
+        return
+    lines = [
+        "Auto-triage incremental update pushed to this draft PR.",
+        "",
+        f"- Linked issue: #{issue_number}",
+        f"- Updated files count: {len(changed_files)}",
+    ]
+    if changed_files:
+        lines.append("- Files changed:")
+        for path in sorted(changed_files)[:20]:
+            lines.append(f"  - `{path}`")
+    scope = str(disable_edit_summary.get("disable_scope", "")).strip()
+    notes = str(disable_edit_summary.get("notes", "")).strip()
+    if scope:
+        lines.append(f"- Disable scope: {scope}")
+    if notes:
+        lines.append(f"- Notes: {notes}")
+    body = "\n".join(lines).strip()
+    run_guarded_gh(
+        [
+            "gh",
+            "pr",
+            "comment",
+            "--repo",
+            pr_repo,
+            str(pr_number),
+            "--body",
+            body,
+        ]
+    )
+
+
+def post_issue_justification_comment(
+    *,
+    issue_number: int,
+    issue_repo: str,
+    pr_url: str,
+    failure_signature: str,
+    failure_signal: dict[str, Any],
+    workflow_runs: dict[str, str],
+) -> None:
+    lines = [
+        "CI auto triage updated an existing disable PR after deterministic confirmation of a new failing target.",
+        "",
+        f"- Linked disable PR: {pr_url}",
+        f"- Confirmation rule: same new-failure signature observed twice on PR-branch workflow dispatches",
+        f"- New failure signature: `{failure_signature}`",
+    ]
+    workflow = str(failure_signal.get("workflow", "")).strip()
+    target = str(failure_signal.get("target", "")).strip()
+    error = str(failure_signal.get("error", "")).strip()
+    if workflow:
+        lines.append(f"- Workflow: `{workflow}`")
+    if target:
+        lines.append(f"- New target: `{target}`")
+    if error:
+        lines.append(f"- Error: `{error}`")
+    if workflow_runs:
+        lines.append("- Confirmation run URLs:")
+        for wf_name, run_url in sorted(workflow_runs.items()):
+            if run_url:
+                lines.append(f"  - `{wf_name}`: {run_url}")
+            else:
+                lines.append(f"  - `{wf_name}`: dispatched (run URL unavailable)")
+    body = "\n".join(lines).strip()
+    run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "comment",
+            "--repo",
+            issue_repo,
+            str(issue_number),
+            "--body",
+            body,
+        ]
+    )
+
+
+def pr_label(pr_url: str) -> str:
+    m = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)", pr_url)
+    if not m:
+        return pr_url
+    return f"{m.group(1)}#{m.group(2)}"
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    return _load_state_common(path, schema="disable")
+
+
+def state_index(state: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    return {str(item["key"]): item for item in state.get("items", []) if isinstance(item, dict) and "key" in item}
+
+
+def ensure_state_item(state: dict[str, Any], action: dict[str, Any]) -> dict[str, Any]:
+    source_ts = str(action["source_slack_ts"])
+    key = state_key_for_ts(source_ts)
+    idx = state_index(state)
+    if key in idx:
+        return idx[key]
+    issue = int(action["issue_number"])
+    item = {
+        "key": key,
+        "slack_ts": source_ts,
+        "issue_numbers": [issue],
+        "status": "new",
+        "disable_pr": {"number": 0, "url": "", "branch": "", "head_sha": ""},
+        "attempts": 0,
+        "last_kickoff_runs": [],
+        "notification": {"terminal_notified": False, "last_error": ""},
+        "terminal_reason": "",
+        "history": [],
+    }
+    append_history(item, "state_created", f"Initialized from issue #{issue}")
+    state["items"].append(item)
+    return item
+
+
+def set_status(item: dict[str, Any], status: str, *, event: str, details: str) -> None:
+    if status not in ALLOWED_STATUS:
+        raise ValueError(f"invalid status transition target: {status}")
+    item["status"] = status
+    append_history(item, event, details)
+
+
+def state_has_active_pr(item: dict[str, Any]) -> str | None:
+    status = str(item.get("status", ""))
+    if status not in {"pr_open", "kickoff_running", "kickoff_failed_new_failure"}:
+        return None
+    disable_pr = item.get("disable_pr")
+    if not isinstance(disable_pr, dict):
+        return None
+    pr_url = str(disable_pr.get("url", "")).strip()
+    return pr_url or None
+
+
+def tracked_pr_url(item: dict[str, Any]) -> str:
+    disable_pr = item.get("disable_pr")
+    if not isinstance(disable_pr, dict):
+        return ""
+    return str(disable_pr.get("url", "")).strip()
+
+
+def ensure_git_identity() -> None:
+    name = run(["git", "config", "--get", "user.name"], check=False, capture=True)
+    email = run(["git", "config", "--get", "user.email"], check=False, capture=True)
+    if name.returncode != 0 or not (name.stdout or "").strip():
+        run(["git", "config", "user.name", "CI Auto Disable Bot"], capture=True)
+    if email.returncode != 0 or not (email.stdout or "").strip():
+        run(["git", "config", "user.email", "ci-auto-disable-bot@tenstorrent.invalid"], capture=True)
+
+
+def github_login_for_token(token: str) -> tuple[str | None, str]:
+    req = urllib.request.Request(
+        "https://api.github.com/user",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "tt-metal-ci-triage",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return None, f"http_{exc.code}"
+    except Exception as exc:
+        return None, f"request_error:{type(exc).__name__}"
+    login = str(payload.get("login", "")).strip()
+    if not login:
+        return None, "missing_login"
+    return login, "ok"
+
+
+def push_branch_with_token(branch: str, target_pr_repo: str, token: str) -> None:
+    login, login_reason = github_login_for_token(token)
+    if not login:
+        raise RuntimeError(f"Unable to resolve token login for git push: {login_reason}")
+    push_url = f"https://github.com/{target_pr_repo}.git"
+    askpass_script = Path(tempfile.mkdtemp(prefix="git-askpass-")) / "askpass.sh"
+    askpass_script.write_text(
+        "#!/bin/sh\n"
+        'case "$1" in\n'
+        '  *Username*) echo "$GIT_PUSH_USER" ;;\n'
+        '  *) echo "$GIT_PUSH_TOKEN" ;;\n'
+        "esac\n",
+        encoding="utf-8",
+    )
+    askpass_script.chmod(0o700)
+    run(
+        ["git", "push", "-u", push_url, f"HEAD:refs/heads/{branch}"],
+        capture=True,
+        env={
+            "GIT_TERMINAL_PROMPT": "0",
+            "GIT_ASKPASS": str(askpass_script),
+            "GIT_PUSH_USER": login,
+            "GIT_PUSH_TOKEN": token,
+        },
+    )
+
+
+def can_token_push_to_repo(token: str, repo_slug: str) -> tuple[bool, str]:
+    req = urllib.request.Request(
+        f"https://api.github.com/repos/{repo_slug}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "tt-metal-ci-triage",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.HTTPError as exc:
+        return False, f"http_{exc.code}"
+    except Exception as exc:
+        return False, f"request_error:{type(exc).__name__}"
+    perms = payload.get("permissions", {})
+    if not isinstance(perms, dict):
+        return False, "missing_permissions"
+    if perms.get("push") is True:
+        return True, "ok"
+    return False, f"push_denied permissions={perms}"
+
+
+def write_summary(path: Path, data: dict[str, Any]) -> None:
+    lines: list[str] = []
+    lines.append("# Auto Disable Actions")
+    lines.append("")
+    lines.append(f"- Planned actions: {data.get('planned_actions', 0)}")
+    lines.append(f"- Executed actions: {len(data.get('executed', []))}")
+    lines.append(f"- Skipped actions: {len(data.get('skipped', []))}")
+    lines.append(f"- State updates: {data.get('state_updates', 0)}")
+    lines.append("")
+    lines.append("## State Status Counts")
+    for status, count in sorted((data.get("state_status_counts") or {}).items()):
+        lines.append(f"- {status}: {count}")
+    lines.append("")
+    lines.append("## Executed")
+    for item in data.get("executed", []):
+        issue_number = item.get("issue_number")
+        pr_url = str(item.get("pr_url", "")).strip()
+        lines.append(f"- issue #{issue_number} -> PR: {pr_label(pr_url)}")
+    lines.append("")
+    lines.append("## Skipped")
+    for item in data.get("skipped", []):
+        lines.append(f"- ts {item.get('source_slack_ts')}: {item.get('reason')}")
+    path.write_text("\n".join(lines).rstrip() + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Execute auto-disable action JSON.")
+    parser.add_argument("--actions-json", required=True)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--summary-md", required=True)
+    parser.add_argument("--state-json", required=True)
+    parser.add_argument("--debug-dir", default="")
+    parser.add_argument("--model", default="auto")
+    parser.add_argument("--max-attempts-per-item", type=int, default=10)
+    parser.add_argument("--target-pr-repo", default=DEFAULT_PR_REPO)
+    parser.add_argument("--target-pr-base", default=DEFAULT_PR_BASE)
+    parser.add_argument(
+        "--fork-workflow-outcomes",
+        default="{}",
+        help=(
+            "JSON object mapping workflow id to mocked fork result; value may be outcome string "
+            'or object like {"outcome":"failure","error":"message"}'
+        ),
+    )
+    parser.add_argument(
+        "--extra-pr-check-workflows",
+        default="",
+        help="Comma-separated optional early workflows to run after PR create (allowed: pr-gate.yaml, merge-gate.yaml)",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    target_pr_repo = args.target_pr_repo.strip() or DEFAULT_PR_REPO
+    target_pr_base = args.target_pr_base.strip() or DEFAULT_PR_BASE
+    fork_mode = target_pr_repo != PRIMARY_REPO
+    extra_pr_check_workflows = parse_extra_workflows(args.extra_pr_check_workflows)
+    mock_workflow_outcomes = parse_mock_workflow_outcomes(args.fork_workflow_outcomes)
+    log(
+        "execute_disable_actions: start "
+        f"dry_run={args.dry_run} model={args.model} max_attempts_per_item={args.max_attempts_per_item} "
+        f"target_pr_repo={target_pr_repo} fork_mode={fork_mode}"
+    )
+
+    if not args.dry_run:
+        if not os.environ.get("GITHUB_TOKEN"):
+            print("GITHUB_TOKEN is required", file=sys.stderr)
+            return 2
+        if not os.environ.get("CURSOR_API_KEY"):
+            print("CURSOR_API_KEY is required", file=sys.stderr)
+            return 2
+        push_token = os.environ.get("TARGET_PR_PUSH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+        if not push_token:
+            print("TARGET_PR_PUSH_TOKEN or GITHUB_TOKEN is required", file=sys.stderr)
+            return 2
+        can_push, reason = can_token_push_to_repo(push_token, target_pr_repo)
+        if not can_push:
+            print(f"Token cannot push to {target_pr_repo}: {redact_secrets(reason)}", file=sys.stderr)
+            return 2
+
+    actions_doc = json.loads(Path(args.actions_json).read_text(encoding="utf-8"))
+    actions = actions_doc.get("actions", [])
+    if not isinstance(actions, list):
+        print("Invalid actions JSON: actions must be a list", file=sys.stderr)
+        return 2
+
+    # Validate and dedupe by source ts.
+    dedup: dict[str, dict[str, Any]] = {}
+    for action in actions:
+        if not isinstance(action, dict):
+            continue
+        source_ts = str(action.get("source_slack_ts", "")).strip()
+        issue = action.get("issue_number")
+        if not source_ts or not isinstance(issue, int):
+            continue
+        dedup[source_ts] = action
+    validated_actions = list(dedup.values())
+    log(f"execute_disable_actions: validated {len(validated_actions)} actions after input filtering")
+    state_path = Path(args.state_json)
+    state = load_state(state_path)
+    log(f"execute_disable_actions: loaded state from {state_path}")
+
+    result: dict[str, Any] = {
+        "planned_actions": len(validated_actions),
+        "executed": [],
+        "skipped": [],
+        "dry_run": args.dry_run,
+        "state_path": str(state_path),
+        "state_updates": 0,
+    }
+    debug_root = Path(args.debug_dir) if args.debug_dir else None
+    if debug_root is not None:
+        debug_root.mkdir(parents=True, exist_ok=True)
+        result["debug_dir"] = str(debug_root)
+
+    if not args.dry_run:
+        log("execute_disable_actions: preparing guarded gh runtime copy and auth checks")
+        prepare_guarded_gh_runtime_copy()
+        run_guarded_gh(["gh", "auth", "status"])
+        run(["git", "fetch", "origin", target_pr_base], capture=True)
+        log(f"execute_disable_actions: git fetch origin/{target_pr_base} complete")
+
+    for action in validated_actions:
+        source_ts = str(action["source_slack_ts"])
+        issue_number = int(action["issue_number"])
+        log(f"action: evaluating issue #{issue_number} source_ts={source_ts}")
+        issue_repo = str(action.get("issue_repo", ISSUE_REPO_TEST)).strip() or ISSUE_REPO_TEST
+        issue_url = str(action.get("issue_url", "")).strip() or f"https://github.com/{issue_repo}/issues/{issue_number}"
+        item = ensure_state_item(state, action)
+
+        if item["status"] in {"completed", "paused"}:
+            result["skipped"].append(
+                {
+                    "source_slack_ts": source_ts,
+                    "issue_number": issue_number,
+                    "reason": f"terminal_state:{item['status']}",
+                }
+            )
+            append_history(item, "skip_terminal_state", f"Skipped because status is {item['status']}")
+            continue
+
+        active_pr_url = tracked_pr_url(item)
+        if active_pr_url and not args.dry_run:
+            active_pr_repo = parse_repo_from_pr_url(active_pr_url)
+            if active_pr_repo and active_pr_repo != target_pr_repo:
+                log(
+                    f"action: tracked PR repo mismatch for issue #{issue_number}; "
+                    f"expected {target_pr_repo}, got {active_pr_repo}; resetting state for retarget"
+                )
+                item["disable_pr"] = {"number": 0, "url": "", "branch": "", "head_sha": ""}
+                item["attempts"] = 0
+                set_status(
+                    item,
+                    "new",
+                    event="tracked_pr_repo_mismatch_reset",
+                    details=f"Reset PR metadata and attempts from repo {active_pr_repo} to target {target_pr_repo}",
+                )
+                result["state_updates"] += 1
+                active_pr_url = ""
+        if active_pr_url and not args.dry_run and not is_pr_open(active_pr_url, target_pr_repo):
+            log(f"action: tracked PR is no longer open for issue #{issue_number}: {active_pr_url}")
+            item["disable_pr"] = {"number": 0, "url": "", "branch": "", "head_sha": ""}
+            set_status(
+                item,
+                "new",
+                event="active_pr_not_open_anymore",
+                details=f"Previously tracked PR is no longer open: {active_pr_url}",
+            )
+            result["state_updates"] += 1
+            active_pr_url = ""
+        if active_pr_url:
+            if args.dry_run:
+                log(
+                    f"action: dry-run would evaluate existing PR resume path for issue #{issue_number}: {active_pr_url}"
+                )
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": f"active_tracked_pr_dry_run:{active_pr_url}",
+                    }
+                )
+                append_history(item, "dry_run_active_pr_detected", f"Would resume active PR: {active_pr_url}")
+                continue
+
+            required_workflows = [*DEFAULT_REQUIRED_PR_CHECK_WORKFLOWS, *extra_pr_check_workflows]
+            try:
+                branch = resolve_existing_pr_branch(item, active_pr_url, target_pr_repo)
+                log(
+                    f"action: existing PR detected for issue #{issue_number}; branch={branch}; "
+                    f"evaluating workflow outcomes for resume path"
+                )
+                required_check_runs, dispatch_records = dispatch_required_pr_check_workflows(
+                    branch,
+                    required_workflows,
+                    target_pr_repo,
+                    simulate_only=fork_mode,
+                    mock_outcomes=mock_workflow_outcomes,
+                )
+                record_last_kickoff_runs(item, dispatch_records)
+                post_triggered_workflows_comment(active_pr_url, required_check_runs, target_pr_repo)
+                failure_signal = detect_new_failure_signal(dispatch_records)
+                if not failure_signal:
+                    item["pending_new_failure_signature"] = ""
+                    item["pending_new_failure_count"] = 0
+                    set_status(
+                        item,
+                        "kickoff_running",
+                        event="existing_pr_kickoff_rerun_no_new_failure",
+                        details=f"No actionable new failure signal for {active_pr_url}",
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": f"active_tracked_pr_no_new_failure:{active_pr_url}",
+                            "required_check_runs": required_check_runs,
+                        }
+                    )
+                    continue
+
+                confirm = evaluate_resume_failure_confirmation(item=item, failure_signal=failure_signal)
+                failure_signature = confirm.get("signature", "")
+                if confirm["decision"] == "wait":
+                    set_status(
+                        item,
+                        "kickoff_failed_new_failure",
+                        event="existing_pr_new_failure_first_signal",
+                        details=f"{confirm['reason']} signature={failure_signature}",
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": f"new_failure_needs_second_confirmation:{confirm['reason']}",
+                            "failure_signature": failure_signature,
+                        }
+                    )
+                    continue
+                if confirm["decision"] == "escalate":
+                    set_status(
+                        item,
+                        "needs_human",
+                        event="existing_pr_new_failure_non_deterministic",
+                        details=f"{confirm['reason']} signature={failure_signature}",
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": f"new_failure_non_deterministic:{confirm['reason']}",
+                            "failure_signature": failure_signature,
+                        }
+                    )
+                    continue
+
+                set_status(
+                    item,
+                    "kickoff_failed_new_failure",
+                    event="existing_pr_new_failure_detected",
+                    details=(
+                        f"workflow={failure_signal.get('workflow','')} "
+                        f"target={failure_signal.get('target','')} "
+                        f"error={failure_signal.get('error','')}"
+                    ).strip(),
+                )
+                result["state_updates"] += 1
+                log(
+                    f"action: new failure detected for issue #{issue_number}; "
+                    f"workflow={failure_signal.get('workflow','')} target={failure_signal.get('target','')}"
+                )
+                checkout_branch_from_target_repo(branch, target_pr_repo)
+                before = set(git_changed_files())
+                if before:
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": "working_tree_not_clean_before_resume_action",
+                        }
+                    )
+                    append_history(item, "skip_dirty_tree_resume", "Working tree not clean before resume action")
+                    continue
+
+                item["attempts"] = int(item.get("attempts", 0)) + 1
+                set_status(
+                    item,
+                    "planned",
+                    event="resume_attempt_started",
+                    details=f"Attempt {item['attempts']} on existing branch {branch}",
+                )
+                result["state_updates"] += 1
+
+                resume_action = augment_action_for_resume(action, pr_url=active_pr_url, failure_signal=failure_signal)
+                edit_summary, editor_debug = run_disable_editor(resume_action, issue_url, args.model)
+                if debug_root is not None:
+                    item_dir = debug_root / f"{safe_slug(source_ts)}_issue_{issue_number}"
+                    write_text(
+                        item_dir / "disable_editor_primary.stdout.txt", str(editor_debug.get("primary_stdout", ""))
+                    )
+                    write_text(
+                        item_dir / "disable_editor_primary.stderr.txt", str(editor_debug.get("primary_stderr", ""))
+                    )
+                    if editor_debug.get("used_retry"):
+                        write_text(
+                            item_dir / "disable_editor_retry.stdout.txt", str(editor_debug.get("retry_stdout", ""))
+                        )
+                        write_text(
+                            item_dir / "disable_editor_retry.stderr.txt", str(editor_debug.get("retry_stderr", ""))
+                        )
+                    write_text(item_dir / "disable_edit_summary.json", json.dumps(edit_summary, indent=2))
+
+                changed = git_changed_files()
+                if not changed:
+                    log(f"action: no code changes produced during M3 resume for issue #{issue_number}")
+                    summary_note = str(edit_summary.get("notes", "")).strip() if isinstance(edit_summary, dict) else ""
+                    set_status(
+                        item,
+                        "needs_human",
+                        event="resume_no_changes_from_disable_editor",
+                        details=f"Attempt {item['attempts']} produced no incremental code changes. {summary_note}".strip(),
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": "resume_no_code_changes_from_agent",
+                            "disable_edit_summary": edit_summary,
+                        }
+                    )
+                    continue
+
+                protected = sorted({p for p in changed if p in PROTECTED_AGENT_PATHS})
+                if protected:
+                    log(f"action: protected paths modified during resume for issue #{issue_number}; escalating")
+                    set_status(
+                        item,
+                        "needs_human",
+                        event="resume_protected_paths_modified",
+                        details=f"Attempt {item['attempts']} modified protected paths: {', '.join(protected)}",
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": f"resume_protected_paths_modified:{','.join(protected)}",
+                            "disable_edit_summary": edit_summary,
+                        }
+                    )
+                    continue
+
+                if not has_issue_reference_in_working_diff(issue_number=issue_number, issue_url=issue_url):
+                    log(
+                        f"action: resume edits for issue #{issue_number} missing explicit issue reference in code diff; "
+                        "escalating to needs_human"
+                    )
+                    set_status(
+                        item,
+                        "needs_human",
+                        event="resume_missing_issue_reference_comment",
+                        details=f"Attempt {item['attempts']} did not add issue reference for #{issue_number}",
+                    )
+                    result["state_updates"] += 1
+                    result["skipped"].append(
+                        {
+                            "source_slack_ts": source_ts,
+                            "issue_number": issue_number,
+                            "reason": "resume_missing_issue_reference_comment",
+                            "disable_edit_summary": edit_summary,
+                        }
+                    )
+                    continue
+
+                run(["git", "add", "."], capture=True)
+                commit_msg = f"ci: extend disable for #{issue_number} (existing PR)"
+                ensure_git_identity()
+                log(f"action: committing incremental disable changes for issue #{issue_number} on existing PR")
+                run(["git", "commit", "-m", commit_msg], capture=True)
+                log(f"action: pushing updated branch {branch} for issue #{issue_number}")
+                push_token = os.environ.get("TARGET_PR_PUSH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+                if not push_token:
+                    raise RuntimeError("TARGET_PR_PUSH_TOKEN or GITHUB_TOKEN is required for PR branch push")
+                push_branch_with_token(branch, target_pr_repo, push_token)
+                post_pr_update_changelog_comment(
+                    pr_url=active_pr_url,
+                    pr_repo=target_pr_repo,
+                    issue_number=issue_number,
+                    changed_files=changed,
+                    disable_edit_summary=edit_summary if isinstance(edit_summary, dict) else {},
+                )
+
+                rerun_check_runs, rerun_records = dispatch_required_pr_check_workflows(
+                    branch,
+                    required_workflows,
+                    target_pr_repo,
+                    simulate_only=fork_mode,
+                    mock_outcomes=mock_workflow_outcomes,
+                )
+                record_last_kickoff_runs(item, rerun_records)
+                post_triggered_workflows_comment(active_pr_url, rerun_check_runs, target_pr_repo)
+                if fork_mode:
+                    kickoff_spec = mock_workflow_outcomes.get("kickoff-agent", {"outcome": "unknown", "error": ""})
+                    kickoff_outcome = str(kickoff_spec.get("outcome", "unknown"))
+                    kickoff_error = str(kickoff_spec.get("error", "")).strip()
+                    kickoff_tail = (
+                        "fork-mode: skipped kickoff agent dispatch; "
+                        f"would invoke kickoff for {active_pr_url} (mock outcome={kickoff_outcome}"
+                        + (f", error={kickoff_error}" if kickoff_error else "")
+                        + ")"
+                    )
+                    log(kickoff_tail)
+                else:
+                    log(f"action: invoking kickoff workflow agent for existing PR {active_pr_url}")
+                    kickoff_tail = invoke_kickoff_agent(active_pr_url, args.model)
+
+                item["disable_pr"] = {
+                    "number": parse_pr_number(active_pr_url),
+                    "url": active_pr_url,
+                    "branch": branch,
+                    "head_sha": git_head_sha(),
+                }
+                set_status(
+                    item,
+                    "kickoff_running",
+                    event="existing_pr_updated_and_kickoff_rerun",
+                    details=active_pr_url,
+                )
+                result["state_updates"] += 1
+                item["pending_new_failure_signature"] = ""
+                item["pending_new_failure_count"] = 0
+                issue_repo = str(action.get("issue_repo", ISSUE_REPO_TEST)).strip() or ISSUE_REPO_TEST
+                post_issue_justification_comment(
+                    issue_number=issue_number,
+                    issue_repo=issue_repo,
+                    pr_url=active_pr_url,
+                    failure_signature=failure_signature,
+                    failure_signal=failure_signal,
+                    workflow_runs={**required_check_runs, **rerun_check_runs},
+                )
+                result["executed"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "branch": branch,
+                        "pr_url": active_pr_url,
+                        "required_check_runs": rerun_check_runs,
+                        "disable_edit_summary": edit_summary,
+                        "kickoff_output_tail": kickoff_tail,
+                        "attempts": item["attempts"],
+                        "resume_existing_pr": True,
+                    }
+                )
+                continue
+            except Exception as exc:
+                safe_exc = redact_secrets(str(exc))
+                log(f"action: failed M3 resume flow issue #{issue_number}: {safe_exc}")
+                set_status(item, "needs_human", event="resume_action_failed", details=safe_exc)
+                result["state_updates"] += 1
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": f"resume_action_failed:{safe_exc}",
+                    }
+                )
+                continue
+
+        if int(item.get("attempts", 0)) >= args.max_attempts_per_item:
+            set_status(
+                item,
+                "needs_human",
+                event="max_attempts_exceeded",
+                details=f"attempts={item.get('attempts', 0)} threshold={args.max_attempts_per_item}",
+            )
+            result["state_updates"] += 1
+            result["skipped"].append(
+                {
+                    "source_slack_ts": source_ts,
+                    "issue_number": issue_number,
+                    "reason": "max_attempts_exceeded",
+                }
+            )
+            continue
+
+        pr_title = str(action.get("pr_title", "")).strip() or f"ci: disable failing test for #{issue_number}"
+        pr_body = str(action.get("pr_body", "")).strip()
+        if not pr_body:
+            pr_body = (
+                f"Refs #{issue_number}\n\n"
+                f"Source Issue: {issue_url}\n"
+                f"Auto-disable-source-ts: {source_ts}\n"
+                f"Source Slack: {action.get('source_slack_permalink', '')}\n"
+            )
+        if f"Auto-disable-source-ts: {source_ts}" not in pr_body:
+            pr_body += f"\n\nAuto-disable-source-ts: {source_ts}\n"
+
+        existing = None if args.dry_run else ensure_no_duplicate_open_pr(source_ts, target_pr_repo)
+        if existing:
+            log(f"action: found matching open PR marker for issue #{issue_number}: {existing}")
+            item["disable_pr"]["url"] = existing
+            item["disable_pr"]["number"] = parse_pr_number(existing)
+            set_status(item, "pr_open", event="existing_pr_detected", details=f"Found open PR {existing}")
+            result["state_updates"] += 1
+            result["skipped"].append(
+                {"source_slack_ts": source_ts, "issue_number": issue_number, "reason": f"already_open_pr:{existing}"}
+            )
+            continue
+
+        branch = branch_name(action)
+        if not args.dry_run:
+            branch = choose_branch_name(branch, source_ts, int(item.get("attempts", 0)) + 1, target_pr_repo)
+            if branch != branch_name(action):
+                log(f"action: adjusted branch name for issue #{issue_number} to avoid remote collision: {branch}")
+        if args.dry_run:
+            log(f"action: dry-run planned for issue #{issue_number} on branch {branch}")
+            set_status(
+                item,
+                "planned",
+                event="dry_run_planned_disable",
+                details=f"Would create or update branch {branch}",
+            )
+            result["state_updates"] += 1
+            result["executed"].append(
+                {
+                    "source_slack_ts": source_ts,
+                    "issue_number": issue_number,
+                    "branch": branch,
+                    "pr_url": "(dry-run)",
+                    "kickoff_output_tail": "(dry-run)",
+                }
+            )
+            continue
+
+        try:
+            log(f"action: checking out branch {branch} for issue #{issue_number}")
+            checkout_ref = base_checkout_ref(target_pr_repo, target_pr_base)
+            run(["git", "checkout", "-B", branch, checkout_ref], capture=True)
+            before = set(git_changed_files())
+            if before:
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": "working_tree_not_clean_before_action",
+                    }
+                )
+                append_history(item, "skip_dirty_tree", "Working tree not clean before action")
+                continue
+
+            item["attempts"] = int(item.get("attempts", 0)) + 1
+            set_status(
+                item, "planned", event="attempt_started", details=f"Attempt {item['attempts']} on branch {branch}"
+            )
+            result["state_updates"] += 1
+
+            edit_summary, editor_debug = run_disable_editor(action, issue_url, args.model)
+            if debug_root is not None:
+                item_dir = debug_root / f"{safe_slug(source_ts)}_issue_{issue_number}"
+                write_text(item_dir / "disable_editor_primary.stdout.txt", str(editor_debug.get("primary_stdout", "")))
+                write_text(item_dir / "disable_editor_primary.stderr.txt", str(editor_debug.get("primary_stderr", "")))
+                if editor_debug.get("used_retry"):
+                    write_text(item_dir / "disable_editor_retry.stdout.txt", str(editor_debug.get("retry_stdout", "")))
+                    write_text(item_dir / "disable_editor_retry.stderr.txt", str(editor_debug.get("retry_stderr", "")))
+                write_text(item_dir / "disable_edit_summary.json", json.dumps(edit_summary, indent=2))
+            changed = git_changed_files()
+            if not changed:
+                log(f"action: no code changes produced by disable editor for issue #{issue_number}")
+                summary_note = str(edit_summary.get("notes", "")).strip() if isinstance(edit_summary, dict) else ""
+                skip_reason = "no_code_changes_from_agent"
+                if summary_note:
+                    skip_reason += f":{summary_note}"
+                set_status(
+                    item,
+                    "needs_human",
+                    event="no_changes_from_disable_editor",
+                    details=f"Attempt {item['attempts']} produced no code changes. {summary_note}".strip(),
+                )
+                result["state_updates"] += 1
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": skip_reason,
+                        "disable_edit_summary": edit_summary,
+                    }
+                )
+                continue
+            protected = sorted({p for p in changed if p in PROTECTED_AGENT_PATHS})
+            if protected:
+                log(f"action: protected paths modified for issue #{issue_number}; escalating to needs_human")
+                set_status(
+                    item,
+                    "needs_human",
+                    event="protected_paths_modified",
+                    details=f"Attempt {item['attempts']} modified protected paths: {', '.join(protected)}",
+                )
+                result["state_updates"] += 1
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": f"protected_paths_modified:{','.join(protected)}",
+                        "disable_edit_summary": edit_summary,
+                    }
+                )
+                continue
+
+            if not has_issue_reference_in_working_diff(issue_number=issue_number, issue_url=issue_url):
+                log(
+                    f"action: disable edits for issue #{issue_number} missing explicit issue reference in code diff; "
+                    "escalating to needs_human"
+                )
+                set_status(
+                    item,
+                    "needs_human",
+                    event="missing_issue_reference_comment",
+                    details=f"Attempt {item['attempts']} did not add issue reference for #{issue_number}",
+                )
+                result["state_updates"] += 1
+                result["skipped"].append(
+                    {
+                        "source_slack_ts": source_ts,
+                        "issue_number": issue_number,
+                        "reason": "missing_issue_reference_comment",
+                        "disable_edit_summary": edit_summary,
+                    }
+                )
+                continue
+
+            run(["git", "add", "."], capture=True)
+            commit_msg = f"ci: disable failing test for #{issue_number}"
+            ensure_git_identity()
+            log(f"action: committing disable changes for issue #{issue_number}")
+            run(["git", "commit", "-m", commit_msg], capture=True)
+            log(f"action: pushing branch {branch} for issue #{issue_number}")
+            push_token = os.environ.get("TARGET_PR_PUSH_TOKEN") or os.environ.get("GITHUB_TOKEN", "")
+            if not push_token:
+                raise RuntimeError("TARGET_PR_PUSH_TOKEN or GITHUB_TOKEN is required for PR branch push")
+            push_branch_with_token(branch, target_pr_repo, push_token)
+
+            log(f"action: creating draft PR for issue #{issue_number}")
+            pr = run_guarded_gh(
+                [
+                    "gh",
+                    "pr",
+                    "create",
+                    "--repo",
+                    target_pr_repo,
+                    "--draft",
+                    "--base",
+                    target_pr_base,
+                    "--head",
+                    branch,
+                    "--title",
+                    pr_title,
+                    "--body",
+                    pr_body,
+                    "--label",
+                    "CI auto triage",
+                ]
+            )
+            pr_url = pr.stdout.strip().splitlines()[-1].strip()
+            log(f"action: created PR {pr_url} for issue #{issue_number}")
+            required_check_runs, dispatch_records = dispatch_required_pr_check_workflows(
+                branch,
+                [*DEFAULT_REQUIRED_PR_CHECK_WORKFLOWS, *extra_pr_check_workflows],
+                target_pr_repo,
+                simulate_only=fork_mode,
+                mock_outcomes=mock_workflow_outcomes,
+            )
+            record_last_kickoff_runs(item, dispatch_records)
+            post_triggered_workflows_comment(pr_url, required_check_runs, target_pr_repo)
+            if fork_mode:
+                kickoff_spec = mock_workflow_outcomes.get("kickoff-agent", {"outcome": "unknown", "error": ""})
+                kickoff_outcome = str(kickoff_spec.get("outcome", "unknown"))
+                kickoff_error = str(kickoff_spec.get("error", "")).strip()
+                kickoff_tail = (
+                    "fork-mode: skipped kickoff agent dispatch; "
+                    f"would invoke kickoff for {pr_url} (mock outcome={kickoff_outcome}"
+                    + (f", error={kickoff_error}" if kickoff_error else "")
+                    + ")"
+                )
+                log(kickoff_tail)
+            else:
+                log(f"action: invoking kickoff workflow agent for PR {pr_url}")
+                kickoff_tail = invoke_kickoff_agent(pr_url, args.model)
+            item["disable_pr"] = {
+                "number": parse_pr_number(pr_url),
+                "url": pr_url,
+                "branch": branch,
+                "head_sha": git_head_sha(),
+            }
+            set_status(item, "kickoff_running", event="pr_created_and_kickoff_started", details=pr_url)
+            result["state_updates"] += 1
+
+            result["executed"].append(
+                {
+                    "source_slack_ts": source_ts,
+                    "issue_number": issue_number,
+                    "branch": branch,
+                    "pr_url": pr_url,
+                    "required_check_runs": required_check_runs,
+                    "disable_edit_summary": edit_summary,
+                    "kickoff_output_tail": kickoff_tail,
+                    "attempts": item["attempts"],
+                }
+            )
+        except Exception as exc:
+            safe_exc = redact_secrets(str(exc))
+            log(f"action: failed issue #{issue_number}: {safe_exc}")
+            set_status(item, "needs_human", event="action_failed", details=safe_exc)
+            result["state_updates"] += 1
+            result["skipped"].append(
+                {"source_slack_ts": source_ts, "issue_number": issue_number, "reason": f"action_failed:{safe_exc}"}
+            )
+
+    out_path = Path(args.output_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    counts: dict[str, int] = {}
+    for item in state.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status", "unknown"))
+        counts[status] = counts.get(status, 0) + 1
+    result["state_status_counts"] = counts
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    save_state(state_path, state)
+    write_summary(Path(args.summary_md), result)
+    log(f"execute_disable_actions: wrote outputs to {out_path} and {args.summary_md}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/generate_disable_actions_prompt.py
+++ b/tools/ci/generate_disable_actions_prompt.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Generate Cursor prompt for structured stale-disable action planning."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Build prompt from template for disable action planning.")
+    parser.add_argument("--template", required=True, help="Prompt template markdown path")
+    parser.add_argument("--candidates-json", required=True, help="Stale candidate JSON path")
+    parser.add_argument("--output", required=True, help="Rendered prompt output path")
+    parser.add_argument("--max-actions", type=int, default=3, help="Hard cap for disable actions")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    template = Path(args.template).read_text(encoding="utf-8")
+    text = template.replace("__CANDIDATES_JSON_PATH__", args.candidates_json)
+    text = text.replace("__MAX_ACTIONS__", str(args.max_actions))
+    out = Path(args.output)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(text, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/load_previous_triage_state.py
+++ b/tools/ci/load_previous_triage_state.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Restore triage state from the latest successful triage workflow artifact."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.guarded import run_guarded_gh
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Restore triage state from prior successful workflow run.")
+    parser.add_argument("--repo", default="tenstorrent/tt-metal")
+    parser.add_argument("--workflow", default="triage-ci.yaml")
+    parser.add_argument("--artifact-name", default="triage-state")
+    parser.add_argument("--state-path", default="build_ci/triage_state/ci_triage_state.json")
+    parser.add_argument("--max-runs", type=int, default=20)
+    return parser.parse_args()
+
+
+def first_state_file(root: Path) -> Path | None:
+    matches = sorted(root.rglob("ci_triage_state.json"))
+    return matches[0] if matches else None
+
+
+def main() -> int:
+    args = parse_args()
+    current_run_id = os.environ.get("GITHUB_RUN_ID", "")
+
+    try:
+        runs = run_guarded_gh(
+            [
+                "gh",
+                "run",
+                "list",
+                "--repo",
+                args.repo,
+                "--workflow",
+                args.workflow,
+                "--status",
+                "completed",
+                "--limit",
+                str(args.max_runs),
+                "--json",
+                "databaseId,conclusion",
+            ]
+        )
+    except RuntimeError:
+        print(json.dumps({"restored": False, "reason": "run_list_failed"}))
+        return 0
+
+    payload = json.loads(runs.stdout or "[]")
+    if not isinstance(payload, list):
+        print(json.dumps({"restored": False, "reason": "invalid_run_list_payload"}))
+        return 0
+    candidate_ids: list[int] = []
+    for run_info in payload:
+        if not isinstance(run_info, dict):
+            continue
+        run_id = run_info.get("databaseId")
+        conclusion = str(run_info.get("conclusion", ""))
+        if not isinstance(run_id, int):
+            continue
+        if conclusion != "success":
+            continue
+        if current_run_id and str(run_id) == current_run_id:
+            continue
+        candidate_ids.append(run_id)
+
+    state_path = Path(args.state_path)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    if state_path.exists():
+        print(json.dumps({"restored": False, "reason": "state_already_present", "path": str(state_path)}))
+        return 0
+
+    for run_id in candidate_ids:
+        with tempfile.TemporaryDirectory(prefix="triage-state-") as tmpdir:
+            download = run_guarded_gh(
+                [
+                    "gh",
+                    "run",
+                    "download",
+                    "--repo",
+                    args.repo,
+                    str(run_id),
+                    "--name",
+                    args.artifact_name,
+                    "--dir",
+                    tmpdir,
+                ],
+                check=False,
+            )
+            if download.returncode != 0:
+                continue
+            state_file = first_state_file(Path(tmpdir))
+            if state_file is None:
+                continue
+            shutil.copy2(state_file, state_path)
+            print(json.dumps({"restored": True, "from_run_id": run_id, "path": str(state_path)}))
+            return 0
+
+    print(json.dumps({"restored": False, "reason": "no_prior_state_found", "path": str(state_path)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/render_m4_summary.py
+++ b/tools/ci/render_m4_summary.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Render M4 issue/slack result JSON as markdown summary."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+
+def render_summary(data: dict[str, Any]) -> str:
+    created = data.get("created", [])
+    skipped = data.get("skipped", [])
+    lines: list[str] = []
+    lines.append("")
+    lines.append("# M4 Issue + Slack Summary")
+    lines.append("")
+    lines.append(f"- Candidates total: {data.get('candidate_count', 0)}")
+    lines.append(f"- Candidates processed: {data.get('processed_count', 0)}")
+    lines.append(f"- Fresh agent calls: {data.get('fresh_agent_calls', 0)}")
+    lines.append(f"- Fresh agent reviews: {data.get('fresh_agent_reviews', 0)}")
+    lines.append(f"- Issues created: {len(created) if isinstance(created, list) else 0}")
+    lines.append(f"- Skipped: {len(skipped) if isinstance(skipped, list) else 0}")
+    if isinstance(created, list) and created:
+        lines.append("")
+        lines.append("## Created")
+        for item in created:
+            if not isinstance(item, dict):
+                continue
+            issue_url = item.get("issue_url", "(missing issue url)")
+            workflow_name = item.get("workflow_name", "")
+            job_name = item.get("job_name", "")
+            lines.append(f"- {issue_url} | {workflow_name} / {job_name}")
+            decision = item.get("agent_decision", {})
+            if isinstance(decision, dict):
+                signature = str(decision.get("signature", "")).strip()
+                reason = str(decision.get("reason", "")).strip()
+                if signature:
+                    if len(signature) > 160:
+                        signature = signature[:160] + "..."
+                    lines.append(f"  - Why issue was created: deterministic signature `{signature}`")
+                elif reason:
+                    if len(reason) > 220:
+                        reason = reason[:220] + "..."
+                    lines.append(f"  - Why issue was created: {reason}")
+            owner_selection = item.get("owner_selection", {})
+            if isinstance(owner_selection, dict):
+                selected = owner_selection.get("selected_owner_count", 0)
+                candidates = owner_selection.get("candidate_owner_count", 0)
+                source_counts = owner_selection.get("source_counts", {})
+                if isinstance(source_counts, dict):
+                    lines.append(
+                        "  - Why people were pinged: "
+                        f"selected {selected} of {candidates} candidates from "
+                        f"codeowners={source_counts.get('codeowners', 0)}, "
+                        f"commit_history={source_counts.get('commit_history', 0)}, "
+                        f"auto_triage={source_counts.get('auto_triage', 0)}, "
+                        f"job_owners={source_counts.get('job_owners', 0)}"
+                    )
+            unresolved = item.get("unresolved_owner_handles", [])
+            if isinstance(unresolved, list) and unresolved:
+                redacted = ", ".join(f"@{h}" for h in unresolved[:8])
+                lines.append(f"  - Unresolved GitHub handles: {redacted}")
+            auto_triage_selection = item.get("auto_triage_selection", {})
+            if isinstance(auto_triage_selection, dict):
+                if auto_triage_selection.get("used") and auto_triage_selection.get("permalinks"):
+                    permalink = str(auto_triage_selection.get("permalinks", [""])[0]).strip()
+                    if permalink:
+                        lines.append(f"  - Auto-triage evidence used: {permalink}")
+                else:
+                    reason = str(auto_triage_selection.get("reason", "")).strip() or "no relevant matches"
+                    lines.append(f"  - Auto-triage evidence not used: {reason}")
+    if isinstance(skipped, list) and skipped:
+        lines.append("")
+        lines.append("## Top skip reasons")
+        counts: dict[str, int] = {}
+        for item in skipped:
+            if isinstance(item, dict):
+                reason = str(item.get("reason", "unknown"))
+            else:
+                reason = "unknown"
+            counts[reason] = counts.get(reason, 0) + 1
+        for reason, count in sorted(counts.items(), key=lambda kv: (-kv[1], kv[0]))[:10]:
+            lines.append(f"- {reason}: {count}")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Render M4 markdown summary from JSON output.")
+    parser.add_argument("--input-json", required=True, help="Path to m4_issue_and_slack_result.json")
+    args = parser.parse_args()
+    path = Path(args.input_json)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise SystemExit("Expected JSON object payload")
+    print(render_summary(payload), end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/select_stale_unresolved_threads.py
+++ b/tools/ci/select_stale_unresolved_threads.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Select stale unresolved Slack top-level messages for auto-disable handling."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any
+
+# Ensure repository root is importable when running as `python tools/ci/<script>.py`.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.slack_thread_agent_analysis import analyze_thread_with_agent
+
+NON_ACTIONABLE_SUBTYPES = {
+    "channel_join",
+    "channel_leave",
+    "channel_topic",
+    "channel_purpose",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Filter Slack export to unresolved stale candidates.")
+    parser.add_argument("--input", required=True, help="Path to enriched Slack JSON")
+    parser.add_argument("--output", required=True, help="Path to candidate JSON")
+    parser.add_argument("--stale-hours", type=float, default=32.0, help="Minimum age in hours")
+    parser.add_argument("--channel-id", default="C0APK6215B5", help="Slack channel ID for permalink generation")
+    parser.add_argument("--max-candidates", type=int, default=20, help="Optional max candidate count")
+    parser.add_argument(
+        "--hold-hours-after-progress",
+        type=float,
+        default=24.0,
+        help="Temporary hold window after high-confidence progress signals",
+    )
+    return parser.parse_args()
+
+
+def permalink(channel_id: str, ts: str) -> str:
+    return f"https://tenstorrent.slack.com/archives/{channel_id}/p{ts.replace('.', '')}"
+
+
+def issue_numbers(msg: dict[str, Any]) -> list[int]:
+    refs = msg.get("referenced_issue_numbers", [])
+    if isinstance(refs, list):
+        return [int(n) for n in refs if isinstance(n, int) or (isinstance(n, str) and n.isdigit())]
+    return []
+
+
+def primary_issue_detail(msg: dict[str, Any]) -> dict[str, Any] | None:
+    refs = msg.get("referenced_issues", [])
+    if not isinstance(refs, list) or not refs:
+        return None
+    first = refs[0]
+    if not isinstance(first, dict):
+        return None
+    return first
+
+
+def message_replies(msg: dict[str, Any]) -> list[dict[str, Any]]:
+    replies = msg.get("thread_replies")
+    if not isinstance(replies, list):
+        replies = msg.get("replies")
+    if not isinstance(replies, list):
+        return []
+    return [row for row in replies if isinstance(row, dict)]
+
+
+def main() -> int:
+    args = parse_args()
+    now = time.time()
+    src = Path(args.input)
+    payload = json.loads(src.read_text(encoding="utf-8"))
+    messages = payload.get("messages", [])
+
+    analysis_model = str(os.environ.get("SLACK_THREAD_ANALYSIS_MODEL", "auto")).strip() or "auto"
+
+    candidates: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    for msg in messages:
+        ts = str(msg.get("ts", "")).strip()
+        if not ts:
+            continue
+        subtype = str(msg.get("subtype", "")).strip()
+        if subtype in NON_ACTIONABLE_SUBTYPES:
+            skipped.append({"ts": ts, "reason": f"non_actionable_subtype:{subtype}"})
+            continue
+        try:
+            ts_float = float(ts)
+        except ValueError:
+            skipped.append({"ts": ts, "reason": "invalid_ts"})
+            continue
+
+        age_hours = (now - ts_float) / 3600.0
+        msg_issue_closed = bool(msg.get("issue_closed", False))
+        refs = issue_numbers(msg)
+        primary = primary_issue_detail(msg)
+        primary_repo = str(primary.get("repo", "")).strip() if primary else ""
+        primary_url = str(primary.get("url", "")).strip() if primary else ""
+
+        if msg_issue_closed:
+            skipped.append({"ts": ts, "reason": "issue_closed_true"})
+            continue
+        if age_hours <= args.stale_hours:
+            skipped.append({"ts": ts, "reason": "not_stale", "age_hours": round(age_hours, 2)})
+            continue
+
+        thread_replies = message_replies(msg)
+        try:
+            analysis = analyze_thread_with_agent(
+                top_level_text=str(msg.get("text", "")),
+                thread_replies=thread_replies,
+                hold_hours_after_progress=args.hold_hours_after_progress,
+                include_owner_claim=False,
+                model=analysis_model,
+            )
+        except Exception as exc:
+            skipped.append({"ts": ts, "reason": f"agent_thread_analysis_failed:{exc}"})
+            continue
+        progress = {
+            "progress_state": analysis.get("progress_state", "no_progress"),
+            "confidence": analysis.get("confidence", "low"),
+            "defer_disable": bool(analysis.get("defer_disable", False)),
+            "reason": analysis.get("progress_reason", "unspecified"),
+        }
+        fix_request = {
+            "requested": bool(analysis.get("fix_request_requested", False)),
+            "reason": analysis.get("fix_request_reason", "unspecified"),
+        }
+        if bool(progress.get("defer_disable", False)):
+            skipped.append(
+                {
+                    "ts": ts,
+                    "reason": "defer_disable_due_to_progress",
+                    "progress_state": progress.get("progress_state"),
+                    "progress_reason": progress.get("reason"),
+                }
+            )
+            continue
+
+        candidates.append(
+            {
+                "source_slack_ts": ts,
+                "source_slack_permalink": permalink(args.channel_id, ts),
+                "age_hours": round(age_hours, 2),
+                "issue_closed": False,
+                "issue_status_lookup_failed": bool(msg.get("issue_status_lookup_failed", False)),
+                "issue_numbers": refs,
+                "primary_issue_number": refs[0] if refs else None,
+                "primary_issue_repo": primary_repo or None,
+                "primary_issue_url": primary_url or None,
+                "top_level_text": str(msg.get("text", "")),
+                "thread_reply_count": len(thread_replies),
+                "progress_signal": progress,
+                "fix_request_signal": fix_request,
+            }
+        )
+
+    # Prioritize actionable candidates with explicit issue linkage first, then oldest.
+    candidates.sort(
+        key=lambda c: (
+            0 if c.get("primary_issue_number") is not None else 1,
+            -float(c["age_hours"]),
+        )
+    )
+    limited = candidates[: args.max_candidates]
+    out_payload = {
+        "generated_at_unix": now,
+        "generated_at_utc": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(now)),
+        "stale_hours_threshold": args.stale_hours,
+        "channel_id": args.channel_id,
+        "input_message_count": len(messages),
+        "candidate_count": len(limited),
+        "candidates": limited,
+        "skipped_count": len(skipped),
+        "skipped": skipped,
+    }
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(out_payload, indent=2), encoding="utf-8")
+    print(json.dumps({"candidate_count": len(limited), "skipped_count": len(skipped)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/slack_thread_agent_analysis.py
+++ b/tools/ci/slack_thread_agent_analysis.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Agent-driven Slack thread analysis helpers for CI triage flows."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.markers import parse_json_after_marker  # noqa: F401 – re-exported
+from tools.ci.common.run_helper import run
+
+FINAL_MARKER = "===FINAL_THREAD_ANALYSIS_JSON==="
+
+
+def analyze_thread_with_agent(
+    *,
+    top_level_text: str,
+    thread_replies: list[dict[str, Any]],
+    bot_user_ids: set[str] | None = None,
+    hold_hours_after_progress: float = 24.0,
+    include_owner_claim: bool = False,
+    model: str = "auto",
+) -> dict[str, Any]:
+    curated_replies: list[dict[str, str]] = []
+    for reply in thread_replies[-20:]:
+        if not isinstance(reply, dict):
+            continue
+        curated_replies.append(
+            {
+                "ts": str(reply.get("ts", "")).strip(),
+                "user": str(reply.get("user", "")).strip(),
+                "text": str(reply.get("text", "")).strip()[:1200],
+            }
+        )
+
+    payload = {
+        "top_level_text": top_level_text[:2000],
+        "thread_replies": curated_replies,
+        "bot_user_ids": sorted(bot_user_ids or set()),
+        "hold_hours_after_progress": float(max(0.0, hold_hours_after_progress)),
+        "include_owner_claim": bool(include_owner_claim),
+    }
+    prompt = (
+        "You are analyzing a CI triage Slack thread.\n"
+        "Token-efficiency rule: do one short pass and output only final JSON contract.\n"
+        "Rules:\n"
+        "- Use only provided text, do not invent context.\n"
+        "- progress_state must be one of: resolved_signal, fix_in_progress, blocked, investigating, no_progress.\n"
+        "- defer_disable=true only when there is a high-confidence active progress signal within hold window.\n"
+        "- fix_request_requested=true only when someone explicitly asks agent/bot to create or draft a fix.\n"
+        "- If include_owner_claim=true, detect explicit self-ownership from non-bot replies; otherwise return false/empty.\n"
+        "At end print marker exactly on its own line:\n"
+        f"{FINAL_MARKER}\n"
+        "Then print only JSON object:\n"
+        "{\n"
+        '  "progress_state": "resolved_signal|fix_in_progress|blocked|investigating|no_progress",\n'
+        '  "confidence": "high|medium|low",\n'
+        '  "defer_disable": true,\n'
+        '  "progress_reason": "short reason",\n'
+        '  "fix_request_requested": false,\n'
+        '  "fix_request_reason": "short reason",\n'
+        '  "owner_claimed": false,\n'
+        '  "owner_slack_user_id": "",\n'
+        '  "owner_claim_reason": "short reason"\n'
+        "}\n\n"
+        f"Input JSON:\n{json.dumps(payload, ensure_ascii=True)}\n"
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model and model != "auto":
+        cmd.extend(["--model", model])
+    proc = run(cmd)
+    parsed = parse_json_after_marker(proc.stdout or "", FINAL_MARKER)
+    return {
+        "progress_state": str(parsed.get("progress_state", "no_progress")).strip() or "no_progress",
+        "confidence": str(parsed.get("confidence", "low")).strip() or "low",
+        "defer_disable": bool(parsed.get("defer_disable", False)),
+        "progress_reason": str(parsed.get("progress_reason", "unspecified")).strip() or "unspecified",
+        "fix_request_requested": bool(parsed.get("fix_request_requested", False)),
+        "fix_request_reason": str(parsed.get("fix_request_reason", "unspecified")).strip() or "unspecified",
+        "owner_claimed": bool(parsed.get("owner_claimed", False)),
+        "owner_slack_user_id": str(parsed.get("owner_slack_user_id", "")).strip(),
+        "owner_claim_reason": str(parsed.get("owner_claim_reason", "unspecified")).strip() or "unspecified",
+    }

--- a/tools/tests/ci/test_execute_disable_actions_resume.py
+++ b/tools/tests/ci/test_execute_disable_actions_resume.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import pytest
+
+from tools.ci.execute_disable_actions import (
+    evaluate_resume_failure_confirmation,
+    has_issue_reference_in_working_diff,
+)
+
+
+def test_evaluate_resume_failure_confirmation_requires_two_matching_failures() -> None:
+    item: dict[str, object] = {}
+    failure_signal = {
+        "workflow": "all-static-checks.yaml",
+        "target": "tests/foo.py::test_bar",
+        "error": "assertion failed",
+        "details": {"new_failure_target": "tests/foo.py::test_bar"},
+    }
+    first = evaluate_resume_failure_confirmation(item=item, failure_signal=failure_signal)
+    assert first["decision"] == "wait"
+    second = evaluate_resume_failure_confirmation(item=item, failure_signal=failure_signal)
+    assert second["decision"] == "proceed"
+
+
+def test_evaluate_resume_failure_confirmation_escalates_on_signature_mismatch() -> None:
+    item: dict[str, object] = {}
+    sig1 = {"workflow": "wf", "target": "a", "error": "e1", "details": {}}
+    sig2 = {"workflow": "wf", "target": "b", "error": "e2", "details": {}}
+    first = evaluate_resume_failure_confirmation(item=item, failure_signal=sig1)
+    assert first["decision"] == "wait"
+    second = evaluate_resume_failure_confirmation(item=item, failure_signal=sig2)
+    assert second["decision"] == "escalate"
+
+
+def test_has_issue_reference_in_working_diff_detects_added_reference(monkeypatch: pytest.MonkeyPatch) -> None:
+    import tools.ci.execute_disable_actions as mod
+
+    class _Proc:
+        stdout = "diff --git a/file b/file\n" "@@ -1 +1 @@\n" "+# TODO(#123): temporarily disable flaky test\n"
+
+    monkeypatch.setattr(mod, "run", lambda *_args, **_kwargs: _Proc())
+    assert has_issue_reference_in_working_diff(issue_number=123, issue_url="https://github.com/x/y/issues/123")

--- a/tools/tests/ci/test_slice_04_draft_pr.py
+++ b/tools/tests/ci/test_slice_04_draft_pr.py
@@ -1,0 +1,92 @@
+"""Contract tests for Slice 4: stale thread selection and disable-action execution.
+
+Validates that select_stale_unresolved_threads filters correctly and
+execute_disable_actions state management contracts hold.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.ci.execute_disable_actions import (
+    ALLOWED_STATUS,
+    ensure_state_item,
+    load_state,
+    save_state,
+    set_status,
+    state_index,
+    state_key_for_ts,
+)
+from tools.ci.select_stale_unresolved_threads import (
+    issue_numbers,
+    message_replies,
+    permalink,
+    primary_issue_detail,
+)
+
+
+def test_state_round_trip(tmp_path):
+    """State can be saved and reloaded with schema=disable validation."""
+    path = tmp_path / "state.json"
+    from tools.ci.common.state import empty_state
+
+    state = empty_state()
+    state["items"].append({"key": "slack_ts:1.0", "status": "new", "attempts": 0})
+    save_state(path, state)
+    loaded = load_state(path)
+    assert len(loaded["items"]) == 1
+    assert loaded["items"][0]["key"] == "slack_ts:1.0"
+
+
+def test_ensure_state_item_creates_new_entry():
+    from tools.ci.common.state import empty_state
+
+    state = empty_state()
+    action = {"source_slack_ts": "123.456", "issue_number": 42}
+    item = ensure_state_item(state, action)
+    assert item["key"] == state_key_for_ts("123.456")
+    assert item["status"] == "new"
+    assert 42 in item["issue_numbers"]
+
+
+def test_ensure_state_item_returns_existing():
+    from tools.ci.common.state import empty_state
+
+    state = empty_state()
+    action = {"source_slack_ts": "1.0", "issue_number": 1}
+    first = ensure_state_item(state, action)
+    second = ensure_state_item(state, action)
+    assert first is second
+    assert len(state["items"]) == 1
+
+
+def test_set_status_transitions():
+    item = {"status": "new", "history": []}
+    set_status(item, "planned", event="test", details="reason")
+    assert item["status"] == "planned"
+    assert len(item["history"]) == 1
+
+
+def test_permalink_format():
+    assert permalink("C123", "1234567890.123456") == (
+        "https://tenstorrent.slack.com/archives/C123/p1234567890123456"
+    )
+
+
+def test_issue_numbers_extracts_ints():
+    msg = {"referenced_issue_numbers": [42, "99"]}
+    assert issue_numbers(msg) == [42, 99]
+
+
+def test_primary_issue_detail_returns_first():
+    msg = {"referenced_issues": [{"repo": "org/repo", "number": 1}]}
+    detail = primary_issue_detail(msg)
+    assert detail is not None
+    assert detail["number"] == 1
+
+
+def test_message_replies_handles_both_keys():
+    assert message_replies({"thread_replies": [{"ts": "1"}]}) == [{"ts": "1"}]
+    assert message_replies({"replies": [{"ts": "2"}]}) == [{"ts": "2"}]
+    assert message_replies({}) == []


### PR DESCRIPTION
## Summary

- Add `execute_disable_actions.py` -- the core agent-driven pipeline for creating draft PRs that disable stale failing tests
- Add `select_stale_unresolved_threads.py` for filtering threads by staleness criteria
- Add `generate_disable_actions_prompt.py` for creating agent prompts
- Add `.github/actions/auto-disable-stale-ci/` composite action with prompt template
- 11 tests covering state management, resume evaluation, permalink formatting, and issue detection

## Context

This is **Slice 4 / Tier 3** of the CI triage autonomy port. Stacked on Slice 2 (Slack ingestion) and includes Slice 1 (state + agent analysis) content via merge.

## Dependencies

- Slice 0 (foundation), Slice 1 (state + agent analysis), Slice 2 (Slack ingestion)

## Test plan

- [x] All 11 slice tests pass locally
- [x] All prior slice tests still pass
- [ ] Review agent-driven disable pipeline logic


Made with [Cursor](https://cursor.com)