### PR TITLE
Slice 5: M4 issue creation pipeline and failing job extraction

### DIFF
--- a/tools/ci/extract_failing_jobs.py
+++ b/tools/ci/extract_failing_jobs.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+Extract jobs that failed in the last N consecutive workflow runs.
+
+The script downloads workflow-data from the latest aggregate-workflow-data run,
+filters to workflows with N consecutive failures, then fetches run jobs from
+the GitHub API to find which specific jobs failed in all N runs.
+
+Workflows whose display name contains any keyword in
+``SKIP_WORKFLOW_NAME_KEYWORDS`` (case-insensitive substring match) are skipped:
+no per-run job downloads for those entries. The aggregate artifact is still
+downloaded as a single file upstream.
+
+Usage:
+  python tools/ci/extract_failing_jobs.py
+  python tools/ci/extract_failing_jobs.py t3000-unit-tests
+
+Optional env vars:
+  CONSECUTIVE_FAILURES   Number of consecutive failures required (default: 3)
+  GITHUB_OWNER           Default: tenstorrent
+  GITHUB_REPO            Default: tt-metal
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from http.client import IncompleteRead
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+OWNER = os.environ.get("GITHUB_OWNER", "tenstorrent")
+REPO = os.environ.get("GITHUB_REPO", "tt-metal")
+WORKFLOW_FILE = "aggregate-workflow-data.yaml"
+ARTIFACT_NAME = "workflow-data"
+CONSECUTIVE_FAILURES = int(os.environ.get("CONSECUTIVE_FAILURES", "3"))
+
+# Substrings; if any appear in the workflow display name (case-insensitive), skip job fetches.
+SKIP_WORKFLOW_NAME_KEYWORDS: tuple[str, ...] = ("sanity",)
+
+
+def resolve_token() -> str | None:
+    if os.environ.get("GITHUB_TOKEN"):
+        return os.environ["GITHUB_TOKEN"]
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return None
+
+
+def download_workflow_data() -> tuple[list, int]:
+    print("Finding latest aggregate-workflow-data run...", file=sys.stderr)
+    result = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            f"--workflow={WORKFLOW_FILE}",
+            f"--repo={OWNER}/{REPO}",
+            "--status=completed",
+            "--limit=1",
+            "--json=databaseId,conclusion",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to list workflow runs: {result.stderr}")
+
+    runs = json.loads(result.stdout)
+    if not runs:
+        raise RuntimeError("No completed runs found for aggregate-workflow-data")
+
+    run_id = runs[0]["databaseId"]
+    conclusion = runs[0]["conclusion"]
+    print(f"  Latest run: {run_id} (conclusion: {conclusion})", file=sys.stderr)
+    if conclusion != "success":
+        print(
+            f"  Warning: latest run did not succeed ({conclusion}); data may be stale.",
+            file=sys.stderr,
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print(f"  Downloading '{ARTIFACT_NAME}' artifact...", file=sys.stderr)
+        result = subprocess.run(
+            [
+                "gh",
+                "run",
+                "download",
+                str(run_id),
+                f"--repo={OWNER}/{REPO}",
+                "-n",
+                ARTIFACT_NAME,
+                "-D",
+                tmpdir,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to download artifact: {result.stderr}")
+
+        json_file = Path(tmpdir) / "workflow-data.json"
+        if not json_file.exists():
+            json_files = list(Path(tmpdir).rglob("*.json"))
+            if not json_files:
+                raise RuntimeError("No JSON files found in downloaded artifact")
+            json_file = json_files[0]
+
+        print(
+            f"  Loaded workflow data ({json_file.stat().st_size / 1_000_000:.1f} MB)",
+            file=sys.stderr,
+        )
+        with open(json_file, encoding="utf-8") as f:
+            return json.load(f), int(run_id)
+
+
+def load_cache(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            parsed = json.load(f)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def gh_api_request(url: str, token: str | None, max_retries: int = 5) -> dict:
+    for attempt in range(max_retries):
+        req = Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except IncompleteRead:
+            if attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise
+        except HTTPError as err:
+            if err.code == 404:
+                return {"jobs": []}
+            if err.code in (502, 503, 504) and attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise
+        except URLError as err:
+            if attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise RuntimeError(f"Request failed: {err}") from err
+
+    raise RuntimeError(f"Exhausted retries for {url}")
+
+
+def fetch_jobs_for_run(run_id: int, token: str | None) -> list[dict]:
+    jobs: list[dict] = []
+    page = 1
+    per_page = 100
+
+    while True:
+        url = (
+            f"https://api.github.com/repos/{OWNER}/{REPO}"
+            f"/actions/runs/{run_id}/jobs?per_page={per_page}&page={page}"
+        )
+        data = gh_api_request(url, token)
+        batch = data.get("jobs", [])
+        jobs.extend(batch)
+
+        if len(batch) < per_page:
+            break
+        page += 1
+        time.sleep(0.5)
+
+    return jobs
+
+
+def extract_failing_jobs(
+    workflow_data: list,
+    token: str | None,
+    aggregate_run_id: int,
+    workflow_filter: str | None = None,
+    output_path: Path | None = None,
+    previous_cache: dict | None = None,
+    cache_output_path: Path | None = None,
+) -> dict:
+    results = []
+    api_calls = 0
+    cached_reused_workflows = 0
+    previous_cache = previous_cache or {}
+    previous_workflows = previous_cache.get("workflows", {})
+    if not isinstance(previous_workflows, dict):
+        previous_workflows = {}
+
+    def write_incremental() -> None:
+        if output_path is None:
+            return
+        payload = {
+            "description": ("Jobs that failed in all of the last " f"{CONSECUTIVE_FAILURES} workflow runs"),
+            "total_jobs_affected": len(results),
+            "jobs": results,
+        }
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        print(f"    Wrote {len(results)} jobs to {output_path}", file=sys.stderr)
+
+    def write_cache() -> None:
+        if cache_output_path is None:
+            return
+        cache_output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "aggregate_run_id": aggregate_run_id,
+            "consecutive_failures": CONSECUTIVE_FAILURES,
+            "workflows": workflow_cache,
+        }
+        with open(cache_output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    write_incremental()
+    workflow_cache: dict[str, dict] = {}
+
+    for workflow_name, runs in workflow_data:
+        if not runs:
+            continue
+
+        name_lower = str(workflow_name).lower()
+        skip_kw = next((kw for kw in SKIP_WORKFLOW_NAME_KEYWORDS if kw.lower() in name_lower), None)
+        if skip_kw is not None:
+            print(
+                f'  Skipping workflow "{workflow_name}" (name contains keyword {skip_kw!r}).',
+                file=sys.stderr,
+            )
+            continue
+
+        if workflow_filter:
+            yaml_path = runs[0].get("path", "")
+            yaml_name = yaml_path.rsplit("/", 1)[-1].removesuffix(".yaml").removesuffix(".yml")
+            if yaml_name != workflow_filter:
+                continue
+
+        sorted_runs = sorted(
+            runs,
+            key=lambda run: run.get("created_at", "") or run.get("run_started_at", ""),
+            reverse=True,
+        )
+        last_n = sorted_runs[:CONSECUTIVE_FAILURES]
+
+        if len(last_n) < CONSECUTIVE_FAILURES:
+            continue
+        if not all(run.get("conclusion") == "failure" for run in last_n):
+            continue
+
+        run_id_to_failed_jobs: dict[int, dict[str, str]] = {}
+        run_ids_for_cache = [int(r.get("id")) for r in last_n if r.get("id")]
+        if len(run_ids_for_cache) < CONSECUTIVE_FAILURES:
+            continue
+        yaml_path = runs[0].get("path", "")
+        workflow_key = f"{yaml_path}|{workflow_name}"
+        previous_entry = previous_workflows.get(workflow_key)
+        if isinstance(previous_entry, dict):
+            prev_run_ids = previous_entry.get("run_ids", [])
+            prev_jobs = previous_entry.get("jobs", [])
+            if (
+                isinstance(prev_run_ids, list)
+                and isinstance(prev_jobs, list)
+                and [int(x) for x in prev_run_ids] == run_ids_for_cache
+            ):
+                for item in prev_jobs:
+                    if isinstance(item, dict):
+                        results.append(item)
+                workflow_cache[workflow_key] = {
+                    "workflow_name": workflow_name,
+                    "yaml_path": yaml_path,
+                    "run_ids": run_ids_for_cache,
+                    "jobs": [item for item in prev_jobs if isinstance(item, dict)],
+                    "reused": True,
+                }
+                cached_reused_workflows += 1
+                print(
+                    f'  Reusing cached failing jobs for "{workflow_name}" (run ids unchanged).',
+                    file=sys.stderr,
+                )
+                write_incremental()
+                write_cache()
+                continue
+
+        print(
+            f'  Fetching jobs for "{workflow_name}" ({CONSECUTIVE_FAILURES} runs)...',
+            file=sys.stderr,
+        )
+        for run in last_n:
+            run_id = run.get("id")
+            if not run_id:
+                continue
+
+            jobs = fetch_jobs_for_run(run_id, token)
+            api_calls += 1
+            failed = {
+                job["name"]: job.get("html_url") or job.get("url", "")
+                for job in jobs
+                if job.get("conclusion") == "failure"
+            }
+            run_id_to_failed_jobs[run_id] = failed
+            time.sleep(0.3)
+
+        if len(run_id_to_failed_jobs) < CONSECUTIVE_FAILURES:
+            continue
+
+        run_ids = list(run_id_to_failed_jobs.keys())
+        jobs_failed_in_all = set(run_id_to_failed_jobs[run_ids[0]].keys())
+        for run_id in run_ids[1:]:
+            jobs_failed_in_all &= set(run_id_to_failed_jobs[run_id].keys())
+
+        workflow_jobs: list[dict] = []
+        for job_name in jobs_failed_in_all:
+            urls = [
+                run_id_to_failed_jobs[run_id][job_name]
+                for run in last_n
+                if (run_id := run.get("id")) in run_id_to_failed_jobs and job_name in run_id_to_failed_jobs[run_id]
+            ]
+            item = {
+                "job_name": job_name,
+                "workflow_name": workflow_name,
+                "consecutive_failures": CONSECUTIVE_FAILURES,
+                "failing_job_urls": urls,
+                "workflow_run_urls": [run.get("html_url") or run.get("url", "") for run in last_n],
+            }
+            results.append(item)
+            workflow_jobs.append(item)
+        workflow_cache[workflow_key] = {
+            "workflow_name": workflow_name,
+            "yaml_path": yaml_path,
+            "run_ids": run_ids_for_cache,
+            "jobs": workflow_jobs,
+            "reused": False,
+        }
+
+        write_incremental()
+        write_cache()
+
+    print(
+        (
+            f"Done. {api_calls} API calls made, {len(results)} consistently-failing jobs found, "
+            f"{cached_reused_workflows} workflows reused from cache."
+        ),
+        file=sys.stderr,
+    )
+    payload = {
+        "description": (f"Jobs that failed in all of the last {CONSECUTIVE_FAILURES} workflow runs"),
+        "total_jobs_affected": len(results),
+        "jobs": results,
+        "aggregate_run_id": aggregate_run_id,
+        "cached_reused_workflows": cached_reused_workflows,
+    }
+    write_cache()
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract jobs failing in last N runs.")
+    parser.add_argument("workflow_filter_positional", nargs="?", default=None)
+    parser.add_argument("--workflow-filter", default=None)
+    parser.add_argument(
+        "--output-json",
+        default=None,
+        help="Output path for failing jobs JSON (defaults to build_ci/ci_ticketing/create_tickets/failing_jobs.json)",
+    )
+    parser.add_argument(
+        "--cache-input",
+        default=None,
+        help="Optional previous cache JSON path or directory containing failing_jobs_cache.json",
+    )
+    parser.add_argument(
+        "--cache-output",
+        default=None,
+        help="Cache output path (defaults to build_ci/ci_ticketing/create_tickets/failing_jobs_cache.json)",
+    )
+    args = parser.parse_args()
+    workflow_filter = args.workflow_filter or args.workflow_filter_positional
+    project_root = Path(__file__).resolve().parents[2]
+    output_dir = project_root / "build_ci" / "ci_ticketing" / "create_tickets"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = Path(args.output_json) if args.output_json else (output_dir / "failing_jobs.json")
+    cache_output_path = Path(args.cache_output) if args.cache_output else (output_dir / "failing_jobs_cache.json")
+    cache_input_path: Path | None = None
+    if args.cache_input:
+        candidate = Path(args.cache_input)
+        if candidate.is_dir():
+            found = next(iter(candidate.rglob("failing_jobs_cache.json")), None)
+            if found:
+                cache_input_path = found
+        elif candidate.exists():
+            cache_input_path = candidate
+
+    token = resolve_token()
+    if not token:
+        print(
+            "Error: No GitHub token found.\n" "  Run `gh auth login` or set GITHUB_TOKEN.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Authenticated with GitHub.", file=sys.stderr)
+    if workflow_filter:
+        print(f"Filtering to workflow: {workflow_filter}", file=sys.stderr)
+
+    previous_cache = load_cache(cache_input_path) if cache_input_path else {}
+    workflow_data, aggregate_run_id = download_workflow_data()
+    result = extract_failing_jobs(
+        workflow_data,
+        token,
+        aggregate_run_id,
+        workflow_filter,
+        output_path=output_path,
+        previous_cache=previous_cache,
+        cache_output_path=cache_output_path,
+    )
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"Wrote {output_path}", file=sys.stderr)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/m4_create_issues_and_notify.py
+++ b/tools/ci/m4_create_issues_and_notify.py
@@ -1,0 +1,1243 @@
+#!/usr/bin/env python3
+"""M4: Create issues from deterministic aggregate failures and notify Slack."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.codeowners import codeowners_match, parse_codeowners  # noqa: F401 – re-exported
+from tools.ci.common.github import github_user_info  # noqa: F401 – re-exported
+from tools.ci.common.guarded import run_guarded_gh  # noqa: F401 – re-exported
+from tools.ci.common.markers import parse_agent_json_payload, strip_json_fence  # noqa: F401
+from tools.ci.common.run_helper import run  # noqa: F401 – re-exported
+from tools.ci.common.slack import post_slack_message, slack_api_form  # noqa: F401 – re-exported
+
+PRIMARY_REPO = "tenstorrent/tt-metal"
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+SLACK_CHANNEL_TEST = "C0APK6215B5"
+MARKER = "===FINAL_M4_REVIEW_DECISION==="
+PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])((?:tt_metal|ttnn|models|tests|\\.github)/[A-Za-z0-9_./-]+)")
+MAX_OWNER_MENTIONS = 3
+JOB_OWNERS_PATH = Path(".github/actions/analyze-workflow-data/owners.json")
+
+
+def log(message: str) -> None:
+    print(f"[m4] {message}", flush=True)
+
+
+def parse_job_url(url: str) -> tuple[int, int]:
+    m = re.search(r"/actions/runs/(\d+)/job/(\d+)", url)
+    if not m:
+        raise ValueError(f"unsupported job URL format: {url}")
+    return int(m.group(1)), int(m.group(2))
+
+
+def load_candidates(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    jobs = payload.get("jobs", [])
+    if not isinstance(jobs, list):
+        return []
+    return [job for job in jobs if isinstance(job, dict)]
+
+
+def load_optional_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def write_job_log_file(*, job_url: str, read_token: str, out_path: Path) -> Path:
+    run_id, job_id = parse_job_url(job_url)
+    proc = run_guarded_gh(
+        ["gh", "run", "view", str(run_id), "--repo", PRIMARY_REPO, "--job", str(job_id), "--log-failed"],
+        github_token=read_token,
+    )
+    text = (proc.stdout or "").strip()
+    if not text:
+        proc = run_guarded_gh(
+            ["gh", "run", "view", str(run_id), "--repo", PRIMARY_REPO, "--job", str(job_id), "--log"],
+            github_token=read_token,
+        )
+        text = (proc.stdout or "").strip()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    return out_path
+
+
+def parse_agent_json(text: str) -> dict[str, Any]:
+    parsed = _parse_agent_json_payload(text, marker=MARKER)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected JSON object for single decision payload, got {type(parsed).__name__}")
+    return parsed
+
+
+_parse_agent_json_payload = parse_agent_json_payload
+_strip_json_fence = strip_json_fence
+
+
+def load_command_spec(path: str, fallback: str) -> str:
+    p = Path(path)
+    if not p.exists():
+        return fallback
+    return p.read_text(encoding="utf-8")
+
+
+def fetch_recent_slack_messages(*, slack_token: str, channel_id: str, limit: int = 20) -> list[dict[str, Any]]:
+    from tools.ci.common.slack import slack_api_get_simple
+
+    payload = slack_api_get_simple(slack_token, "conversations.history", {"channel": channel_id, "limit": str(limit)})
+    if not payload.get("ok", False):
+        raise RuntimeError(f"Slack history fetch failed: {payload.get('error', 'unknown_error')}")
+    messages = payload.get("messages", [])
+    return messages if isinstance(messages, list) else []
+
+
+def build_open_issue_context(open_issues: list[dict[str, Any]], cap: int = 20) -> str:
+    lines: list[str] = []
+    for issue in open_issues[:cap]:
+        number = issue.get("number")
+        title = str(issue.get("title", "")).strip()
+        url = str(issue.get("url", "")).strip()
+        body = str(issue.get("body", "")).strip()
+        marker_match = re.search(r"Auto-triage-fingerprint:\s*([A-Za-z0-9_-]+)", body)
+        fp = marker_match.group(1) if marker_match else ""
+        lines.append(f"- #{number} {title} ({url}) fingerprint={fp}")
+    return "\n".join(lines) if lines else "(none)"
+
+
+def build_recent_slack_context(messages: list[dict[str, Any]], cap: int = 10) -> str:
+    lines: list[str] = []
+    for msg in messages[:cap]:
+        ts = str(msg.get("ts", "")).strip()
+        user = str(msg.get("user", "") or msg.get("bot_id", "")).strip()
+        text = str(msg.get("text", "")).strip().replace("\n", " ")
+        if len(text) > 220:
+            text = text[:220] + "..."
+        lines.append(f"- ts={ts} user={user} text={text}")
+    return "\n".join(lines) if lines else "(none)"
+
+
+def owners_for_paths(paths: list[str], rules: list[tuple[str, list[str]]]) -> set[str]:
+    owners: set[str] = set()
+    for path in paths:
+        matched: list[str] = []
+        for pattern, rule_owners in rules:
+            if codeowners_match(path, pattern):
+                matched = rule_owners
+        owners.update(matched)
+    return owners
+
+
+def _tokenize_owner_hint(value: str) -> list[str]:
+    tokens = re.split(r"[^a-z0-9]+", value.lower())
+    return [t for t in tokens if len(t) >= 3]
+
+
+def owners_from_workflow_name(
+    workflow_name: str, *, rules: list[tuple[str, list[str]]], workflow_root: Path
+) -> set[str]:
+    if not workflow_name.strip():
+        return set()
+    hint_tokens = set(_tokenize_owner_hint(workflow_name))
+    if not hint_tokens:
+        return set()
+    matched_paths: list[str] = []
+    for ext in ("*.yaml", "*.yml"):
+        for wf in workflow_root.glob(ext):
+            rel = wf.as_posix()
+            canonical_rel = f".github/workflows/{wf.name}"
+            file_tokens = set(_tokenize_owner_hint(wf.stem))
+            overlap = len(hint_tokens.intersection(file_tokens))
+            # Require at least 2 shared tokens (or 1 when workflow name itself
+            # has only one meaningful token), to avoid broad false matches.
+            required = 1 if len(hint_tokens) == 1 else 2
+            if overlap >= required:
+                matched_paths.append(rel)
+                matched_paths.append(canonical_rel)
+    if not matched_paths:
+        return set()
+    owners: set[str] = set()
+    for rel_path in matched_paths:
+        owners.update(owners_for_paths([rel_path], rules))
+    return owners
+
+
+def normalize_owner_component(value: str) -> str:
+    lowered = value.strip().lower()
+    lowered = lowered.replace("_", " ").replace("-", " ")
+    lowered = re.sub(r"[^a-z0-9/ ]+", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered).strip()
+    return lowered
+
+
+def load_job_owner_records(path: Path = JOB_OWNERS_PATH) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    contains = payload.get("contains", []) if isinstance(payload, dict) else []
+    return [x for x in contains if isinstance(x, dict)] if isinstance(contains, list) else []
+
+
+def owner_ids_from_owner_field(value: Any) -> set[str]:
+    out: set[str] = set()
+    if isinstance(value, dict):
+        uid = str(value.get("id", "")).strip()
+        if uid:
+            out.add(uid)
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                uid = str(item.get("id", "")).strip()
+                if uid:
+                    out.add(uid)
+    return out
+
+
+def job_owner_ids_for_failure(
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_owner_records: list[dict[str, Any]],
+) -> set[str]:
+    if not job_owner_records:
+        return set()
+    candidates = {
+        normalize_owner_component(job_name),
+        normalize_owner_component(workflow_name),
+        normalize_owner_component(f"{workflow_name} / {job_name}"),
+    }
+    candidates = {c for c in candidates if c}
+    if not candidates:
+        return set()
+    matched: set[str] = set()
+    for rec in job_owner_records:
+        component = normalize_owner_component(str(rec.get("job-name-component", "")).strip())
+        if not component:
+            continue
+        is_match = component in candidates or any(component in c or c in component for c in candidates if len(c) >= 8)
+        if not is_match:
+            continue
+        matched.update(owner_ids_from_owner_field(rec.get("owner")))
+    return matched
+
+
+def parse_auto_triage_decision(decision: dict[str, Any]) -> dict[str, Any]:
+    used = bool(decision.get("auto_triage_used", False))
+    reason = str(decision.get("auto_triage_reason", "")).strip()
+    links_raw = decision.get("auto_triage_permalinks", [])
+    links: list[str] = []
+    if isinstance(links_raw, list):
+        for item in links_raw:
+            link = str(item).strip()
+            if link.startswith("https://tenstorrent.slack.com/archives/"):
+                links.append(link)
+    links = list(dict.fromkeys(links))[:3]
+    if used and links:
+        return {
+            "used": True,
+            "reason": reason or "agent selected relevant HIGH CONFIDENCE auto-triage context",
+            "selected_count": len(links),
+            "high_confidence_count": len(links),
+            "permalinks": links,
+        }
+    return {
+        "used": False,
+        "reason": reason or "agent did not find relevant HIGH CONFIDENCE auto-triage evidence",
+        "selected_count": len(links),
+        "high_confidence_count": 0,
+        "permalinks": links,
+    }
+
+
+def extract_repo_paths(text: str) -> list[str]:
+    out: list[str] = []
+    for m in PATH_PATTERN.finditer(text):
+        value = m.group(1).strip()
+        if value and value not in out:
+            out.append(value)
+    return out
+
+
+def slack_lookup_by_email(token: str, email: str) -> str | None:
+    try:
+        payload = slack_api_form(token, "users.lookupByEmail", {"email": email})
+    except Exception:
+        return None
+    if not payload.get("ok"):
+        return None
+    user = payload.get("user", {})
+    user_id = str(user.get("id", "")).strip()
+    return user_id or None
+
+
+def slack_list_members(token: str) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    cursor = ""
+    while True:
+        params = {"limit": "200"}
+        if cursor:
+            params["cursor"] = cursor
+        payload = slack_api_form(token, "users.list", params)
+        if not payload.get("ok"):
+            break
+        batch = payload.get("members", [])
+        if isinstance(batch, list):
+            members.extend([m for m in batch if isinstance(m, dict)])
+        cursor = str(payload.get("response_metadata", {}).get("next_cursor", "")).strip()
+        if not cursor:
+            break
+    return members
+
+
+def slack_lookup_by_username(token: str, username: str, members_cache: list[dict[str, Any]] | None) -> str | None:
+    if members_cache is None:
+        return None
+    target = username.strip().lower()
+    if not target:
+        return None
+    targets = {target}
+    if target.endswith("tt") and len(target) > 2:
+        targets.add(target[:-2])
+    for member in members_cache:
+        if member.get("deleted") or member.get("is_bot"):
+            continue
+        profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+        candidates = [
+            str(member.get("name", "")),
+            str(profile.get("display_name", "")),
+            str(profile.get("real_name", "")),
+        ]
+        if any(c.strip().lower() in targets for c in candidates if c.strip()):
+            uid = str(member.get("id", "")).strip()
+            if uid:
+                return uid
+    return None
+
+
+def slack_lookup_by_full_name(full_name: str, members_cache: list[dict[str, Any]] | None) -> str | None:
+    if members_cache is None:
+        return None
+    name = full_name.strip()
+    if not name:
+        return None
+    name_l = name.lower()
+    candidate_rows: list[tuple[str, str, str, str]] = []
+    for member in members_cache:
+        if member.get("deleted") or member.get("is_bot"):
+            continue
+        uid = str(member.get("id", "")).strip()
+        if not uid:
+            continue
+        profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+        row = (
+            uid,
+            str(member.get("name", "")).strip(),
+            str(profile.get("display_name", "")).strip(),
+            str(profile.get("real_name", "")).strip(),
+        )
+        candidate_rows.append(row)
+
+    # Exact match by full name first.
+    for uid, name_field, display_name, real_name in candidate_rows:
+        values = [name_field, display_name, real_name]
+        if any(v and v.lower() == name_l for v in values):
+            return uid
+
+    # Fuzzy fallback from working GH->Slack mapping pattern:
+    # if a >=3-char name token uniquely matches one Slack member, use it.
+    words = [w.lower() for w in re.split(r"\s+", name) if len(w) >= 3]
+    seen_words: set[str] = set()
+    for word in words:
+        if word in seen_words:
+            continue
+        seen_words.add(word)
+        matches: set[str] = set()
+        for uid, name_field, display_name, real_name in candidate_rows:
+            values_l = [name_field.lower(), display_name.lower(), real_name.lower()]
+            if any(word in v for v in values_l if v):
+                matches.add(uid)
+        if len(matches) == 1:
+            return next(iter(matches))
+    return None
+
+
+def recent_author_emails_for_paths(paths: list[str], *, limit_per_path: int = 5) -> set[str]:
+    emails: set[str] = set()
+    for path in paths:
+        try:
+            proc = run(
+                ["git", "log", f"-n{limit_per_path}", "--format=%ae", "--", path],
+                check=False,
+                capture=True,
+            )
+        except Exception:
+            continue
+        for line in (proc.stdout or "").splitlines():
+            email = line.strip()
+            if email and "@" in email:
+                emails.add(email)
+    return emails
+
+
+def render_owner_mentions(
+    *,
+    issue_token: str,
+    slack_token: str,
+    workflow_name: str,
+    job_name: str,
+    text_sources: list[str],
+    members_cache: list[dict[str, Any]] | None,
+    auto_triage_user_ids: list[str] | None = None,
+    job_owner_user_ids: list[str] | None = None,
+) -> tuple[str, list[str], dict[str, Any]]:
+    combined = "\n".join(text_sources + [workflow_name, job_name])
+    paths = extract_repo_paths(combined)
+    codeowners = parse_codeowners(Path(".github/CODEOWNERS"))
+    gh_usernames = owners_for_paths(paths, codeowners)
+    codeowners_weight = 2
+    if not gh_usernames:
+        gh_usernames = owners_from_workflow_name(
+            workflow_name,
+            rules=codeowners,
+            workflow_root=Path(".github/workflows"),
+        )
+        codeowners_weight = 1
+    score_by_uid: dict[str, int] = {}
+    unresolved_handles: list[str] = []
+    source_counts = {"codeowners": 0, "commit_history": 0, "auto_triage": 0, "job_owners": 0}
+
+    for username in sorted(gh_usernames):
+        # CODEOWNERS teams (org/team) are not direct users and cannot map
+        # to a single Slack user id.
+        if "/" in username:
+            unresolved_handles.append(username)
+            continue
+        info = github_user_info(issue_token, username)
+        email = str(info.get("email", "")).strip()
+        gh_name = str(info.get("name", "")).strip()
+        gh_login = str(info.get("login", username)).strip()
+        user_id = slack_lookup_by_email(slack_token, email) if email else None
+        if not user_id:
+            user_id = slack_lookup_by_username(slack_token, gh_login, members_cache)
+        if not user_id and gh_name:
+            user_id = slack_lookup_by_full_name(gh_name, members_cache)
+        if user_id:
+            score_by_uid[user_id] = score_by_uid.get(user_id, 0) + codeowners_weight
+            source_counts["codeowners"] += 1
+        else:
+            unresolved_handles.append(username)
+
+    # Supplement with recent path authors when CODEOWNERS is sparse.
+    for email in sorted(recent_author_emails_for_paths(paths)):
+        user_id = slack_lookup_by_email(slack_token, email)
+        if user_id:
+            # Recent commit authors are usually stronger relevance signals.
+            score_by_uid[user_id] = score_by_uid.get(user_id, 0) + 3
+            source_counts["commit_history"] += 1
+
+    for uid in auto_triage_user_ids or []:
+        if uid:
+            score_by_uid[uid] = score_by_uid.get(uid, 0) + 1
+            source_counts["auto_triage"] += 1
+
+    pipeline_reorg_related = any("pipeline_reorg/" in p for p in paths)
+    job_owner_weight = 4 if pipeline_reorg_related else 2
+    for uid in job_owner_user_ids or []:
+        if uid:
+            score_by_uid[uid] = score_by_uid.get(uid, 0) + job_owner_weight
+            source_counts["job_owners"] += 1
+
+    ranked_uids = sorted(score_by_uid.items(), key=lambda kv: (-kv[1], kv[0]))
+    top_uids = [uid for uid, _ in ranked_uids[:MAX_OWNER_MENTIONS]]
+    mentions = " ".join(f"<@{uid}>" for uid in top_uids)
+    selection_meta: dict[str, Any] = {
+        "selection_method": "weighted_top3",
+        "selected_owner_count": len(top_uids),
+        "candidate_owner_count": len(score_by_uid),
+        "source_counts": source_counts,
+    }
+    return mentions, unresolved_handles, selection_meta
+
+
+def normalize_slack_text(
+    *,
+    slack_text: str,
+    issue_url: str,
+    owner_mentions: str,
+) -> str:
+    text = slack_text
+    text = re.sub(
+        r"Issue:\s*https://github\.com/tenstorrent/tt-metal/issues/TBD",
+        f"Issue: {issue_url}",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"Issue:\s*TBD", f"Issue: {issue_url}", text, flags=re.IGNORECASE)
+    text = re.sub(r"Likely owners:\s*.+", f"Likely owners: {owner_mentions}", text, flags=re.IGNORECASE)
+    if issue_url not in text:
+        text = text.rstrip() + f"\nIssue: {issue_url}"
+    if "Likely owners:" not in text:
+        owner_text = owner_mentions if owner_mentions else "(owner resolution pending)"
+        text = text.rstrip() + f"\nLikely owners: {owner_text}"
+    return text
+
+
+def find_exact_previous_decision(
+    review_entries: list[dict[str, Any]],
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_urls: list[str],
+) -> dict[str, Any] | None:
+    for entry in review_entries:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("workflow_name", "")).strip() != workflow_name:
+            continue
+        if str(entry.get("job_name", "")).strip() != job_name:
+            continue
+        prev_decision = entry.get("decision")
+        if not isinstance(prev_decision, dict):
+            continue
+        cached_reason = str(prev_decision.get("reason", "")).lower()
+        if "only log head excerpts provided" in cached_reason:
+            continue
+        if "prompt exceeded os argument length" in cached_reason:
+            continue
+        prev_urls = entry.get("job_urls")
+        if isinstance(prev_urls, list) and [str(u).strip() for u in prev_urls] == job_urls:
+            return prev_decision
+    return None
+
+
+def decision_key(workflow_name: str, job_name: str, job_urls: list[str]) -> str:
+    return json.dumps(
+        {"workflow_name": workflow_name, "job_name": job_name, "job_urls": job_urls},
+        sort_keys=True,
+    )
+
+
+def sanitize_for_path(value: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+    sanitized = sanitized.strip("-")
+    return sanitized or "item"
+
+
+def agent_review_and_prepare_outputs(
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_urls: list[str],
+    log_paths: list[str],
+    open_issue_context: str,
+    recent_slack_context: str,
+    model: str,
+) -> dict[str, Any]:
+    create_ticket_spec = load_command_spec(
+        ".cursor/commands/ci/ci-create-tickets.md",
+        "Create deterministic tickets only when the same terminal failure appears in all 3 logs.",
+    )
+    slack_draft_spec = load_command_spec(
+        ".cursor/commands/ci/ci-draft-slack-ci-issue.md",
+        "Draft concise Slack incident updates with direct links.",
+    )
+    log_sections: list[str] = []
+    for idx, (url, path) in enumerate(zip(job_urls, log_paths, strict=False), start=1):
+        log_sections.append(f"Run {idx} URL: {url}\nRun {idx} local log path: {path}")
+    prompt = (
+        "You are the M4 reviewer for deterministic CI failures.\n"
+        "You MUST manually compare all three logs and determine if terminal failure signatures are the same.\n"
+        "You MUST also review existing open issues and recent Slack messages before drafting outputs.\n"
+        "CRITICAL: logs are available as local files below; inspect those files directly instead of relying on excerpts in this prompt.\n"
+        "Use shell/read tools to inspect those paths and determine the terminal failure signature.\n"
+        "Criteria: deterministic only if the same job failed 3 times in a row with semantically identical terminal failure.\n\n"
+        f"Workflow: {workflow_name}\n"
+        f"Job: {job_name}\n"
+        "Open issues context:\n"
+        f"{open_issue_context}\n\n"
+        "Recent Slack messages context:\n"
+        f"{recent_slack_context}\n\n"
+        "Ticket command guidance:\n"
+        f"{create_ticket_spec}\n\n"
+        "Slack draft guidance:\n"
+        f"{slack_draft_spec}\n\n"
+        "Decide if all three runs share one identical terminal failure signature.\n"
+        "If yes, draft issue title/body and draft initial Slack message text.\n"
+        "If uncertain, set create_issue=false and draft_slack=false.\n\n"
+        + "Log file references:\n"
+        + "\n".join(f"- {section}" for section in log_sections)
+        + "\n\nOutput marker exactly on its own line:\n"
+        + MARKER
+        + "\nThen output compact JSON only:\n"
+        + (
+            '{"deterministic":false,"confidence":"low|medium|high","signature":"","error_excerpt":"","reason":"",'
+            '"create_issue":false,"draft_slack":false,"issue_title":"","issue_body":"","slack_text":""}'
+        )
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    proc = run(cmd)
+    return parse_agent_json(proc.stdout or "")
+
+
+def parse_batch_agent_json(text: str) -> list[dict[str, Any]]:
+    parsed = _parse_agent_json_payload(text, marker=MARKER)
+    decisions = parsed.get("decisions", []) if isinstance(parsed, dict) else []
+    return decisions if isinstance(decisions, list) else []
+
+
+def agent_review_batch_prepare_outputs(
+    *,
+    jobs: list[dict[str, Any]],
+    open_issue_context: str,
+    recent_slack_context: str,
+    auto_triage_slack_json_path: str,
+    model: str,
+) -> list[dict[str, Any]]:
+    create_ticket_spec = load_command_spec(
+        ".cursor/commands/ci/ci-create-tickets.md",
+        "Create deterministic tickets only when the same terminal failure appears in all 3 logs.",
+    )
+    slack_draft_spec = load_command_spec(
+        ".cursor/commands/ci/ci-draft-slack-ci-issue.md",
+        "Draft concise Slack incident updates with direct links.",
+    )
+    sections: list[str] = []
+    for idx, job in enumerate(jobs, start=1):
+        workflow_name = str(job.get("workflow_name", "")).strip()
+        job_name = str(job.get("job_name", "")).strip()
+        job_urls = job.get("job_urls", [])
+        log_paths = job.get("log_paths", [])
+        if not isinstance(job_urls, list) or not isinstance(log_paths, list):
+            continue
+        lines = [f"[JOB {idx}]", f"Workflow: {workflow_name}", f"Job: {job_name}"]
+        for run_idx, (url, path) in enumerate(zip(job_urls, log_paths, strict=False), start=1):
+            lines.append(f"Run {run_idx} URL: {url}")
+            lines.append(f"Run {run_idx} local log path: {path}")
+        lines.append(f"Auto-triage export JSON path (full, uncurated): {auto_triage_slack_json_path}")
+        sections.append("\n".join(lines))
+    prompt = (
+        "You are the M4 reviewer for deterministic CI failures.\n"
+        "For EACH provided job, manually compare all three logs and determine if terminal failure signatures are the same.\n"
+        "You MUST review existing open issues and recent Slack messages before drafting outputs.\n"
+        "You MUST independently inspect the full auto-triage JSON export file and decide whether any "
+        "HIGH CONFIDENCE triage thread is relevant for each job. Do not rely on any pre-curated triage snippets.\n"
+        "CRITICAL: logs are available as local files below; inspect those files directly.\n"
+        "Use shell/read tools to inspect those paths and determine terminal failure signatures.\n"
+        "Criteria: deterministic only if the same job failed 3 times in a row with semantically identical terminal failure.\n\n"
+        "Open issues context:\n"
+        f"{open_issue_context}\n\n"
+        "Recent Slack messages context:\n"
+        f"{recent_slack_context}\n\n"
+        "Ticket command guidance:\n"
+        f"{create_ticket_spec}\n\n"
+        "Slack draft guidance:\n"
+        f"{slack_draft_spec}\n\n"
+        "Jobs to review:\n"
+        + "\n\n".join(sections)
+        + "\n\nOutput marker exactly on its own line:\n"
+        + MARKER
+        + "\nThen output compact JSON only:\n"
+        + '{"decisions":[{"workflow_name":"","job_name":"","job_urls":[],"deterministic":false,"confidence":"low|medium|high","signature":"","error_excerpt":"","reason":"","create_issue":false,"draft_slack":false,"issue_title":"","issue_body":"","slack_text":"","auto_triage_used":false,"auto_triage_reason":"","auto_triage_permalinks":[]}]}'
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    proc = run(cmd)
+    return parse_batch_agent_json(proc.stdout or "")
+
+
+def fingerprint_for(workflow_name: str, job_name: str, signature: str) -> str:
+    raw = f"{workflow_name}\n{job_name}\n{signature.strip().lower()}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def job_identity_key(workflow_name: str, job_name: str) -> str:
+    raw = f"{workflow_name}\n{job_name}".strip().lower().encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def issue_marker(fingerprint: str) -> str:
+    return f"Auto-triage-fingerprint: {fingerprint}"
+
+
+def issue_job_identity_marker(job_key: str) -> str:
+    return f"Auto-triage-job-key: {job_key}"
+
+
+def list_open_issue_bodies(*, issue_token: str) -> list[dict[str, Any]]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            ISSUE_REPO_TEST,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,body,url",
+        ],
+        github_token=issue_token,
+    )
+    parsed = json.loads(proc.stdout or "[]")
+    return parsed if isinstance(parsed, list) else []
+
+
+def find_existing_issue_for_fingerprint(open_issues: list[dict[str, Any]], fingerprint: str) -> str | None:
+    marker = issue_marker(fingerprint)
+    for issue in open_issues:
+        body = str(issue.get("body", ""))
+        if marker in body:
+            return str(issue.get("url", "")).strip() or None
+    return None
+
+
+def find_existing_issue_for_job_identity(
+    open_issues: list[dict[str, Any]],
+    *,
+    workflow_name: str,
+    job_name: str,
+) -> str | None:
+    marker = issue_job_identity_marker(job_identity_key(workflow_name, job_name))
+    workflow_l = workflow_name.lower()
+    job_l = job_name.lower()
+    for issue in open_issues:
+        body = str(issue.get("body", ""))
+        title = str(issue.get("title", ""))
+        url = str(issue.get("url", "")).strip() or None
+        if marker in body:
+            return url
+        combined = f"{title}\n{body}".lower()
+        # Legacy fallback for older issues that predate job-key marker.
+        if workflow_l in combined and job_l in combined:
+            return url
+    return None
+
+
+def find_existing_issue_for_title(open_issues: list[dict[str, Any]], title: str) -> str | None:
+    wanted = title.strip().lower()
+    if not wanted:
+        return None
+    for issue in open_issues:
+        existing_title = str(issue.get("title", "")).strip().lower()
+        if existing_title == wanted:
+            return str(issue.get("url", "")).strip() or None
+    return None
+
+
+def create_issue(
+    *,
+    issue_token: str,
+    title: str,
+    body: str,
+) -> str:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            ISSUE_REPO_TEST,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            "CI auto triage",
+        ],
+        github_token=issue_token,
+    )
+    return (proc.stdout or "").strip().splitlines()[-1].strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="M4 deterministic issue + Slack bootstrap automation.")
+    parser.add_argument(
+        "--failing-jobs-json",
+        default="build_ci/ci_ticketing/create_tickets/failing_jobs.json",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json",
+    )
+    parser.add_argument(
+        "--review-cache-json",
+        default="build_ci/ci_ticketing/create_tickets/m4_review_cache.json",
+    )
+    parser.add_argument(
+        "--previous-artifact-dir",
+        default="build_ci/m4_cache_prev",
+    )
+    parser.add_argument(
+        "--downloaded-logs-dir",
+        default="build_ci/ci_ticketing/create_tickets/downloaded_logs",
+    )
+    parser.add_argument("--max-candidates", type=int, default=20)
+    parser.add_argument("--max-new-issues", type=int, default=1)
+    parser.add_argument(
+        "--max-agent-reviews",
+        type=int,
+        default=0,
+        help="Deprecated: review count is no longer capped; retained for compatibility.",
+    )
+    parser.add_argument("--model", default="auto")
+    parser.add_argument(
+        "--auto-triage-slack-json",
+        default="build_ci/raw_data/slack_C0APK6215B5_last_14_days.json",
+    )
+    args = parser.parse_args()
+
+    read_token = os.environ.get("AGGREGATE_READ_TOKEN", "").strip()
+    issue_token = os.environ.get("ISSUE_WRITE_TOKEN", "").strip()
+    slack_token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not read_token:
+        print("AGGREGATE_READ_TOKEN is required", file=sys.stderr)
+        return 2
+    if not issue_token:
+        print("ISSUE_WRITE_TOKEN is required", file=sys.stderr)
+        return 2
+    if not slack_token:
+        print("SLACK_BOT_TOKEN is required", file=sys.stderr)
+        return 2
+    if not os.environ.get("CURSOR_API_KEY", "").strip():
+        print("CURSOR_API_KEY is required", file=sys.stderr)
+        return 2
+
+    jobs_path = Path(args.failing_jobs_json)
+    if not jobs_path.exists():
+        print(f"Missing failing jobs input: {jobs_path}", file=sys.stderr)
+        return 2
+    candidates = load_candidates(jobs_path)
+    if not candidates:
+        log("No failing jobs found; nothing to do.")
+        Path(args.output_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output_json).write_text(json.dumps({"created": [], "skipped": []}, indent=2), encoding="utf-8")
+        return 0
+
+    previous_dir = Path(args.previous_artifact_dir)
+    prev_review_path = previous_dir / "m4_review_cache.json"
+    if not prev_review_path.exists():
+        matches = list(previous_dir.rglob("m4_review_cache.json"))
+        if matches:
+            prev_review_path = matches[0]
+    prev_review_payload = load_optional_json(prev_review_path) or {}
+    prev_review_version = int(prev_review_payload.get("version", 1)) if isinstance(prev_review_payload, dict) else 1
+    prev_review_entries = prev_review_payload.get("entries", [])
+    if not isinstance(prev_review_entries, list):
+        prev_review_entries = []
+    if prev_review_version < 2:
+        prev_review_entries = []
+        log("Ignoring prior m4 review cache (version < 2).")
+    open_issues = list_open_issue_bodies(issue_token=issue_token)
+    recent_slack_messages = fetch_recent_slack_messages(
+        slack_token=slack_token, channel_id=SLACK_CHANNEL_TEST, limit=20
+    )
+    auto_triage_json_path = str(Path(args.auto_triage_slack_json))
+    job_owner_records = load_job_owner_records()
+    slack_members_cache = slack_list_members(slack_token)
+    open_issue_context = build_open_issue_context(open_issues)
+    recent_slack_context = build_recent_slack_context(recent_slack_messages)
+    created: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    review_cache_entries: list[dict[str, Any]] = []
+    max_new_issues = max(args.max_new_issues, 0)
+    max_agent_reviews = max(args.max_agent_reviews, 0)
+    fresh_agent_reviews = 0
+    fresh_agent_calls = 0
+    prepared: list[dict[str, Any]] = []
+    for candidate in candidates[: max(args.max_candidates, 0)]:
+        job_name = str(candidate.get("job_name", "")).strip()
+        workflow_name = str(candidate.get("workflow_name", "")).strip()
+        urls_raw = candidate.get("failing_job_urls", [])
+        if not job_name or not workflow_name or not isinstance(urls_raw, list):
+            continue
+        job_urls = [str(u).strip() for u in urls_raw if str(u).strip()][:3]
+        if len(job_urls) < 3:
+            skipped.append({"job_name": job_name, "reason": "requires_3_failing_runs"})
+            continue
+        prepared.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+            }
+        )
+
+    logs_root = Path(args.downloaded_logs_dir)
+    if logs_root.exists():
+        shutil.rmtree(logs_root)
+    logs_root.mkdir(parents=True, exist_ok=True)
+    decisions_by_key: dict[str, dict[str, Any]] = {}
+    reused_cache_keys: set[str] = set()
+    to_review: list[dict[str, Any]] = []
+
+    for item in prepared:
+        workflow_name = item["workflow_name"]
+        job_name = item["job_name"]
+        job_urls = item["job_urls"]
+        existing_by_identity = find_existing_issue_for_job_identity(
+            open_issues,
+            workflow_name=workflow_name,
+            job_name=job_name,
+        )
+        if existing_by_identity:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_job_identity:{existing_by_identity}",
+                }
+            )
+            continue
+        key = decision_key(workflow_name, job_name, job_urls)
+        prior = find_exact_previous_decision(
+            prev_review_entries,
+            workflow_name=workflow_name,
+            job_name=job_name,
+            job_urls=job_urls,
+        )
+        if prior:
+            decisions_by_key[key] = prior
+            reused_cache_keys.add(key)
+            log(f"Reused cached review decision for workflow={workflow_name} job={job_name}")
+            continue
+        job_slug = sanitize_for_path(f"{workflow_name}-{job_name}")[:120]
+        log_paths: list[str] = []
+        log_fetch_error = ""
+        for idx, url in enumerate(job_urls, start=1):
+            log_path = logs_root / job_slug / f"run{idx}.log"
+            try:
+                write_job_log_file(job_url=url, read_token=read_token, out_path=log_path)
+                log_paths.append(str(log_path))
+            except Exception as exc:
+                log_fetch_error = str(exc)
+                break
+        if log_fetch_error:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "log_fetch_failed",
+                    "details": log_fetch_error[:500],
+                }
+            )
+            log(
+                "Skipped candidate due to log fetch failure "
+                f"workflow={workflow_name} job={job_name}: {log_fetch_error[:220]}"
+            )
+            continue
+        to_review.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+                "log_paths": log_paths,
+            }
+        )
+
+    if to_review:
+        log(f"Running batched agent review for {len(to_review)} jobs")
+        try:
+            batch_decisions = agent_review_batch_prepare_outputs(
+                jobs=to_review,
+                open_issue_context=open_issue_context,
+                recent_slack_context=recent_slack_context,
+                auto_triage_slack_json_path=auto_triage_json_path,
+                model=args.model,
+            )
+            fresh_agent_calls += 1
+            batch_map: dict[str, dict[str, Any]] = {}
+            for decision in batch_decisions:
+                if not isinstance(decision, dict):
+                    continue
+                workflow_name = str(decision.get("workflow_name", "")).strip()
+                job_name = str(decision.get("job_name", "")).strip()
+                job_urls = decision.get("job_urls", [])
+                if not workflow_name or not job_name or not isinstance(job_urls, list):
+                    continue
+                normalized_urls = [str(u).strip() for u in job_urls if str(u).strip()][:3]
+                batch_map[decision_key(workflow_name, job_name, normalized_urls)] = decision
+            for review_item in to_review:
+                key = decision_key(
+                    review_item["workflow_name"],
+                    review_item["job_name"],
+                    review_item["job_urls"],
+                )
+                decision = batch_map.get(key)
+                if not decision:
+                    decision = {
+                        "deterministic": False,
+                        "confidence": "low",
+                        "signature": "",
+                        "error_excerpt": "",
+                        "reason": "Batch review did not return a decision for this job.",
+                        "create_issue": False,
+                        "draft_slack": False,
+                        "issue_title": "",
+                        "issue_body": "",
+                        "slack_text": "",
+                    }
+                decisions_by_key[key] = decision
+                fresh_agent_reviews += 1
+        except OSError as exc:
+            if exc.errno != 7:
+                raise
+            for review_item in to_review:
+                key = decision_key(
+                    review_item["workflow_name"],
+                    review_item["job_name"],
+                    review_item["job_urls"],
+                )
+                decisions_by_key[key] = {
+                    "deterministic": False,
+                    "confidence": "low",
+                    "signature": "",
+                    "error_excerpt": "",
+                    "reason": "Prompt exceeded OS argument length while sending batched file references to agent.",
+                    "create_issue": False,
+                    "draft_slack": False,
+                    "issue_title": "",
+                    "issue_body": "",
+                    "slack_text": "",
+                }
+                fresh_agent_reviews += 1
+            fresh_agent_calls += 1
+
+    for item in prepared:
+        if len(created) >= max_new_issues:
+            skipped.append({"reason": f"max_new_issues_reached:{max_new_issues}"})
+            break
+        workflow_name = item["workflow_name"]
+        job_name = item["job_name"]
+        job_urls = item["job_urls"]
+        auto_triage_user_ids: list[str] = []
+        job_owner_user_ids = sorted(
+            job_owner_ids_for_failure(
+                workflow_name=workflow_name,
+                job_name=job_name,
+                job_owner_records=job_owner_records,
+            )
+        )
+        key = decision_key(workflow_name, job_name, job_urls)
+        decision = decisions_by_key.get(key)
+        if not decision:
+            continue
+        auto_triage_selection = parse_auto_triage_decision(decision)
+        reused_cache = key in reused_cache_keys
+        review_cache_entries.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+                "decision": decision,
+                "reused_cache": reused_cache,
+            }
+        )
+        deterministic = bool(decision.get("deterministic", False))
+        confidence = str(decision.get("confidence", "low")).strip().lower()
+        signature = str(decision.get("signature", "")).strip()
+        excerpt = str(decision.get("error_excerpt", "")).strip()
+        reason = str(decision.get("reason", "")).strip()
+        create_issue_flag = bool(decision.get("create_issue", False))
+        draft_slack_flag = bool(decision.get("draft_slack", False))
+        issue_title = str(decision.get("issue_title", "")).strip()
+        issue_body_from_agent = str(decision.get("issue_body", "")).strip()
+        slack_text = str(decision.get("slack_text", "")).strip()
+        if not deterministic or confidence != "high" or not signature or not create_issue_flag:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "agent_rejected_or_low_confidence",
+                    "decision": decision,
+                }
+            )
+            log(
+                "Skipped candidate "
+                f"workflow={workflow_name} job={job_name}: {reason[:220] if reason else 'rejected_or_low_confidence'}"
+            )
+            continue
+
+        # Re-check identity here because open_issues mutates within this run
+        # after each created issue, and prepared candidates may contain repeats.
+        existing_by_identity = find_existing_issue_for_job_identity(
+            open_issues,
+            workflow_name=workflow_name,
+            job_name=job_name,
+        )
+        if existing_by_identity:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_job_identity_postcreate:{existing_by_identity}",
+                }
+            )
+            continue
+
+        fp = fingerprint_for(workflow_name, job_name, signature)
+        existing = find_existing_issue_for_fingerprint(open_issues, fp)
+        if existing:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked:{existing}",
+                    "fingerprint": fp,
+                }
+            )
+            continue
+
+        if not issue_title:
+            issue_title = f"CI auto triage: deterministic failure in {job_name}"
+        existing_by_title = find_existing_issue_for_title(open_issues, issue_title)
+        if existing_by_title:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_title:{existing_by_title}",
+                    "issue_title": issue_title,
+                }
+            )
+            continue
+        if not issue_body_from_agent:
+            issue_body_from_agent = (
+                f"Workflow: `{workflow_name}`\n"
+                f"Job: `{job_name}`\n\n"
+                f"Failure signature: `{signature}`\n\n"
+                f"Error excerpt:\n"
+                f"```\n{excerpt or reason or 'No excerpt captured'}\n```\n\n"
+                f"Failing job URLs (last 3):\n" + "\n".join(f"- {url}" for url in job_urls)
+            )
+        marker = issue_marker(fp)
+        job_marker = issue_job_identity_marker(job_identity_key(workflow_name, job_name))
+        issue_body = issue_body_from_agent
+        if marker not in issue_body:
+            issue_body = issue_body.rstrip() + "\n\n" + marker + "\n"
+        if job_marker not in issue_body:
+            issue_body = issue_body.rstrip() + "\n" + job_marker + "\n"
+        if not draft_slack_flag:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "agent_declined_slack_draft",
+                    "fingerprint": fp,
+                    "decision": decision,
+                }
+            )
+            continue
+        issue_url = create_issue(issue_token=issue_token, title=issue_title, body=issue_body)
+        open_issues.append({"url": issue_url, "title": issue_title, "body": issue_body})
+        if not slack_text:
+            slack_text = (
+                f"CI auto triage detected a deterministic failure (3x in a row) for `{job_name}` in `{workflow_name}`.\n"
+                f"Issue: {issue_url}\n"
+                f"Fingerprint: `{fp}`\n"
+                f"Latest run: {job_urls[0]}"
+            )
+        owner_mentions, unresolved_handles, owner_selection = render_owner_mentions(
+            issue_token=issue_token,
+            slack_token=slack_token,
+            workflow_name=workflow_name,
+            job_name=job_name,
+            text_sources=[issue_body, excerpt, reason, signature],
+            members_cache=slack_members_cache,
+            auto_triage_user_ids=auto_triage_user_ids,
+            job_owner_user_ids=job_owner_user_ids,
+        )
+        slack_text = normalize_slack_text(
+            slack_text=slack_text,
+            issue_url=issue_url,
+            owner_mentions=owner_mentions,
+        )
+        if auto_triage_selection.get("used") and auto_triage_selection.get("permalinks"):
+            permalink = str(auto_triage_selection.get("permalinks", [""])[0]).strip()
+            if permalink and permalink not in slack_text:
+                slack_text = slack_text.rstrip() + f"\nRelated auto-triage thread: {permalink}"
+        else:
+            reason = str(auto_triage_selection.get("reason", "")).strip()
+            if reason:
+                slack_text = slack_text.rstrip() + f"\nAuto-triage context: not used ({reason})."
+        if unresolved_handles:
+            slack_text = (
+                slack_text.rstrip()
+                + "\nUnresolved GitHub owner handles: "
+                + ", ".join(f"@{h}" for h in unresolved_handles)
+            )
+        slack_ts = post_slack_message(slack_token=slack_token, channel_id=SLACK_CHANNEL_TEST, text=slack_text)
+        recent_slack_messages.insert(0, {"ts": slack_ts, "user": "m4-auto-triage", "text": slack_text})
+        open_issue_context = build_open_issue_context(open_issues)
+        created.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "fingerprint": fp,
+                "issue_url": issue_url,
+                "slack_channel": SLACK_CHANNEL_TEST,
+                "slack_ts": slack_ts,
+                "job_urls": job_urls,
+                "agent_decision": decision,
+                "owner_mentions": owner_mentions,
+                "unresolved_owner_handles": unresolved_handles,
+                "owner_selection": owner_selection,
+                "auto_triage_selection": auto_triage_selection,
+            }
+        )
+        log(f"Created issue and posted Slack bootstrap: {issue_url} (ts={slack_ts})")
+
+    output = {
+        "created": created,
+        "skipped": skipped,
+        "candidate_count": len(candidates),
+        "processed_count": min(len(candidates), max(args.max_candidates, 0)),
+        "max_new_issues": max_new_issues,
+        "max_agent_reviews": max_agent_reviews,
+        "fresh_agent_reviews": fresh_agent_reviews,
+        "fresh_agent_calls": fresh_agent_calls,
+    }
+    out_path = Path(args.output_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    review_cache_payload = {
+        "version": 2,
+        "entries": review_cache_entries,
+    }
+    review_cache_path = Path(args.review_cache_json)
+    review_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    review_cache_path.write_text(json.dumps(review_cache_payload, indent=2), encoding="utf-8")
+    print(json.dumps({"created_count": len(created), "skipped_count": len(skipped)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/tests/ci/test_m4_marker_parsing.py
+++ b/tools/tests/ci/test_m4_marker_parsing.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+import tools.ci.m4_create_issues_and_notify as mod
+
+
+def test_parse_batch_agent_json_accepts_raw_json_without_marker():
+    text = (
+        '{"decisions":[{"workflow_name":"wf","job_name":"job","job_urls":["u1","u2","u3"],'
+        '"deterministic":true,"confidence":"high","signature":"abc","error_excerpt":"x",'
+        '"reason":"ok","create_issue":true,"draft_slack":true,"issue_title":"t","issue_body":"b","slack_text":"s"}]}'
+    )
+    decisions = mod.parse_batch_agent_json(text)
+    assert isinstance(decisions, list)
+    assert len(decisions) == 1
+    assert decisions[0]["workflow_name"] == "wf"
+
+
+def test_parse_batch_agent_json_missing_marker_has_actionable_error():
+    with pytest.raises(ValueError) as exc:
+        mod.parse_batch_agent_json("agent output without marker and without json payload")
+    message = str(exc.value)
+    assert "marker not found" in message
+    assert "output excerpt" in message
+
+
+def test_find_existing_issue_for_job_identity_matches_newly_created_body_marker():
+    workflow_name = "aggregate-workflow-data"
+    job_name = "Galaxy Qwen3-32B long context demo tests"
+    job_key = mod.job_identity_key(workflow_name, job_name)
+    marker = mod.issue_job_identity_marker(job_key)
+    open_issues = [{"url": "https://github.com/ebanerjeeTT/issue_dump/issues/999", "body": f"foo\n{marker}\nbar"}]
+    existing = mod.find_existing_issue_for_job_identity(
+        open_issues,
+        workflow_name=workflow_name,
+        job_name=job_name,
+    )
+    assert existing == "https://github.com/ebanerjeeTT/issue_dump/issues/999"
+
+
+def test_find_existing_issue_for_title_matches_case_insensitive_exact():
+    open_issues = [
+        {
+            "url": "https://github.com/ebanerjeeTT/issue_dump/issues/854",
+            "title": "[CI] Galaxy Qwen3-32B long context demo: trace buffer size exceeds allocated region",
+        }
+    ]
+    existing = mod.find_existing_issue_for_title(
+        open_issues,
+        "[ci] galaxy qwen3-32b long context demo: trace buffer size exceeds allocated region",
+    )
+    assert existing == "https://github.com/ebanerjeeTT/issue_dump/issues/854"
+
+
+def test_slack_lookup_by_full_name_exact_and_unique_word_match():
+    members = [
+        {
+            "id": "U1",
+            "name": "utku",
+            "profile": {"display_name": "Utku Aydonat", "real_name": "Utku Aydonat"},
+        },
+        {
+            "id": "U2",
+            "name": "other",
+            "profile": {"display_name": "Ali User", "real_name": "Ali User"},
+        },
+    ]
+    assert mod.slack_lookup_by_full_name("Utku Aydonat", members) == "U1"
+    assert mod.slack_lookup_by_full_name("Utku", members) == "U1"
+
+
+def test_slack_lookup_by_username_accepts_tt_suffix_variants():
+    members = [
+        {
+            "id": "U1",
+            "name": "aliu",
+            "profile": {"display_name": "Aliu", "real_name": "Ali User"},
+        }
+    ]
+    assert mod.slack_lookup_by_username("", "aliuTT", members) == "U1"
+
+
+def test_owners_from_workflow_name_matches_codeowners_workflow_rules(tmp_path):
+    wf_root = tmp_path / ".github" / "workflows"
+    wf_root.mkdir(parents=True)
+    (wf_root / "t3000-unit-tests-impl.yaml").write_text("name: test\n", encoding="utf-8")
+    rules = [(".github/workflows/t3000-unit-tests-impl.yaml", ["aliuTT", "cfjchu"])]
+    owners = mod.owners_from_workflow_name(
+        "T3K T3000 unit tests",
+        rules=rules,
+        workflow_root=wf_root,
+    )
+    assert owners == {"aliuTT", "cfjchu"}
+
+
+def test_render_owner_mentions_caps_to_top_three(monkeypatch):
+    monkeypatch.setattr(mod, "parse_codeowners", lambda _path: [("tests/", ["u1", "u2", "u3", "u4"])])
+    monkeypatch.setattr(mod, "extract_repo_paths", lambda _text: ["tests/foo.py"])
+    monkeypatch.setattr(mod, "owners_for_paths", lambda _paths, _rules: {"u1", "u2", "u3", "u4"})
+    monkeypatch.setattr(mod, "owners_from_workflow_name", lambda *_args, **_kwargs: set())
+    monkeypatch.setattr(
+        mod,
+        "github_user_info",
+        lambda _token, username: {"login": username, "name": username, "email": ""},
+    )
+    username_to_uid = {"u1": "U1", "u2": "U2", "u3": "U3", "u4": "U4"}
+    monkeypatch.setattr(mod, "slack_lookup_by_username", lambda *_args: username_to_uid[_args[1]])
+    monkeypatch.setattr(mod, "slack_lookup_by_full_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "recent_author_emails_for_paths", lambda _paths: set())
+    monkeypatch.setattr(mod, "slack_lookup_by_email", lambda *_args, **_kwargs: None)
+
+    mentions, unresolved, selection = mod.render_owner_mentions(
+        issue_token="x",
+        slack_token="y",
+        workflow_name="wf",
+        job_name="job",
+        text_sources=["x"],
+        members_cache=[],
+    )
+    tokens = [tok for tok in mentions.split(" ") if tok.strip()]
+    assert len(tokens) == 3
+    assert unresolved == []
+    assert selection["selected_owner_count"] == 3
+
+
+def test_parse_auto_triage_decision_includes_permalinks_and_reason():
+    decision = {
+        "auto_triage_used": True,
+        "auto_triage_reason": "matched HIGH CONFIDENCE thread",
+        "auto_triage_permalinks": [
+            "https://tenstorrent.slack.com/archives/C0APK6215B5/p1775000000123456",
+            "https://example.com/not-allowed",
+        ],
+    }
+    meta = mod.parse_auto_triage_decision(decision)
+    assert meta["used"] is True
+    assert meta["reason"] == "matched HIGH CONFIDENCE thread"
+    assert meta["permalinks"] == ["https://tenstorrent.slack.com/archives/C0APK6215B5/p1775000000123456"]
+
+
+def test_job_owner_ids_for_failure_matches_owners_json_entries():
+    records = [
+        {
+            "job-name-component": "t3000-unit-tests / t3k ttnn tests",
+            "owner": {"id": "UBHPP2NDP", "name": "Joseph Chu"},
+        }
+    ]
+    ids = mod.job_owner_ids_for_failure(
+        workflow_name="(T3K) T3000 unit tests",
+        job_name="t3000-unit-tests / t3k_ttnn_tests",
+        job_owner_records=records,
+    )
+    assert ids == {"UBHPP2NDP"}

--- a/tools/tests/ci/test_slice_05_m4_issues.py
+++ b/tools/tests/ci/test_slice_05_m4_issues.py
@@ -1,0 +1,79 @@
+"""Contract tests for Slice 5: M4 issue creation and notification.
+
+Validates that M4 correctly processes failing jobs JSON, deduplicates
+against open issues, and produces expected creation/skip records.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import tools.ci.m4_create_issues_and_notify as m4
+
+
+def test_job_identity_key_is_deterministic():
+    key1 = m4.job_identity_key("wf-A", "job-B")
+    key2 = m4.job_identity_key("wf-A", "job-B")
+    assert key1 == key2
+    assert isinstance(key1, str)
+    assert len(key1) > 0
+
+
+def test_issue_job_identity_marker_contains_key():
+    key = m4.job_identity_key("workflow", "job")
+    marker = m4.issue_job_identity_marker(key)
+    assert key in marker
+    assert "Auto-triage-job-key" in marker
+
+
+def test_find_existing_issue_for_job_identity_returns_none_when_no_match():
+    result = m4.find_existing_issue_for_job_identity(
+        [{"url": "u1", "body": "no markers here"}],
+        workflow_name="wf",
+        job_name="job",
+    )
+    assert result is None
+
+
+def test_parse_batch_agent_json_with_decisions_key():
+    payload = json.dumps({
+        "decisions": [
+            {
+                "workflow_name": "wf",
+                "job_name": "job",
+                "job_urls": ["u1"],
+                "deterministic": True,
+                "confidence": "high",
+                "signature": "sig",
+                "error_excerpt": "err",
+                "reason": "r",
+                "create_issue": True,
+                "draft_slack": True,
+                "issue_title": "title",
+                "issue_body": "body",
+                "slack_text": "text",
+            }
+        ]
+    })
+    result = m4.parse_batch_agent_json(payload)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["workflow_name"] == "wf"
+
+
+def test_extract_repo_paths_finds_known_prefixes():
+    text = "Error in tt_metal/llrt/foo.cpp and tests/unit/test_bar.py"
+    paths = m4.extract_repo_paths(text)
+    assert any("tt_metal" in p for p in paths)
+    assert any("tests" in p for p in paths)
+
+
+def test_owners_for_paths_uses_last_matching_rule():
+    rules = [
+        ("*", ["default"]),
+        ("tests/", ["test_owner"]),
+    ]
+    owners = m4.owners_for_paths(["tests/foo.py"], rules)
+    assert "test_owner" in owners


### PR DESCRIPTION
## Summary

- Add `extract_failing_jobs.py` for deterministic extraction of failing CI jobs from GitHub Actions workflow runs
- Add `m4_create_issues_and_notify.py` for creating GitHub issues, assigning owners via CODEOWNERS, and sending Slack notifications
- 16 tests covering marker parsing, owner resolution, job identity, and batch agent JSON handling

## Context

This is **Slice 5 / Tier 3** of the CI triage autonomy port. Stacked on Slice 2 (Slack ingestion). Independent of Slice 4 (draft PRs) and Slice 6 (M5 lifecycle).

## Dependencies

- Slice 0 (foundation: `common/codeowners`, `common/github`, `common/guarded`, `common/markers`, `common/run_helper`, `common/slack`)
- Slice 2 (M4 reads the Slack channel export artifact at runtime, no Python import dependency)

## Test plan

- [x] All 16 slice tests pass locally
- [x] All prior slice tests still pass
- [ ] Review issue creation and owner resolution logic


Made with [Cursor](https://cursor.com)