### PR TITLE
Slice 8: Reusable workflow, testing harness, and documentation

### DIFF
--- a/.github/actions/generate-slack-data-report/action.yml
+++ b/.github/actions/generate-slack-data-report/action.yml
@@ -1,0 +1,62 @@
+name: "Generate Slack Data Report"
+description: "Runs Cursor Agent over exported Slack JSON and writes a markdown report"
+inputs:
+  input-json-path:
+    description: "Path to exported Slack JSON"
+    required: true
+  report-path:
+    description: "Path where markdown report should be written"
+    required: true
+  model:
+    description: "Cursor agent model to use (for example: auto, claude-3-7-sonnet, gpt-5)"
+    required: false
+    default: "auto"
+runs:
+  using: "composite"
+  steps:
+    - name: Generate markdown report with Cursor agent
+      shell: bash
+      run: |
+        set -euo pipefail
+        repo_root="$(cd "${{ github.action_path }}/../../.." && pwd)"
+        input_json="${{ inputs.input-json-path }}"
+        report_path="${{ inputs.report-path }}"
+        model="${{ inputs.model }}"
+        prompt_file="${{ github.action_path }}/prompt.md"
+
+        if [ ! -f "$input_json" ]; then
+          echo "Input JSON not found: $input_json"
+          exit 1
+        fi
+
+        mkdir -p "$(dirname "$report_path")"
+        prompt_text="$(cat "$prompt_file")"
+        prompt_text="${prompt_text//__INPUT_JSON_PATH__/$input_json}"
+        run_prompt="$prompt_text"
+        run_prompt+=$'\n\nImportant output contract:\n'
+        run_prompt+=$'- You may reason however you want while working.\n'
+        run_prompt+=$'- At the very end, emit this exact marker on its own line:\n'
+        run_prompt+=$'===FINAL_REPORT_MD===\n'
+        run_prompt+=$'- After that marker, output only the final markdown report.\n'
+        raw_output_path="${report_path}.raw.log"
+        echo "Running Cursor agent with model: $model"
+        echo "Writing report to: $report_path"
+        echo "Streaming readable Cursor output to job logs..."
+        if [ "$model" = "auto" ]; then
+          agent --trust \
+            --output-format stream-json \
+            --stream-partial-output \
+            -p "$run_prompt" | python -u "${{ github.action_path }}/stream_json_pretty.py" "$raw_output_path"
+        else
+          agent --trust --model "$model" \
+            --output-format stream-json \
+            --stream-partial-output \
+            -p "$run_prompt" | python -u "${{ github.action_path }}/stream_json_pretty.py" "$raw_output_path"
+        fi
+        python "${{ github.action_path }}/extract_final_report.py" "$raw_output_path" "$report_path"
+        if [ ! -s "$report_path" ]; then
+          echo "Failed to extract final markdown report from agent output."
+          echo "Raw output was saved to: $raw_output_path"
+          exit 1
+        fi
+        test -s "$report_path"

--- a/.github/actions/generate-slack-data-report/extract_final_report.py
+++ b/.github/actions/generate-slack-data-report/extract_final_report.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Extract final markdown report section from Cursor stream-json raw log."""
+
+from __future__ import annotations
+
+from difflib import SequenceMatcher
+import json
+import sys
+from pathlib import Path
+
+
+MARKER = "===FINAL_REPORT_MD===\n"
+
+
+def normalize(text: str) -> str:
+    return " ".join(text.replace("\r", "").replace("\n", " ").split())
+
+
+def overlap_suffix_prefix(old: str, new: str) -> int:
+    max_k = min(len(old), len(new))
+    for k in range(max_k, 0, -1):
+        if old[-k:] == new[:k]:
+            return k
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: extract_final_report.py <raw_output_path> <report_path>", file=sys.stderr)
+        return 2
+
+    raw_path = Path(sys.argv[1])
+    report_path = Path(sys.argv[2])
+    full_text = ""
+    last_snapshot = ""
+
+    for line in raw_path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        try:
+            obj = json.loads(line)
+        except Exception:
+            continue
+
+        if obj.get("type") != "assistant":
+            continue
+
+        message = obj.get("message", {})
+        content = message.get("content", [])
+        if not isinstance(content, list):
+            continue
+
+        for item in content:
+            if not isinstance(item, dict):
+                continue
+            text = item.get("text")
+            if isinstance(text, str):
+                if text.startswith(last_snapshot):
+                    delta = text[len(last_snapshot) :]
+                elif last_snapshot.startswith(text):
+                    # Older replayed snapshot; ignore.
+                    delta = ""
+                else:
+                    # Suppress near-identical corrected snapshots.
+                    if last_snapshot:
+                        similarity = SequenceMatcher(None, normalize(last_snapshot), normalize(text)).ratio()
+                        if similarity >= 0.985:
+                            last_snapshot = text
+                            continue
+                    overlap = overlap_suffix_prefix(last_snapshot, text)
+                    delta = text[overlap:]
+                last_snapshot = text
+                if delta:
+                    full_text += delta
+
+    # Use the last marker in case the model emits retries/corrections.
+    final_md = full_text.rsplit(MARKER, 1)[1].strip() if MARKER in full_text else ""
+    report_path.write_text(final_md, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/actions/generate-slack-data-report/prompt.md
+++ b/.github/actions/generate-slack-data-report/prompt.md
@@ -1,0 +1,46 @@
+Read the JSON file at __INPUT_JSON_PATH__.
+
+Produce a concise markdown report with:
+1) percentage of top-level messages that led to tests being disabled
+2) percentage of top-level messages that led to developers fixing the problem
+3) percentage of top-level messages/jobs still failing with no disable and no clear resolution
+4) average time between first top-level message and first clear "fixed/resolved" signal
+
+Requirements:
+- Use only evidence from message text and thread replies in this JSON.
+- State your classification heuristics explicitly in a "Methodology" section.
+- Do not use subagents (`task`) and do not run shell/edit commands; work directly from the provided JSON content.
+- Do not attempt network access, GitHub API calls, or `gh` commands.
+- Minimize intermediate narration. Keep work output concise until the final report section.
+- Parse only from `messages[]`, each top-level item's `text`, and its `thread_replies[]` (plus useful text in `attachments[].text` / `attachments[].fallback` when present).
+- Primary decision gate: use the boolean `issue_closed` that is already attached to each top-level message.
+- Hard rule: if `issue_closed` is `true`, treat that top-level message as solved/fixed without further debate.
+- Only analyze thread text deeply when `issue_closed` is `false`.
+- If a top-level message has multiple issues, use `issue_closed` and `all_referenced_issues_closed` exactly as provided in the JSON.
+- Treat developer-posted PR links in the same thread as a strong signal and prioritize them over generic discussion text.
+- Recognize GitHub links in Slack format, including:
+  - `<https://github.com/tenstorrent/tt-metal/issues/12345|...>`
+  - `<https://github.com/tenstorrent/tt-metal/pull/12345|...>`
+  - `https://github.com/tenstorrent/tt-metal/pull/12345`
+  - `/pull/12345/changes` and PR links with `#issuecomment-...`
+- Classification precedence (highest to lowest):
+  0) **Closed ticket signal**: referenced issue is closed -> solved/fixed.
+  1) **Disabled**: thread contains phrases like "PR to disable", "disable the test", "disable for now", or clear disable-intent around a PR link.
+  2) **Fixed/Resolved**: thread contains fix-intent PR references ("PR to fix", "fix here", "addresses this", "tests now pass", "now merged", "looks resolved") and no stronger disable signal.
+  3) **Unresolved**: no convincing disable/fix signal, or evidence is ambiguous/conflicting.
+- If a PR link exists but status is uncertain, classify as unresolved unless nearby thread text explicitly indicates fix/resolve outcome.
+- If no issue link is present in a top-level message, fall back entirely to thread evidence.
+- For average time-to-fix, use the timestamp delta between top-level `ts` and the earliest reply that provides a clear fixed/resolved signal.
+- In the final report, include a short "High-confidence evidence examples" section with 3-5 concrete thread snippets (message ts + key phrase) that drove classifications.
+- In the methodology, explicitly report how many messages were classified via `issue_closed` signal vs thread-evidence signal.
+- In the final report, include a section named "Unresolved Messages (Links)" that lists **every** unresolved top-level message with:
+  - message `ts`
+  - a one-line reason it is unresolved
+  - a Slack permalink
+- Build Slack permalinks from top-level message `ts` using:
+  - `https://tenstorrent.slack.com/archives/C0APK6215B5/p<ts_without_dot>`
+  - Example: ts `1773082489.672879` -> `https://tenstorrent.slack.com/archives/C0APK6215B5/p1773082489672879`
+- Include total top-level message count and per-category counts.
+- If an item is ambiguous, classify as "still failing/unresolved" and mention ambiguity.
+- Show percentages with one decimal place.
+- If no resolved items exist, report average time as "N/A".

--- a/.github/actions/generate-slack-data-report/stream_json_pretty.py
+++ b/.github/actions/generate-slack-data-report/stream_json_pretty.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Pretty-print Cursor stream-json output while preserving raw logs."""
+
+from __future__ import annotations
+
+import json
+import sys
+from difflib import SequenceMatcher
+from pathlib import Path
+from typing import Any
+
+
+def safe_get_text(obj: dict[str, Any]) -> str:
+    message = obj.get("message", {})
+    content = message.get("content", [])
+    parts: list[str] = []
+    if isinstance(content, list):
+        for item in content:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+    return "".join(parts)
+
+
+def normalize_for_log(text: str) -> str:
+    return " ".join(text.replace("\r", "").replace("\n", " ").split())
+
+
+def tool_label(obj: dict[str, Any]) -> str:
+    tool_call = obj.get("tool_call", {})
+    if isinstance(tool_call, dict):
+        for key in tool_call:
+            if key.endswith("ToolCall"):
+                return key[: -len("ToolCall")]
+    return "unknown"
+
+
+def overlap_suffix_prefix(old: str, new: str) -> int:
+    max_k = min(len(old), len(new))
+    for k in range(max_k, 0, -1):
+        if old[-k:] == new[:k]:
+            return k
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: stream_json_pretty.py <raw_output_path>", file=sys.stderr)
+        return 2
+
+    raw_path = Path(sys.argv[1])
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+
+    assistant_chars = 0
+    assistant_buffer = ""
+    last_assistant_snapshot = ""
+    last_printed_preview = ""
+    final_marker_seen = False
+    final_marker = "===FINAL_REPORT_MD==="
+
+    def flush_assistant(force: bool = False) -> None:
+        nonlocal assistant_buffer, last_printed_preview
+        while assistant_buffer:
+            split_idx = -1
+            for punct in ("\n", ".", "!", "?"):
+                idx = assistant_buffer.rfind(punct)
+                if idx > split_idx:
+                    split_idx = idx
+
+            if force:
+                chunk = assistant_buffer
+                assistant_buffer = ""
+            elif split_idx >= 80:
+                chunk = assistant_buffer[: split_idx + 1]
+                assistant_buffer = assistant_buffer[split_idx + 1 :]
+            elif len(assistant_buffer) >= 420:
+                # Force periodic emission on long unpunctuated spans.
+                chunk = assistant_buffer[:420]
+                assistant_buffer = assistant_buffer[420:]
+            else:
+                break
+
+            preview = normalize_for_log(chunk)
+            if preview:
+                # Skip exact duplicate preview lines.
+                if preview == last_printed_preview:
+                    continue
+                # Skip near-duplicates/corrections that only slightly modify
+                # the previous preview.
+                if last_printed_preview:
+                    if preview.startswith(last_printed_preview) and len(preview) - len(last_printed_preview) < 80:
+                        continue
+                    if last_printed_preview.startswith(preview):
+                        continue
+                    similarity = SequenceMatcher(None, last_printed_preview, preview).ratio()
+                    if similarity >= 0.97 and abs(len(preview) - len(last_printed_preview)) < 80:
+                        continue
+                print(f"[assistant] {preview}", flush=True)
+                last_printed_preview = preview
+
+    with raw_path.open("w", encoding="utf-8") as raw_out:
+        for line in sys.stdin:
+            raw_out.write(line)
+            raw_out.flush()
+
+            stripped = line.strip()
+            if not stripped:
+                continue
+
+            try:
+                obj = json.loads(stripped)
+            except Exception:
+                continue
+
+            event_type = obj.get("type")
+            subtype = obj.get("subtype")
+
+            if event_type == "system":
+                if subtype == "init":
+                    model = obj.get("model", "unknown")
+                    print(f"[system] initialized model={model}", flush=True)
+                continue
+
+            if event_type == "tool_call":
+                if subtype == "started":
+                    print(f"[tool] started {tool_label(obj)}", flush=True)
+                elif subtype == "completed":
+                    print(f"[tool] completed {tool_label(obj)}", flush=True)
+                continue
+
+            if event_type == "assistant":
+                text = safe_get_text(obj)
+                if text:
+                    # stream-json often emits cumulative snapshots, sometimes with
+                    # resets/overlaps. Compute a stable incremental delta.
+                    if text.startswith(last_assistant_snapshot):
+                        delta = text[len(last_assistant_snapshot) :]
+                    elif last_assistant_snapshot.startswith(text):
+                        # Older snapshot replayed; ignore.
+                        delta = ""
+                    else:
+                        # Some models emit corrected near-duplicate snapshots
+                        # (for example spacing tweaks). Suppress those.
+                        if last_assistant_snapshot:
+                            similarity = SequenceMatcher(
+                                None,
+                                normalize_for_log(last_assistant_snapshot),
+                                normalize_for_log(text),
+                            ).ratio()
+                            if similarity >= 0.985:
+                                delta = ""
+                                last_assistant_snapshot = text
+                                continue
+                        overlap = overlap_suffix_prefix(last_assistant_snapshot, text)
+                        delta = text[overlap:]
+                    last_assistant_snapshot = text
+
+                    if delta:
+                        assistant_chars += len(delta)
+
+                        if not final_marker_seen:
+                            merged = assistant_buffer + delta
+                            marker_idx = merged.find(final_marker)
+                            if marker_idx >= 0:
+                                # Flush any pre-marker text and stop detailed logging.
+                                assistant_buffer = merged[:marker_idx]
+                                flush_assistant(force=True)
+                                print("[assistant] final markdown section started", flush=True)
+                                final_marker_seen = True
+                                assistant_buffer = ""
+                            else:
+                                assistant_buffer = merged
+                                flush_assistant(force=False)
+                continue
+
+            if event_type == "result":
+                flush_assistant(force=True)
+                duration = obj.get("duration_ms")
+                print(f"[result] completed duration_ms={duration}", flush=True)
+                last_assistant_snapshot = ""
+                continue
+
+    flush_assistant(force=True)
+    print(f"[summary] assistant_chars_streamed={assistant_chars}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/triage-ci.yaml
+++ b/.github/workflows/triage-ci.yaml
@@ -1,0 +1,1261 @@
+name: "(triage) CI Triage Autonomy"
+
+on:
+  workflow_call:
+    inputs:
+      days:
+        required: false
+        type: string
+        default: "30"
+      data-report-model:
+        required: false
+        type: string
+        default: "claude-4-sonnet"
+      data-gathering-mode:
+        required: false
+        type: boolean
+        default: false
+      auto-disable-model:
+        required: false
+        type: string
+        default: "claude-4-sonnet"
+      stale-hours-threshold:
+        required: false
+        type: string
+        default: "32"
+      stale-progress-hold-hours:
+        required: false
+        type: string
+        default: "24"
+      max-auto-disable-actions:
+        required: false
+        type: string
+        default: "3"
+      max-attempts-per-item:
+        required: false
+        type: string
+        default: "10"
+      extra-pr-check-workflows:
+        required: false
+        type: string
+        default: ""
+      target-pr-repo:
+        required: false
+        type: string
+        default: "ebanerjeeTT/tt-metal"
+      target-pr-base:
+        required: false
+        type: string
+        default: "main"
+      fork-workflow-outcomes:
+        required: false
+        type: string
+        default: "{}"
+      fork-push-check-only:
+        required: false
+        type: boolean
+        default: false
+      auto-disable-dry-run:
+        required: false
+        type: boolean
+        default: false
+      m4-max-new-issues:
+        required: false
+        type: string
+        default: "1"
+      m4-max-agent-reviews:
+        required: false
+        type: string
+        default: "0"
+      testing-mode:
+        required: false
+        type: boolean
+        default: false
+      testing-max-codeowners:
+        required: false
+        type: string
+        default: "10"
+      run-scope:
+        required: false
+        type: string
+        default: "full"
+      issue-lifecycle-processed-hours:
+        required: false
+        type: string
+        default: "24"
+      issue-lifecycle-max-issues:
+        required: false
+        type: string
+        default: "3"
+      issue-lifecycle-model:
+        required: false
+        type: string
+        default: "claude-4-sonnet"
+      triage-logic-ref:
+        required: false
+        type: string
+        default: "main"
+  workflow_dispatch:
+    inputs:
+      days:
+        description: "Number of days of Slack history to export"
+        required: false
+        default: "30"
+      data-report-model:
+        description: "Cursor model for Slack data gathering report"
+        required: false
+        type: choice
+        options:
+          - auto
+          - claude-4-sonnet
+          - claude-4-opus
+          - claude-3.7-sonnet
+          - gpt-5
+          - gpt-5-mini
+          - gpt-4.1
+          - o3
+          - gemini-2.5-pro
+          - gemini-2.5-flash
+        default: "claude-4-sonnet"
+      data-gathering-mode:
+        description: "If checked, run Cursor agent to generate Slack stats report"
+        required: false
+        type: boolean
+        default: false
+      auto-disable-model:
+        description: "Cursor model for stale auto-disable mode"
+        required: false
+        type: choice
+        options:
+          - auto
+          - claude-4-sonnet
+          - claude-4-opus
+          - claude-3.7-sonnet
+          - gpt-5
+          - gpt-5-mini
+          - gpt-4.1
+          - o3
+          - gemini-2.5-pro
+          - gemini-2.5-flash
+        default: "claude-4-sonnet"
+      stale-hours-threshold:
+        description: "Slack message age threshold in hours for automatic disable actions"
+        required: false
+        default: "32"
+      stale-progress-hold-hours:
+        description: "Hours to defer disable after fresh progress signal"
+        required: false
+        default: "24"
+      max-auto-disable-actions:
+        description: "Maximum number of disable PRs to attempt in one run"
+        required: false
+        default: "3"
+      max-attempts-per-item:
+        description: "Maximum attempts per candidate before needs_human"
+        required: false
+        default: "10"
+      extra-pr-check-workflows:
+        description: "Optional comma-separated early workflows after PR create (pr-gate.yaml,merge-gate.yaml)"
+        required: false
+        default: ""
+      target-pr-repo:
+        description: "Repository where auto-disable draft PRs should be created"
+        required: false
+        default: "ebanerjeeTT/tt-metal"
+      target-pr-base:
+        description: "Base branch in target PR repo"
+        required: false
+        default: "main"
+      fork-workflow-outcomes:
+        description: "JSON mapping of mocked fork workflow results; values can be 'outcome' string or object {outcome,error,...}"
+        required: false
+        default: "{}"
+      fork-push-check-only:
+        description: "If checked, only verify fork branch creation and skip all triage/AI work"
+        required: false
+        type: boolean
+        default: false
+      auto-disable-dry-run:
+        description: "If checked, produce plan only and skip push/PR/kickoff execution"
+        required: false
+        type: boolean
+        default: false
+      m4-max-new-issues:
+        description: "Maximum number of new M4 issues/slack bootstrap messages to create in one run"
+        required: false
+        default: "1"
+      m4-max-agent-reviews:
+        description: "Deprecated compatibility input (M4 now reviews all eligible jobs in one batch call)"
+        required: false
+        default: "0"
+      testing-mode:
+        description: "If checked, run only owner-resolution Slack testing session"
+        required: false
+        type: boolean
+        default: false
+      testing-max-codeowners:
+        description: "Maximum CODEOWNERS GitHub users to test in testing mode"
+        required: false
+        default: "10"
+      run-scope:
+        description: "Which modular stage(s) to run"
+        required: false
+        type: choice
+        options:
+          - full
+          - data-report-only
+          - draft-prs-only
+          - create-issues-only
+          - thread-lifecycle-only
+          - issue-lifecycle-only
+          - bug-escape-only
+        default: "full"
+      issue-lifecycle-processed-hours:
+        description: "Minimum hours between processing the same issue again"
+        required: false
+        default: "24"
+      issue-lifecycle-max-issues:
+        description: "Maximum number of issues to process per issue lifecycle run"
+        required: false
+        default: "3"
+      issue-lifecycle-model:
+        description: "Cursor model for issue lifecycle analysis"
+        required: false
+        type: choice
+        options:
+          - auto
+          - claude-4-sonnet
+          - claude-4-opus
+          - claude-3.7-sonnet
+          - gpt-5
+          - gpt-5-mini
+          - gpt-4.1
+          - o3
+          - gemini-2.5-pro
+          - gemini-2.5-flash
+        default: "claude-4-sonnet"
+      triage-logic-ref:
+        description: "Branch/tag/SHA in tenstorrent/tt-auto-triage for triage logic"
+        required: false
+        default: "main"
+
+permissions:
+  actions: write
+  contents: write
+  issues: read
+  pull-requests: write
+
+jobs:
+  fork-push-check:
+    name: "Fork branch push probe"
+    if: ${{ inputs['fork-push-check-only'] }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Ensure EVAN_RESTRICTED_TOKEN is configured
+        env:
+          TARGET_PR_PUSH_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          if [ -z "$TARGET_PR_PUSH_TOKEN" ]; then
+            echo "Missing secret EVAN_RESTRICTED_TOKEN"
+            exit 1
+          fi
+
+      - name: Create probe branch on fork
+        env:
+          TARGET_PR_REPO: ${{ inputs['target-pr-repo'] || 'ebanerjeeTT/tt-metal' }}
+          TARGET_PR_BASE: ${{ inputs['target-pr-base'] || 'main' }}
+          TARGET_PR_PUSH_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          login="$(GH_TOKEN="$TARGET_PR_PUSH_TOKEN" gh api user --jq .login)"
+          probe_branch="ci-fork-push-probe-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          askpass="$(mktemp)"
+          cat > "$askpass" <<'EOF'
+          #!/bin/sh
+          case "$1" in
+            *Username*) echo "$GIT_PUSH_USER" ;;
+            *) echo "$GIT_PUSH_TOKEN" ;;
+          esac
+          EOF
+          chmod 700 "$askpass"
+          git config user.name "CI Auto Disable Bot"
+          git config user.email "ci-auto-disable-bot@tenstorrent.invalid"
+          # Ensure checkout-injected GITHUB_TOKEN credentials do not override PAT auth.
+          git config --local --unset-all http.https://github.com/.extraheader || true
+          git fetch "https://github.com/${TARGET_PR_REPO}.git" "$TARGET_PR_BASE"
+          git checkout -B "$probe_branch" FETCH_HEAD
+          git commit --allow-empty -m "ci: fork push probe ${GITHUB_RUN_ID}"
+          GIT_TERMINAL_PROMPT=0 \
+          GIT_ASKPASS="$askpass" \
+          GIT_PUSH_USER="$login" \
+          GIT_PUSH_TOKEN="$TARGET_PR_PUSH_TOKEN" \
+          git push "https://github.com/${TARGET_PR_REPO}.git" "HEAD:refs/heads/${probe_branch}"
+          echo "Probe branch pushed to ${TARGET_PR_REPO}: ${probe_branch}"
+
+  prep-triage-data:
+    name: "Prepare triage data"
+    if: ${{ !inputs['fork-push-check-only'] && !inputs['testing-mode'] }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Ensure SLACK_BOT_TOKEN is configured
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "Missing secret SLACK_BOT_TOKEN"
+            exit 1
+          fi
+
+      - name: Install Cursor CLI (kept for upcoming analysis steps)
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Export Evan top-level Slack messages and thread replies
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/export_slack_author_threads.py \
+            --channel-id C0APK6215B5 \
+            --author-user-id U08GTDV8MDH \
+            --days "${{ inputs.days || 30 }}" \
+            --output build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json
+
+      - name: Enrich export with GitHub issue closure booleans
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_REPO_GITHUB_TOKEN: ${{ secrets.ISSUE_REPO_GITHUB_TOKEN || secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/enrich_slack_with_issue_status.py \
+            --input build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json \
+            --output build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json
+
+      - name: Upload Slack export artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: slack-C0APK6215B5-U08GTDV8MDH-threads
+          path: build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json
+          retention-days: 7
+
+      - name: Export last 14 days of triage channel activity
+        if: ${{ !inputs['data-gathering-mode'] }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/export_slack_channel.py \
+            --channel-id C0APK6215B5 \
+            --days 14 \
+            --output build_ci/raw_data/slack_C0APK6215B5_last_14_days.json
+
+      - name: Enrich triage channel export with issue closure booleans
+        if: ${{ !inputs['data-gathering-mode'] }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_REPO_GITHUB_TOKEN: ${{ secrets.ISSUE_REPO_GITHUB_TOKEN || secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/enrich_slack_with_issue_status.py \
+            --input build_ci/raw_data/slack_C0APK6215B5_last_14_days.json \
+            --output build_ci/raw_data/slack_C0APK6215B5_last_14_days.json
+
+      - name: Ensure CURSOR_API_KEY is configured (data gathering mode)
+        if: ${{ inputs['data-gathering-mode'] }}
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret EVAN_CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Ensure CURSOR_API_KEY is configured (auto-disable mode)
+        if: ${{ !inputs['data-gathering-mode'] }}
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret EVAN_CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Ensure EVAN_RESTRICTED_TOKEN is configured for fork/issue access (auto-disable mode)
+        if: ${{ !inputs['data-gathering-mode'] }}
+        env:
+          TARGET_PR_PUSH_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          if [ -z "$TARGET_PR_PUSH_TOKEN" ]; then
+            echo "Missing secret EVAN_RESTRICTED_TOKEN (required for fork push/PR + issue access)"
+            exit 1
+          fi
+
+      - name: Upload shared raw-data bundle
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: triage-raw-data
+          path: |
+            build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json
+            build_ci/raw_data/slack_C0APK6215B5_last_14_days.json
+          retention-days: 7
+
+  run-data-report:
+    name: "Run data gathering report"
+    if: ${{ !inputs['fork-push-check-only'] && !inputs['testing-mode'] && inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'data-report-only') }}
+    needs: [prep-triage-data]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download shared raw-data bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-raw-data
+          path: build_ci/raw_data
+
+      - name: Generate Slack data gathering report with Cursor agent
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        uses: ./.tt-auto-triage/.github/actions/generate-slack-data-report
+        with:
+          input-json-path: build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_threads.json
+          report-path: build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_report.md
+          model: ${{ inputs['data-report-model'] || 'claude-4-sonnet' }}
+
+      - name: Upload data gathering report artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: slack-C0APK6215B5-U08GTDV8MDH-report
+          path: build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_report.md
+          retention-days: 7
+
+      - name: Publish report to run summary
+        run: |
+          set -euo pipefail
+          report_path="build_ci/raw_data/slack_C0APK6215B5_U08GTDV8MDH_report.md"
+          {
+            echo "# Slack Data Gathering Report"
+            echo
+            cat "$report_path"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  run-draft-prs:
+    name: "Run draft PR create/update stage"
+    if: ${{ !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'draft-prs-only') }}
+    needs: [prep-triage-data]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download shared raw-data bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-raw-data
+          path: build_ci/raw_data
+
+      - name: Install Cursor CLI for disable planning
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Auto-disable stale unresolved CI messages
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+          GITHUB_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+          TARGET_PR_PUSH_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        uses: ./.tt-auto-triage/.github/actions/auto-disable-stale-ci
+        with:
+          input-json-path: build_ci/raw_data/slack_C0APK6215B5_last_14_days.json
+          stale-hours: ${{ inputs['stale-hours-threshold'] || '32' }}
+          hold-hours-after-progress: ${{ inputs['stale-progress-hold-hours'] || '24' }}
+          max-actions: ${{ inputs['max-auto-disable-actions'] || '3' }}
+          max-attempts-per-item: ${{ inputs['max-attempts-per-item'] || '10' }}
+          extra-pr-check-workflows: ${{ inputs['extra-pr-check-workflows'] || '' }}
+          target-pr-repo: ${{ inputs['target-pr-repo'] || 'ebanerjeeTT/tt-metal' }}
+          target-pr-base: ${{ inputs['target-pr-base'] || 'main' }}
+          fork-workflow-outcomes: ${{ inputs['fork-workflow-outcomes'] || '{}' }}
+          model: ${{ inputs['auto-disable-model'] || 'claude-4-sonnet' }}
+          dry-run: ${{ inputs['auto-disable-dry-run'] || 'false' }}
+          output-dir: build_ci/auto_disable
+
+      - name: Upload draft PR stage artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: draft-pr-stage-artifacts
+          path: |
+            build_ci/auto_disable/stale_candidates.json
+            build_ci/auto_disable/disable_actions.json
+            build_ci/auto_disable/execution_result.json
+            build_ci/auto_disable/summary.md
+            build_ci/auto_disable/debug
+          retention-days: 7
+
+      - name: Upload triage state artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state/ci_triage_state.json
+          retention-days: 7
+
+  run-create-issues:
+    name: "Run issue creation stage"
+    if: ${{ !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'create-issues-only') }}
+    needs: [prep-triage-data]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download shared raw-data bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-raw-data
+          path: build_ci/raw_data
+
+      - name: Install Cursor CLI for M4 agent review
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: M4 restore previous cache artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          mkdir -p build_ci/m4_cache_prev
+          prev_run_id="$(gh run list --workflow triage-ci.yaml --repo tenstorrent/tt-metal --status success --limit 1 --json databaseId --jq '.[0].databaseId' || true)"
+          if [ -n "${prev_run_id:-}" ] && [ "$prev_run_id" != "null" ]; then
+            gh run download "$prev_run_id" --repo tenstorrent/tt-metal -n auto-disable-artifacts -D build_ci/m4_cache_prev || true
+          fi
+
+      - name: M4 extract deterministic failing jobs from aggregate workflow data
+        env:
+          # Use repo-scoped GITHUB_TOKEN for aggregate-workflow-data artifact reads.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/extract_failing_jobs.py \
+            --cache-input "build_ci/m4_cache_prev" \
+            --cache-output "build_ci/ci_ticketing/create_tickets/failing_jobs_cache.json" \
+            --output-json "build_ci/ci_ticketing/create_tickets/failing_jobs.json"
+
+      - name: M4 create issues and post Slack bootstrap messages
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+          AGGREGATE_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/m4_create_issues_and_notify.py \
+            --failing-jobs-json "build_ci/ci_ticketing/create_tickets/failing_jobs.json" \
+            --output-json "build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json" \
+            --review-cache-json "build_ci/ci_ticketing/create_tickets/m4_review_cache.json" \
+            --previous-artifact-dir "build_ci/m4_cache_prev" \
+            --auto-triage-slack-json "build_ci/raw_data/slack_C0APK6215B5_last_14_days.json" \
+            --max-new-issues "${{ inputs['m4-max-new-issues'] || '1' }}" \
+            --max-agent-reviews "${{ inputs['m4-max-agent-reviews'] || '0' }}" \
+            --model "${{ inputs['auto-disable-model'] || 'claude-4-sonnet' }}"
+
+      - name: Upload issue-creation artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: create-issues-stage-artifacts
+          path: |
+            build_ci/ci_ticketing/create_tickets/failing_jobs.json
+            build_ci/ci_ticketing/create_tickets/failing_jobs_cache.json
+            build_ci/ci_ticketing/create_tickets/downloaded_logs
+            build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json
+            build_ci/ci_ticketing/create_tickets/m4_review_cache.json
+          retention-days: 7
+
+  run-thread-lifecycle:
+    name: "Run thread analysis + assignment stage"
+    if: ${{ !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'thread-lifecycle-only') }}
+    needs: [prep-triage-data]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download shared raw-data bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-raw-data
+          path: build_ci/raw_data
+
+      - name: Download triage state if present
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state
+        continue-on-error: true
+
+      - name: Restore previous triage state artifact (cross-run gating)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/load_previous_triage_state.py \
+            --repo tenstorrent/tt-metal \
+            --workflow triage-ci.yaml \
+            --artifact-name triage-state \
+            --state-path build_ci/triage_state/ci_triage_state.json
+
+      - name: Ensure triage state file exists
+        run: |
+          set -euo pipefail
+          mkdir -p build_ci/triage_state
+          if [ ! -f "build_ci/triage_state/ci_triage_state.json" ]; then
+            cat > build_ci/triage_state/ci_triage_state.json <<'EOF'
+          {"version":1,"updated_at_utc":"","items":[]}
+          EOF
+          fi
+
+      - name: Ensure CURSOR_API_KEY is configured for M5 agent review
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret EVAN_CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Install Cursor CLI for M5 agent review
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: M5 lifecycle follow-up + assignment + post-disable notices
+        env:
+          ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/m5_manage_issue_lifecycle.py \
+            --slack-json "build_ci/raw_data/slack_C0APK6215B5_last_14_days.json" \
+            --state-json "build_ci/triage_state/ci_triage_state.json" \
+            --output-json "build_ci/ci_ticketing/create_tickets/m5_lifecycle_result.json" \
+            --summary-md "build_ci/ci_ticketing/create_tickets/m5_lifecycle_summary.md" \
+            --channel-id "C0APK6215B5"
+
+      - name: Upload thread lifecycle artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: thread-lifecycle-stage-artifacts
+          path: |
+            build_ci/ci_ticketing/create_tickets/m5_lifecycle_result.json
+            build_ci/ci_ticketing/create_tickets/m5_lifecycle_summary.md
+          retention-days: 7
+
+      - name: Upload triage state artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state/ci_triage_state.json
+          retention-days: 7
+
+  run-bug-escape:
+    name: "Run bug-escape enrichment stage"
+    if: ${{ always() && !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'bug-escape-only') && (needs.run-thread-lifecycle.result == 'success' || needs.run-thread-lifecycle.result == 'skipped') }}
+    needs: [run-thread-lifecycle]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download triage state
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state
+        continue-on-error: true
+
+      - name: Restore previous triage state artifact (cross-run gating)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/load_previous_triage_state.py \
+            --repo tenstorrent/tt-metal \
+            --workflow triage-ci.yaml \
+            --artifact-name triage-state \
+            --state-path build_ci/triage_state/ci_triage_state.json
+
+      - name: Ensure triage state file exists
+        run: |
+          set -euo pipefail
+          mkdir -p build_ci/triage_state
+          if [ ! -f "build_ci/triage_state/ci_triage_state.json" ]; then
+            cat > build_ci/triage_state/ci_triage_state.json <<'EOF'
+          {"version":1,"updated_at_utc":"","items":[]}
+          EOF
+          fi
+
+      - name: M6 bug-escape enrichment (test scope)
+        env:
+          ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/m6_bug_escape_enrichment.py \
+            --state-json "build_ci/triage_state/ci_triage_state.json" \
+            --issue-repo "ebanerjeeTT/issue_dump" \
+            --output-json "build_ci/ci_ticketing/create_tickets/m6_bug_escape_events.json" \
+            --summary-md "build_ci/ci_ticketing/create_tickets/m6_bug_escape_summary.md"
+
+      - name: Upload bug-escape artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: bug-escape-stage-artifacts
+          path: |
+            build_ci/ci_ticketing/create_tickets/m6_bug_escape_events.json
+            build_ci/ci_ticketing/create_tickets/m6_bug_escape_summary.md
+          retention-days: 7
+
+      - name: Publish bug-escape summary to run summary
+        run: |
+          set -euo pipefail
+          m6_md="build_ci/ci_ticketing/create_tickets/m6_bug_escape_summary.md"
+          if [ -s "$m6_md" ]; then
+            echo "# M6 Bug Escape Summary" >> "$GITHUB_STEP_SUMMARY"
+            echo >> "$GITHUB_STEP_SUMMARY"
+            cat "$m6_md" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No M6 summary produced." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  run-issue-lifecycle:
+    name: "Run issue lifecycle stage"
+    if: ${{ always() && !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && (inputs['run-scope'] == 'full' || inputs['run-scope'] == 'issue-lifecycle-only') && (needs.run-create-issues.result == 'success' || needs.run-create-issues.result == 'skipped') }}
+    needs: [prep-triage-data, run-create-issues]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download triage state if present
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state
+        continue-on-error: true
+
+      - name: Restore previous triage state artifact (cross-run gating)
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/load_previous_triage_state.py \
+            --repo tenstorrent/tt-metal \
+            --workflow triage-ci.yaml \
+            --artifact-name triage-state \
+            --state-path build_ci/triage_state/ci_triage_state.json
+
+      - name: Ensure triage state file exists
+        run: |
+          set -euo pipefail
+          mkdir -p build_ci/triage_state
+          if [ ! -f "build_ci/triage_state/ci_triage_state.json" ]; then
+            cat > build_ci/triage_state/ci_triage_state.json <<'EOF'
+          {"version":1,"updated_at_utc":"","items":[]}
+          EOF
+          fi
+
+      - name: Ensure CURSOR_API_KEY is configured for issue lifecycle analysis
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret EVAN_CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Install Cursor CLI for issue lifecycle analysis
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Run issue lifecycle analysis and actions
+        env:
+          ISSUE_WRITE_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+          MAIN_REPO_READ_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/issue_lifecycle_stage.py \
+            --state-json "build_ci/triage_state/ci_triage_state.json" \
+            --output-json "build_ci/ci_ticketing/create_tickets/issue_lifecycle_result.json" \
+            --summary-md "build_ci/ci_ticketing/create_tickets/issue_lifecycle_summary.md" \
+            --issue-repo "ebanerjeeTT/issue_dump" \
+            --source-repo "tenstorrent/tt-metal" \
+            --processed-hours "${{ inputs['issue-lifecycle-processed-hours'] || '24' }}" \
+            --max-issues "${{ inputs['issue-lifecycle-max-issues'] || '3' }}" \
+            --model "${{ inputs['issue-lifecycle-model'] || 'claude-4-sonnet' }}"
+
+      - name: Upload issue lifecycle artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: issue-lifecycle-stage-artifacts
+          path: |
+            build_ci/ci_ticketing/create_tickets/issue_lifecycle_result.json
+            build_ci/ci_ticketing/create_tickets/issue_lifecycle_summary.md
+          retention-days: 7
+
+      - name: Upload triage state artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: triage-state
+          path: build_ci/triage_state/ci_triage_state.json
+          retention-days: 7
+
+  finalize-autonomy-artifacts:
+    name: "Finalize autonomy artifacts + summary"
+    if: ${{ always() && !inputs['fork-push-check-only'] && !inputs['testing-mode'] && !inputs['data-gathering-mode'] && inputs['run-scope'] == 'full' }}
+    needs: [run-draft-prs, run-create-issues, run-thread-lifecycle, run-bug-escape, run-issue-lifecycle]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download draft PR stage artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: draft-pr-stage-artifacts
+          path: build_ci
+        continue-on-error: true
+
+      - name: Download issue creation artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: create-issues-stage-artifacts
+          path: build_ci
+        continue-on-error: true
+
+      - name: Download thread lifecycle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: thread-lifecycle-stage-artifacts
+          path: build_ci
+        continue-on-error: true
+
+      - name: Download bug escape artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: bug-escape-stage-artifacts
+          path: build_ci
+        continue-on-error: true
+
+      - name: Download issue lifecycle artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: issue-lifecycle-stage-artifacts
+          path: build_ci
+        continue-on-error: true
+
+      - name: Download raw-data bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: triage-raw-data
+          path: build_ci/raw_data
+        continue-on-error: true
+
+      - name: Upload auto-disable artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: auto-disable-artifacts
+          path: |
+            build_ci/auto_disable/stale_candidates.json
+            build_ci/auto_disable/disable_actions.json
+            build_ci/auto_disable/execution_result.json
+            build_ci/auto_disable/summary.md
+            build_ci/auto_disable/debug
+            build_ci/ci_ticketing/create_tickets/failing_jobs.json
+            build_ci/ci_ticketing/create_tickets/failing_jobs_cache.json
+            build_ci/ci_ticketing/create_tickets/downloaded_logs
+            build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json
+            build_ci/ci_ticketing/create_tickets/m4_review_cache.json
+            build_ci/ci_ticketing/create_tickets/m5_lifecycle_result.json
+            build_ci/ci_ticketing/create_tickets/m5_lifecycle_summary.md
+            build_ci/ci_ticketing/create_tickets/m6_bug_escape_events.json
+            build_ci/ci_ticketing/create_tickets/m6_bug_escape_summary.md
+            build_ci/ci_ticketing/create_tickets/issue_lifecycle_result.json
+            build_ci/ci_ticketing/create_tickets/issue_lifecycle_summary.md
+            build_ci/raw_data/slack_C0APK6215B5_last_14_days.json
+          retention-days: 7
+
+      - name: Publish modular autonomy summary to run summary
+        run: |
+          set -euo pipefail
+          summary_path="build_ci/auto_disable/summary.md"
+          if [ -s "$summary_path" ]; then
+            {
+              echo "# Auto Disable Summary"
+              echo
+              cat "$summary_path"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "# Auto Disable Summary"
+              echo
+              echo "No summary produced."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
+          m4_json="build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json"
+          if [ -s "$m4_json" ]; then
+            python3 .tt-auto-triage/tools/ci/render_m4_summary.py --input-json "$m4_json" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          m5_md="build_ci/ci_ticketing/create_tickets/m5_lifecycle_summary.md"
+          if [ -s "$m5_md" ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            cat "$m5_md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          m6_md="build_ci/ci_ticketing/create_tickets/m6_bug_escape_summary.md"
+          if [ -s "$m6_md" ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            cat "$m6_md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          issue_lifecycle_md="build_ci/ci_ticketing/create_tickets/issue_lifecycle_summary.md"
+          if [ -s "$issue_lifecycle_md" ]; then
+            echo >> "$GITHUB_STEP_SUMMARY"
+            cat "$issue_lifecycle_md" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  triage-ci-testing-session:
+    name: "Run CI triage testing session"
+    if: ${{ !inputs['fork-push-check-only'] && inputs['testing-mode'] }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Ensure SLACK_BOT_TOKEN is configured
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          if [ -z "$SLACK_BOT_TOKEN" ]; then
+            echo "Missing secret SLACK_BOT_TOKEN"
+            exit 1
+          fi
+
+      - name: Ensure EVAN_RESTRICTED_TOKEN is configured
+        env:
+          OWNER_LOOKUP_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          if [ -z "$OWNER_LOOKUP_TOKEN" ]; then
+            echo "Missing secret EVAN_RESTRICTED_TOKEN"
+            exit 1
+          fi
+
+      - name: Ensure CURSOR_API_KEY is configured
+        env:
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          if [ -z "$CURSOR_API_KEY" ]; then
+            echo "Missing secret EVAN_CURSOR_API_KEY"
+            exit 1
+          fi
+
+      - name: Install Cursor CLI for testing-mode thread analysis
+        run: |
+          set -euo pipefail
+          install_script="$(mktemp)"
+          curl --fail --show-error --silent --location \
+            --proto '=https' --tlsv1.2 \
+            https://cursor.com/install \
+            -o "$install_script"
+          bash "$install_script"
+          rm -f "$install_script"
+          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+
+      - name: Run owner-resolution Slack testing session
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/testing_owner_resolution_session.py \
+            --codeowners-path ".github/CODEOWNERS" \
+            --slack-channel-id "C0APK6215B5" \
+            --max-codeowners "${{ inputs['testing-max-codeowners'] || '10' }}" \
+            --output-json "build_ci/testing/owner_resolution_session.json" \
+            --summary-md "build_ci/testing/owner_resolution_session.md"
+
+      - name: Run thread persona simulation session
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/testing_thread_persona_session.py \
+            --slack-channel-id "C0APK6215B5" \
+            --output-json "build_ci/testing/thread_persona_session.json" \
+            --summary-md "build_ci/testing/thread_persona_session.md"
+
+      - name: Run testing-mode triage E2E thread session
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.EVAN_RESTRICTED_TOKEN }}
+          CURSOR_API_KEY: ${{ secrets.EVAN_CURSOR_API_KEY }}
+        run: |
+          set -euo pipefail
+          python .tt-auto-triage/tools/ci/testing_triage_e2e_session.py \
+            --slack-channel-id "C0APK6215B5" \
+            --max-threads 3 \
+            --output-json "build_ci/testing/triage_e2e_session.json" \
+            --summary-md "build_ci/testing/triage_e2e_session.md"
+
+      - name: Upload testing session artifacts
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # @v4
+        with:
+          name: triage-testing-session
+          path: |
+            build_ci/testing/owner_resolution_session.json
+            build_ci/testing/owner_resolution_session.md
+            build_ci/testing/thread_persona_session.json
+            build_ci/testing/thread_persona_session.md
+            build_ci/testing/triage_e2e_session.json
+            build_ci/testing/triage_e2e_session.md
+          retention-days: 7
+
+      - name: Publish testing summary to run summary
+        run: |
+          set -euo pipefail
+          summary_path="build_ci/testing/owner_resolution_session.md"
+          {
+            echo "# CI Triage Testing Session"
+            echo
+            cat "$summary_path"
+            echo
+            cat "build_ci/testing/thread_persona_session.md"
+            echo
+            cat "build_ci/testing/triage_e2e_session.md"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  publish-run-summary:
+    name: "Publish unified run summary"
+    if: ${{ always() }}
+    needs:
+      [
+        fork-push-check,
+        prep-triage-data,
+        run-data-report,
+        run-draft-prs,
+        run-create-issues,
+        run-thread-lifecycle,
+        run-bug-escape,
+        run-issue-lifecycle,
+        finalize-autonomy-artifacts,
+        triage-ci-testing-session,
+      ]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Checkout tt-auto-triage logic repository
+        uses: actions/checkout@v4
+        with:
+          repository: tenstorrent/tt-auto-triage
+          ref: ${{ inputs['triage-logic-ref'] || 'main' }}
+          path: .tt-auto-triage
+          persist-credentials: false
+
+      - name: Download summary-relevant artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: build_ci/summary_artifacts
+        continue-on-error: true
+
+      - name: Publish always-on summary
+        run: |
+          set -euo pipefail
+          {
+            echo "# CI Triage Unified Summary"
+            echo
+            echo "- run-scope: \`${{ inputs['run-scope'] || 'full' }}\`"
+            echo "- data-gathering-mode: \`${{ inputs['data-gathering-mode'] || 'false' }}\`"
+            echo "- testing-mode: \`${{ inputs['testing-mode'] || 'false' }}\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          append_if_exists() {
+            file_path="$1"
+            title="$2"
+            if [ -s "$file_path" ]; then
+              {
+                echo "## $title"
+                echo
+                cat "$file_path"
+                echo
+              } >> "$GITHUB_STEP_SUMMARY"
+            fi
+          }
+
+          append_if_exists "build_ci/summary_artifacts/auto-disable-artifacts/summary.md" "Auto Disable"
+          append_if_exists "build_ci/summary_artifacts/thread-lifecycle-stage-artifacts/m5_lifecycle_summary.md" "Thread Lifecycle"
+          append_if_exists "build_ci/summary_artifacts/issue-lifecycle-stage-artifacts/issue_lifecycle_summary.md" "Issue Lifecycle"
+          append_if_exists "build_ci/summary_artifacts/bug-escape-stage-artifacts/m6_bug_escape_summary.md" "Bug Escape"
+          append_if_exists "build_ci/summary_artifacts/slack-C0APK6215B5-U08GTDV8MDH-report/slack_C0APK6215B5_U08GTDV8MDH_report.md" "Data Gathering Report"
+          append_if_exists "build_ci/summary_artifacts/triage-testing-session/owner_resolution_session.md" "Testing Session - Owner Resolution"
+          append_if_exists "build_ci/summary_artifacts/triage-testing-session/thread_persona_session.md" "Testing Session - Thread Persona"
+          append_if_exists "build_ci/summary_artifacts/triage-testing-session/triage_e2e_session.md" "Testing Session - E2E"
+
+          m4_json="build_ci/summary_artifacts/create-issues-stage-artifacts/m4_issue_and_slack_result.json"
+          if [ -s "$m4_json" ]; then
+            {
+              echo "## M4 Issue Creation"
+              echo
+              python3 .tt-auto-triage/tools/ci/render_m4_summary.py --input-json "$m4_json"
+              echo
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -1,0 +1,26 @@
+# CI Ticketing Helpers
+
+This directory contains helpers for the Cursor-driven CI ticketing workflow.
+
+## Extract Repeated Failures
+
+Generate the candidate list used by the create-ticket rule:
+
+```bash
+python tools/ci/extract_failing_jobs.py
+```
+
+Optional workflow filter (yaml name without extension):
+
+```bash
+python tools/ci/extract_failing_jobs.py t3000-unit-tests
+```
+
+The output file is written to:
+
+- `.auto_triage/output/ci_ticketing/create_tickets/failing_jobs.json`
+
+## Notes
+
+- Requires `gh` CLI authentication (`gh auth login`) or `GITHUB_TOKEN`.
+- The script only prepares candidate failures. Issue creation/closure is intentionally done through guided Cursor rule execution with explicit `gh` commands.

--- a/tools/ci/ci-triage-autonomy-agent-planning.md
+++ b/tools/ci/ci-triage-autonomy-agent-planning.md
@@ -1,0 +1,1175 @@
+# CI Triage Autonomy Fresh-Agent Handoff Spec
+
+## 1) Mission Contract
+
+This document is the execution specification for a fresh agent with no prior conversation context.
+The agent must implement and validate an autonomous CI-triage control loop with minimal human oversight.
+
+Primary outcomes:
+
+- No duplicate disable PRs for the same failing signal
+- Existing disable PRs are resumed/extended when new failures appear
+- Successful completion triggers one terminal Slack notification
+- Bug-escape attribution is tracked post-facto by mapping issue -> fix commit/PR
+- New failures are continuously ingested from aggregate workflow data
+- Ticket lifecycle is fully automated (create/update/close with recurrence creating a new issue)
+- Assignment/follow-up/escalation loops continue even after temporary disables
+- Small-scope fix PR drafting is attempted when confidence is high
+- Thread progress is continuously read and used to defer/allow disable actions
+- Bug-escape categorization correlates where failure manifested vs where fix landed
+
+Non-goals for initial delivery:
+
+- public Slack channel rollout
+- broad multi-repo orchestration
+- bypassing repository protections/policies
+
+---
+
+## 2) Reader Profile And Operating Mode
+
+This spec assumes the executing model:
+
+- can read/write repository files
+- can run local scripts and git commands
+- can inspect workflow logs/artifacts
+- can perform iterative implementation + validation
+
+This spec does not assume prior knowledge of this repository.
+
+---
+
+## 3) Placeholder Contract (Portable Template)
+
+Use placeholders throughout implementation and map them per repository.
+
+Required placeholders:
+
+- `{{TRIAGE_WORKFLOW_PATH}}`
+- `{{TRIAGE_WORKFLOW_NAME}}`
+- `{{STATE_ARTIFACT_NAME}}`
+- `{{ACTIONS_ARTIFACT_NAME}}`
+- `{{SLACK_READ_CHANNEL_ID}}`
+- `{{SLACK_NOTIFY_CHANNEL_ID_TEST}}`
+- `{{DEFAULT_STALE_HOURS}}`
+- `{{DEFAULT_MAX_ACTIONS}}`
+- `{{AUTO_DISABLE_COMMAND_PATH}}`
+- `{{KICKOFF_COMMAND_PATH}}`
+- `{{REPO_SLUG}}`
+- `{{ISSUE_TRACKING_REPO_TEST}}`
+- `{{ISSUE_TRACKING_REPO_PROD}}`
+
+If values are unknown at runtime, agent must stop and request clarification before write actions.
+
+Slack ID hard constraint for current bootstrap:
+
+- use only `C0APK6215B5` for Slack reads and test notifications
+- do not use any other concrete Slack channel ID during this bootstrap phase
+
+---
+
+## 4) Preflight Contract (Hard Gate Before Any Writes)
+
+The agent must verify all of the following before enabling live writes:
+
+### 4.1 Environment/Access
+
+- `python3 tools/ci/guarded_gh.py --dry-run --command "gh auth status"` succeeds
+- repository write scopes are available for:
+  - contents
+  - pull requests
+  - actions/workflow dispatch
+- issue-tracking repository write scope is available for `{{ISSUE_TRACKING_REPO_TEST}}`
+- secrets are configured for:
+  - Slack read/export path
+  - Slack notify path (test channel only)
+  - agent API key (if required by CLI)
+
+### 4.2 Workflow Safety
+
+- workflow supports dry-run mode for auto-disable path
+- workflow supports data-gathering/read-only mode
+- test channel IDs are configured and validated
+- public-channel posting is disabled by default
+
+### 4.3 Kill Switches
+
+All of these must exist:
+
+- `auto-disable-dry-run`
+- max actions per run limit
+- max attempts per candidate limit
+- single-flag disable for Slack notify writes
+
+### 4.4 Command Execution Gateway (Hard Rule)
+
+- Direct `gh` execution is forbidden for automated GitHub actions.
+- Any automated GitHub command must be executed only via:
+  - `python3 tools/ci/guarded_gh.py --command "<gh command>"`
+- Commands rejected by `guarded_gh.py` must not be retried by bypassing the wrapper.
+- `guarded_gh.py` allowlist is the execution boundary for issue/pr/workflow operations.
+
+If any preflight check fails, agent must only produce a preflight report and no writes.
+
+---
+
+## 5) Non-Negotiable Invariants
+
+These invariants must always hold:
+
+1. One candidate key maps to at most one active disable PR.
+2. Malformed model output never triggers write actions.
+3. Completed candidates never re-enter active disable flow.
+4. Notifications are terminal-only (no per-attempt spam).
+5. Test-mode channels only until explicit promotion.
+6. State is source of truth; run-time behavior must reconcile state with live GitHub data.
+7. During testing, all automated issue writes must target `{{ISSUE_TRACKING_REPO_TEST}}` only.
+8. During bootstrap testing, both `{{SLACK_READ_CHANNEL_ID}}` and `{{SLACK_NOTIFY_CHANNEL_ID_TEST}}` must resolve to `C0APK6215B5`.
+9. Automated GitHub commands must be executed via `tools/ci/guarded_gh.py` only.
+10. Any new disable added to code must include a nearby non-closing issue reference comment linking the incident ticket.
+11. Token efficiency is a first-class constraint: minimize model calls and prompt size, prefer deterministic scripts for orchestration, and avoid repeated agent invocations when one structured pass is sufficient.
+
+Violation of any invariant is a release blocker.
+
+### 5.1 Token Efficiency Execution Rules
+
+To keep runtime cost bounded for both local implementation and CI:
+
+- default to deterministic Python/shell logic for control flow, validation, and formatting
+- call agent models only for tasks that require semantic judgment or code synthesis
+- prefer one batched agent decision over many per-item agent calls when output contracts allow
+- reuse cached decisions/state artifacts when inputs are unchanged
+- avoid passing large raw logs/threads inline when file-path based retrieval is available
+- if an additional agent call is not likely to change the decision quality, skip it and escalate deterministically
+
+---
+
+## 6) State Schema Contract
+
+Canonical state artifact path:
+
+- `build_ci/triage_state/ci_triage_state.json`
+
+Minimum schema:
+
+```json
+{
+  "version": 1,
+  "updated_at_utc": "string",
+  "items": [
+    {
+      "key": "slack_ts:<ts>",
+      "slack_ts": "string",
+      "issue_numbers": [12345],
+      "status": "new|planned|pr_open|kickoff_running|kickoff_failed_new_failure|completed|needs_human|paused",
+      "disable_pr": {
+        "number": 0,
+        "url": "string",
+        "branch": "string",
+        "head_sha": "string"
+      },
+      "attempts": 0,
+      "last_kickoff_runs": [
+        {"workflow": "string", "run_id": 0, "url": "string", "conclusion": "string"}
+      ],
+      "notification": {
+        "terminal_notified": false,
+        "last_error": ""
+      },
+      "terminal_reason": "",
+      "history": [
+        {"ts_utc": "string", "event": "string", "details": "string"}
+      ]
+    }
+  ]
+}
+```
+
+Schema rules:
+
+- `key` is unique and deterministic (default `slack_ts:<ts>`)
+- `attempts` is monotonic increasing
+- `history` append-only
+- unknown status values are invalid and must fail closed
+
+---
+
+## 7) Decision Tables (Deterministic Control Logic)
+
+## 7.1 Candidate Routing
+
+| Condition | Action | State Transition |
+|---|---|---|
+| `status in {completed, paused}` | skip | unchanged |
+| no state entry | create entry | `new -> planned` |
+| open PR exists for key | resume existing PR flow | `planned/pr_open -> pr_open` |
+| no PR + eligible candidate | create disable PR | `planned -> pr_open` |
+| malformed planner output | no write | `planned -> needs_human` |
+
+## 7.2 Existing PR Workflow Outcome
+
+| Workflow result | Action | State Transition |
+|---|---|---|
+| all required workflows pass | send terminal notify | `pr_open/kickoff_running -> completed` |
+| fail with known already-disabled target | bounded retry kickoff | `kickoff_running -> kickoff_running` |
+| first fail with new target | record candidate signature and rerun same PR workflows once | `pr_open/kickoff_running -> kickoff_failed_new_failure` |
+| second consecutive fail with same new-target signature | branch resume and incremental disable + issue justification update | `kickoff_failed_new_failure -> pr_open` |
+| second fail but signature mismatch/non-deterministic | do not extend disable PR; escalate for human review | `kickoff_failed_new_failure -> needs_human` |
+| dispatch/log fetch failure after retries | escalate | `* -> needs_human` |
+
+## 7.3 Notification Logic
+
+| Condition | Action |
+|---|---|
+| completed and not notified | send one Slack terminal message |
+| completed and notified | no-op |
+| non-terminal states | no Slack notification (unless explicitly enabled for diagnostics) |
+
+---
+
+## 8) Milestone Runbooks (Execution Contract Layer)
+
+Each milestone must include Inputs, Actions, Evidence, Go/No-Go gate, Rollback.
+
+## M0 - Baseline Verification
+
+Inputs:
+
+- current repo state
+- workflow dispatch access
+
+Actions:
+
+1. run data-gathering mode once
+2. run auto-disable dry-run twice
+
+Evidence:
+
+- artifacts exist for both modes
+- summary has single report section
+- dry-run outputs are deterministic
+
+Go/No-Go:
+
+- Go only if both dry-runs match expected shape and no write side effects
+
+Rollback:
+
+- set workflow to dry-run-only path and disable notify
+
+## M1 - State Persistence
+
+Inputs:
+
+- previous run state artifact (if present)
+
+Actions:
+
+1. download latest state artifact
+2. bootstrap if absent
+3. merge candidate updates
+4. upload new state artifact
+
+Evidence:
+
+- run N+1 sees previous state
+- no duplicate `key` entries
+
+Go/No-Go:
+
+- Go only if state survives across 2 consecutive runs
+
+Rollback:
+
+- revert to stateless mode but keep dry-run only
+
+## M2 - Duplicate Prevention
+
+Inputs:
+
+- state + open PR list
+
+Actions:
+
+1. enforce key-level idempotency
+2. enforce PR body marker check
+3. block second PR creation when active PR exists
+
+Evidence:
+
+- replay run creates zero extra PRs
+
+Go/No-Go:
+
+- Must pass replay test 3 times consecutively
+
+Rollback:
+
+- disable creation path; keep state reconciliation only
+
+## M3 - Resume Existing PR Branch
+
+Inputs:
+
+- existing disable PR with failing workflows
+
+Actions:
+
+1. checkout existing PR branch
+2. identify new failing target and compute deterministic failure signature
+3. run required PR-branch workflows again for confirmation
+4. only if same new failure signature repeats twice, apply incremental disable
+5. push to same PR
+6. update linked issue with explicit disable justification (new target + signatures + run URLs)
+7. rerun kickoff workflows
+8. append attempt history
+
+Evidence:
+
+- no second PR
+- same PR updated with new commit
+- issue comment/body updated with clear "why this additional disable was added" justification
+- kickoff reruns linked in summary/state
+- no incremental disable edit occurs when second failure is non-deterministic/mismatched
+
+Go/No-Go:
+
+- Must pass one controlled scenario end-to-end
+
+Rollback:
+
+- lock candidate to `needs_human` and halt auto-extension
+
+## M4 - Failure Ingestion + Correlation + New-Issue Slack Notify
+
+Inputs:
+
+- aggregate workflow data snapshots
+- existing state entries with Slack/issue linkage
+- `extract_failing_jobs.py` output for jobs failing 3 runs in a row
+
+Actions:
+
+1. ingest new failures from aggregate workflow data
+2. compute deterministic `failure_fingerprint`
+3. correlate fingerprint to existing issue/PR/Slack state items
+4. create new issues for unmatched high-confidence fingerprints in `{{ISSUE_TRACKING_REPO_TEST}}`
+5. send initial Slack lifecycle notification/thread anchor for each newly created issue
+6. create or refresh state entries for unmatched fingerprints (fail closed on low confidence)
+
+Evidence:
+
+- new fingerprints appear in state/action artifacts with source links
+- each newly created issue has a corresponding initial Slack lifecycle notification
+- replay run does not duplicate previously seen fingerprints
+- low-confidence fingerprints are suppressed/escalated without writes
+
+Go/No-Go:
+
+- Must pass one controlled ingestion scenario with deterministic replay
+- Must prove issue-create + Slack-initial-notify occurs exactly once per new fingerprint
+
+Rollback:
+
+- disable ingestion issue/slack writes; keep read-only ingest report artifacts
+
+## M5 - Ticket Lifecycle + Terminal Notify
+
+Inputs:
+
+- correlated fingerprints from M4
+- issue/PR state for `{{ISSUE_TRACKING_REPO_TEST}}`
+- Slack thread replies + latest owner responses for each active fingerprint
+
+Actions:
+
+1. run action selector for each active fingerprint (`draft_fix_pr`, `draft_disable_pr`, `refresh_validation`, `observe_only`)
+2. create/update issues for active fingerprints (enforce `CI auto triage` label)
+3. close solved issues when objective pass window is met
+4. create a new issue when a previously closed fingerprint recurs
+5. post/update Slack thread lifecycle messages for existing incidents
+6. consume thread replies as control signals; if owner confirms imminent fix, prefer `observe_only`/defer and suppress disable PR creation
+7. send follow-up lifecycle messages with anti-spam gates:
+   - warning at +24h: "disable will be proposed if unresolved by SLA"
+   - optional final warning near disable threshold
+   - post-disable follow-up ping to the assigned owner with re-enable expectations
+8. if disable PR merges, ensure issue assignee is set/updated and persist assignment rationale in state history
+9. when developer thread/issue request indicates "agent can attempt fix", allow `draft_fix_pr` path under small-fix gates
+10. on completion, mark state `completed`, send one terminal Slack message, set `terminal_notified=true`
+
+Evidence:
+
+- issue create/update/close events recorded in history
+- closed-then-recurred fingerprint creates a new issue linked as recurrence
+- controlled scenario shows `draft_fix_pr` chosen for high-confidence small fix
+- controlled scenario shows `draft_disable_pr` chosen after SLA breach
+- controlled scenario shows owner-confirmed thread reply switches action to defer/`observe_only` with no new disable PR
+- warning lifecycle messages appear exactly once per phase unless state materially changes
+- post-disable follow-up message includes owner ping and issue/PR linkage
+- assignment is present (or explicitly pending with reason) after disable merge
+- one terminal Slack message per completed key
+
+Go/No-Go:
+
+- Must pass end-to-end lifecycle scenarios for fix path, disable path, and owner-confirmed defer path
+
+Rollback:
+
+- stop issue write actions and Slack terminal notifications; keep state reconciliation only
+
+## M6 - Bug Escape Attribution
+
+Inputs:
+
+- resolved item state + fix PR/commit metadata
+
+Actions:
+
+1. map issue -> fix commit/PR
+2. infer problem surface (where failure manifested) from failing test/job metadata
+3. infer fix surface (where fix landed) from fix PR files/labels/paths
+4. correlate problem surface vs fix surface with explicit method + confidence
+5. classify escape type and shift-left recommendation target
+6. append bug escape event
+
+Evidence:
+
+- `bug_escape_events.json` updated
+- rollup summary includes counts, examples, and confidence bands
+- sample events include explicit problem-surface/fix-surface rationale
+
+Go/No-Go:
+
+- sample set must show traceable issue->fix mapping
+
+Rollback:
+
+- keep disable loop active; suspend attribution writes
+
+---
+
+## 9) Failure Recovery Matrix
+
+| Failure Mode | Detect Signal | Retry Policy | Escalation Condition | Escalation Action |
+|---|---|---|---|---|
+| artifact download missing | artifact fetch 404 | 0 retries | immediate | bootstrap new state + warning |
+| malformed model output | missing marker / JSON parse fail | 0 retries | immediate | fail closed, mark `needs_human` |
+| PR create failure | gh non-zero | 2 retries with backoff | still failing | set `needs_human`, persist error |
+| kickoff dispatch failure | no run IDs / gh error | 3 retries | still failing | set `needs_human` |
+| workflow logs unavailable | API/log fetch errors | 3 retries | still failing | keep state, defer next run |
+| push rejected | non-fast-forward/policy | 1 rebase attempt | policy block persists | set `needs_human` |
+| Slack notify failure | Slack API non-ok | retry next run until success | >N configurable retries | keep completed, mark notify pending |
+
+---
+
+## 10) Acceptance Test Matrix (Portable + Repo Example)
+
+| Test ID | Scenario | Mode | Expected Result |
+|---|---|---|---|
+| A1 | no prior state | dry-run | state bootstraps, no writes |
+| A2 | prior state with open PR | dry-run | no duplicate PR planned |
+| A3 | completed item replay | dry-run | skipped with explicit reason |
+| A4 | malformed planner output | dry-run/live | no writes, `needs_human` |
+| A5 | first live candidate | live test | one draft PR + kickoff runs |
+| A6 | unchanged replay | live test | zero new PRs |
+| A7 | new failure on existing PR | live test | same PR updated |
+| A8 | aggregate failure ingestion replay | live test | deterministic fingerprint intake with no duplicate inserts |
+| A9 | new fingerprint issue+Slack bootstrap | live test | new issue created and initial Slack lifecycle message posted exactly once |
+| A10 | ticket lifecycle update/close | live test | issue lifecycle transitions recorded and label policy enforced |
+| A11 | recurrence new-issue check | live test | previously closed fingerprint creates a new linked issue |
+| A12 | action selector fix-vs-disable | live test | selector chooses fix for high-confidence small change and disable for SLA breach |
+| A13 | owner-confirmed defer path | live test | thread reply drives `observe_only`/defer and blocks disable PR |
+| A14 | successful terminal run | live test | completed + one Slack notify |
+| A15 | bug escape attribution | live test | issue->fix mapping recorded |
+| A16 | data-gathering regression check | live test | report behavior unchanged |
+| A17 | thread persona simulation (progress) | live test | "working on it"/"PR soon" style replies defer disable path |
+| A18 | thread persona simulation (blocked/stale) | live test | blocked then stale replies still progress to warning/disable policy |
+| A19 | thread persona simulation (fixed signal) | live test | "fixed" + PR link updates state to verify/resolve path |
+| A20 | thread persona simulation (conflict/noise) | live test | conflicting/vague replies fail safe (observe or escalate), no unsafe disable |
+| A21 | thread persona anti-spam gate | live test | no duplicate phase messages unless state materially changes |
+| A22 | existing PR new-target failure determinism gate | live test | second matching failure required before incremental disable edit |
+| A23 | existing PR new-target issue justification update | live test | when incremental disable happens, linked issue is updated with clear justification and run links |
+
+Minimum promotion threshold:
+
+- A1-A16 pass
+- A1-A23 pass
+- A6 passes 3 consecutive runs
+- no invariant violations
+
+---
+
+## 11) Minimal-Oversight Operator Checkpoints
+
+Use this schedule for overnight or low-touch execution:
+
+- T0: preflight contract pass and kill-switch confirmation
+- T+30m: M0 evidence review
+- T+90m: first live PR and kickoff validation
+- T+3h: replay/no-duplicate validation
+- T+6h: resume-existing-PR validation
+- T+6h: failure-ingestion and correlation validation
+- T+8h: ticket lifecycle (create/update/close + recurrence new-issue) validation
+- T+end: completed-state + notify + bug-escape evidence
+
+At any failed checkpoint:
+
+- freeze promotion
+- force dry-run
+- execute rollback path for current milestone
+
+Bootstrap-specific check:
+
+- verify workflow/default config reads only from `C0APK6215B5`
+- verify notification path posts only to `C0APK6215B5`
+
+---
+
+## 12) Fresh-Agent Bootstrap Prompt (Copy/Paste)
+
+Use this prompt with a fresh agent:
+
+```text
+You are a fresh execution agent for CI triage autonomy.
+Repository root: {{REPO_ROOT}}.
+
+Primary spec to follow exactly:
+tools/ci/ci-triage-autonomy-agent-planning.md
+
+Rules:
+1) Enforce all non-negotiable invariants in the spec.
+2) Run preflight contract first. If any hard gate fails, stop and report only.
+3) Execute milestones in order M0 -> M6.
+4) Do not skip Go/No-Go gates.
+5) Fail closed on malformed LLM output or schema mismatches.
+6) Use placeholders from the spec and map to repo values via Appendix A.
+7) Use test-only Slack channels and dry-run first.
+8) Preserve state as source of truth and reconcile against live PR/workflow data each run.
+9) Produce evidence artifacts and checkpoint report at each milestone.
+10) If blocked, output exact blocker and proposed minimal fix.
+11) Never run `gh` directly for automation; route all automated GitHub commands through `python3 tools/ci/guarded_gh.py`.
+
+Start now with:
+- Read spec
+- Generate preflight report
+- Propose M0 execution steps
+```
+
+---
+
+## 13) Zero-Context Dry-Run Simulation Walkthrough
+
+This section proves a fresh agent can start from zero context.
+
+Step 1:
+
+- read this spec
+- resolve placeholders from Appendix A
+
+Step 2:
+
+- execute preflight contract
+- if any requirement missing, output blocking report and stop
+
+Step 3:
+
+- run M0 only in dry-run mode
+- generate checkpoint evidence:
+  - artifact presence
+  - summary integrity
+  - deterministic output comparison
+
+Step 4:
+
+- if M0 passes, continue to M1 in dry-run mode first
+- perform replay run to validate idempotency logic before live writes
+
+Step 5:
+
+- only after M2 pass criteria, enable limited live run (`max_actions=1`)
+
+Expected outputs for this walkthrough:
+
+- preflight report markdown
+- milestone status table
+- evidence artifact index
+- explicit next action recommendation
+
+---
+
+## 14) Commit-History Discovery Requirement
+
+A fresh agent must inspect recent commits before major edits to avoid reintroducing removed logic.
+
+Required checks:
+
+- recent commit messages around `{{TRIAGE_WORKFLOW_PATH}}`
+- diff history for triage scripts/actions
+- identification of previously failed approaches
+
+If unclear why a behavior exists, agent must document assumption and continue with reversible changes.
+
+---
+
+## 15) Rollback Protocol
+
+If instability or invariant breach is detected:
+
+1. force `auto-disable-dry-run=true`
+2. disable live Slack notifications
+3. stop PR create/update writes
+4. continue state read + observability artifacts
+5. revert only latest milestone changes
+6. rerun M0 to verify recovery baseline
+
+---
+
+## 16) Definition Of Ready / Done
+
+Definition of ready (before live writes):
+
+- preflight pass
+- placeholders mapped
+- dry-run checkpoints M0-M2 pass
+- issue-routing confirmed to `{{ISSUE_TRACKING_REPO_TEST}}`
+
+Definition of done:
+
+- repeated runs converge with no duplicate PRs
+- existing PR resume/extend path proven
+- terminal completion emits exactly one notification
+- bug escape events map issue->fix commit/PR with classification
+- data-gathering mode remains non-regressed
+- aggregate-data intake, ticket create/update/close, Slack lifecycle, and escalation loops are all validated end-to-end
+
+---
+
+## Appendix A: Example Placeholder Mapping For This Repository
+
+Use these as examples; do not hardcode in portable implementations.
+
+- `{{TRIAGE_WORKFLOW_PATH}}` -> `.github/workflows/triage-ci.yaml`
+- `{{TRIAGE_WORKFLOW_NAME}}` -> `(triage) Export Evan Slack threads`
+- `{{STATE_ARTIFACT_NAME}}` -> `triage-state` (recommended)
+- `{{ACTIONS_ARTIFACT_NAME}}` -> `triage-actions` (recommended)
+- `{{SLACK_READ_CHANNEL_ID}}` -> `C0APK6215B5`
+- `{{SLACK_NOTIFY_CHANNEL_ID_TEST}}` -> `C0APK6215B5`
+- `{{DEFAULT_STALE_HOURS}}` -> `32`
+- `{{DEFAULT_MAX_ACTIONS}}` -> `3`
+- `{{AUTO_DISABLE_COMMAND_PATH}}` -> `.cursor/commands/ci/ci-disable-test-ci.md`
+- `{{KICKOFF_COMMAND_PATH}}` -> `.cursor/commands/ci/ci-kickoff-workflows.md`
+- `{{REPO_SLUG}}` -> `tenstorrent/tt-metal`
+- `{{ISSUE_TRACKING_REPO_TEST}}` -> `ebanerjeeTT/issue_dump`
+- `{{ISSUE_TRACKING_REPO_PROD}}` -> `tenstorrent/tt-metal`
+
+---
+
+## Appendix B: Required Evidence Bundle Per Milestone
+
+For each milestone, the agent must produce:
+
+- run summary section with pass/fail gate
+- artifact list with paths
+- key decision log (state transitions)
+- rollback command set for the exact milestone
+
+---
+
+## 17) Full CI Maintenance Feature Set (Expanded Scope)
+
+This section upgrades the system from "auto-disable loop" to full CI maintenance automation.
+
+Feature domains:
+
+1. Failure ingestion from aggregate workflow data
+2. Ticket lifecycle automation
+3. Slack lifecycle automation
+4. Disable-vs-fix action selection
+5. Assignment and escalation automation
+6. Continuous follow-up after disable
+7. Testing strategy with synthetic scenarios/mocks
+
+All domains must integrate into one state machine with shared keys and audit history.
+
+---
+
+## 18) Failure Ingestion Contract (Aggregate Workflow Data)
+
+Primary intake source:
+
+- aggregate workflow data runs (latest successful and recent failed runs)
+- `extract_failing_jobs.py` output used to identify jobs failing 3 times consecutively
+
+Deterministic failure definition (hard):
+
+- a failure is deterministic only when the same job fails 3 runs in a row
+- the failure signature/message across those 3 runs is semantically identical
+- for `.github/workflows/triage-ci.yaml`, signature equivalence is determined by Cursor CLI agent analysis (not simple string matching only)
+
+Intake requirements:
+
+- pull new failure clusters since last processed cursor timestamp
+- normalize each failure into a deterministic `failure_fingerprint`
+- map each fingerprint to existing issue(s), PR(s), and prior state item(s)
+- deduplicate across retried runs and mirrored workflow names
+
+Minimum normalized fields per failure:
+
+```json
+{
+  "failure_fingerprint": "string",
+  "workflow_name": "string",
+  "workflow_run_id": 0,
+  "job_name": "string",
+  "test_target": "string",
+  "first_seen_utc": "string",
+  "last_seen_utc": "string",
+  "signal_strength": "high|medium|low",
+  "source_links": []
+}
+```
+
+Hard rules:
+
+- no ticket creation without a stable fingerprint
+- no action if fingerprint confidence is low and no corroborating evidence exists
+- every downstream action must reference fingerprint + source links
+- do not treat "3 failures in a row" as deterministic unless Cursor agent confirms equivalent failure signature
+- when Cursor signature-equivalence result is uncertain, classify as low confidence and do not write
+
+---
+
+## 19) Ticket Lifecycle Automation Contract
+
+Ticket states:
+
+- `new_candidate`
+- `open_active`
+- `open_waiting_on_owner`
+- `open_disabled_temporarily`
+- `resolved_pending_verification`
+- `closed_resolved`
+- `closed_obsolete`
+
+Issue repository routing rule:
+
+- test/staging: create/update/close issues only in `{{ISSUE_TRACKING_REPO_TEST}}`; recurrence creates a new issue
+- production: use `{{ISSUE_TRACKING_REPO_PROD}}` only after explicit promotion gate
+- pre-promotion writes to production issue repo are forbidden
+
+### 19.1 Create
+
+Create a ticket when:
+
+- fingerprint is persistent (above configurable repeat threshold)
+- no active ticket already linked to same fingerprint
+
+Labeling requirement (hard rule):
+
+- every issue created by this new system must include label `CI auto triage`
+- this system must not apply or rely on label `glean CI maintenance`
+
+Ticket body must include:
+
+- source runs/jobs links
+- failing target fingerprint
+- owner/team hint
+- initial remediation recommendation
+- non-closing references to related work
+
+### 19.2 Update
+
+Periodic update cadence:
+
+- each triage cycle or bounded interval
+
+Update fields:
+
+- fresh run links
+- current status summary
+- latest owner response state
+- open PR links (disable/fix)
+
+### 19.3 Close
+
+Close when either:
+
+1. objective resolved condition met (stable pass window), or
+2. superseded/invalid signal with rationale
+
+Close operation must capture:
+
+- resolving PR/commit linkage
+- resolution evidence window
+- bug-escape classification placeholder (for later enrichment if not available yet)
+
+Labeling requirement on close/update:
+
+- issue label `CI auto triage` must remain present when closing/updating
+- if an issue lacks `CI auto triage`, add it before automated close/update actions
+- never auto-close or auto-update issues that are only labeled `glean CI maintenance` and not `CI auto triage`
+
+### 19.4 Recurrence After Close
+
+If the same fingerprint recurs after close beyond hysteresis threshold, create a new issue instead of reopening the closed issue.
+
+---
+
+## 20) Slack Lifecycle Contract
+
+Slack domains:
+
+- read channel(s) for triage signals
+- notify channel(s) for agent actions
+- optional owner-specific follow-up threads
+
+Slack capabilities:
+
+1. read latest relevant thread context
+2. post/update triage status message
+3. post disable/fix PR links
+4. post completion/escalation notices
+
+Message policy:
+
+- concise, factual, action-oriented
+- include direct links to ticket, PR, workflow runs
+- avoid repeated spam by message keying (`fingerprint + phase + day`)
+
+Thread policy:
+
+- one anchor message per fingerprint lifecycle
+- updates stay in thread unless escalation requires separate visibility
+
+---
+
+## 21) Action Selector Contract (Disable vs Fix vs Observe)
+
+Action options:
+
+- `observe_only`
+- `create_or_update_ticket`
+- `draft_disable_pr`
+- `draft_fix_pr`
+- `kickoff_targeted_workflows`
+- `notify_owner`
+- `escalate`
+
+Selection inputs:
+
+- failure stability
+- blast radius
+- fix complexity estimate
+- prior attempts count
+- owner responsiveness
+
+### 21.1 Disable Path
+
+Prefer disable when:
+
+- severe CI blockage + no quick deterministic fix
+- repeated failures crossing stale threshold
+
+### 21.2 Fix Path
+
+Allow small fix PR drafting only when:
+
+- likely fix is scoped and high-confidence
+- affected files/area are limited
+- tests to validate fix are known and runnable
+
+Fix PRs must be draft by default unless policy allows direct ready-for-review.
+
+### 21.3 Observe Path
+
+Use observe-only when:
+
+- evidence is ambiguous
+- signal is too fresh/noisy
+- previous action is still pending verification
+
+---
+
+## 22) Assignment, Follow-Up, And Escalation Contract
+
+### 22.1 Auto-Assignment
+
+Assignment sources (in priority order):
+
+1. existing ticket owner
+2. relevant-file commit history (recent commits on failure-linked paths)
+3. CODEOWNERS/service ownership map
+4. workflow/job owner hints (including `owners.json` reference signals)
+5. fallback on-call rotation
+
+Assignment rules:
+
+- max 3 owner mentions in any single Slack message
+- prefer owners with strongest multi-signal overlap (commit history + CODEOWNERS + job owner + thread participation)
+- ignore team/group handles for direct mention unless policy explicitly allows
+
+### 22.2 Follow-Up
+
+Follow-up runs independently from disable/fix status.
+
+Even after disable:
+
+- continue ping cadence until root cause is fixed or accepted as deferred with explicit owner approval
+
+Follow-up schedule (example):
+
+- initial assignment ping
+- reminder at +24h with disable warning
+- optional pre-disable warning near threshold (e.g., +40h for +48h disable SLA)
+- post-disable reminder ping to assigned owner until root-cause fix lands
+
+### 22.3 Escalation
+
+Escalate when:
+
+- no owner acknowledgment after threshold
+- no progress updates after threshold
+- repeated disable extensions without root-cause trajectory
+
+Escalation targets:
+
+- owner manager/lead channel (configured mapping required)
+
+Escalation safeguards:
+
+- require at least one prior reminder
+- include concise evidence packet
+- limit escalation frequency per fingerprint
+
+### 22.4 Disable Delay / Proceed Decision Contract
+
+Delay disable when any high-confidence progress signal is present:
+
+- linked fix PR is open and actively updated
+- owner replied recently with concrete ETA/plan
+- recent commits on relevant files indicate active fix work
+
+Proceed with disable when:
+
+- SLA threshold exceeded and no high-confidence progress
+- thread activity is stale/non-substantive
+- no active fix PR or equivalent owner-confirmed trajectory
+
+---
+
+## 23) Post-Disable Continuous Control Loop
+
+After a test is disabled, the loop must continue:
+
+1. monitor whether underlying issue is being worked
+2. continue owner reminders/escalation cadence
+3. detect when true fix PR appears
+4. link fix PR/commit to ticket and bug-escape records
+5. recommend/perform re-enable path when confidence is sufficient
+
+Re-enable gate (minimum):
+
+- sustained pass window on relevant workflows
+- owner acknowledgment or policy-approved auto-reenable
+- no conflicting active incidents for same target
+
+---
+
+## 24) Bug Escape Enrichment Contract (Full)
+
+Bug-escape enrichment runs after resolution events and may be backfilled.
+
+Required record fields:
+
+```json
+{
+  "fingerprint": "string",
+  "issue_number": 0,
+  "disable_pr_number": 0,
+  "fix_pr_number": 0,
+  "fix_commit_sha": "string",
+  "problem_surface": {
+    "layer": "llk|metalium|ttnn|models|infra|unknown",
+    "component": "string",
+    "source": "failing_job|stack_trace|test_path|agent_inference"
+  },
+  "fix_surface": {
+    "layer": "llk|metalium|ttnn|models|infra|unknown",
+    "component": "string",
+    "source": "changed_files|pr_labels|commit_message|agent_inference"
+  },
+  "failure_layer": "llk|metalium|ttnn|models|unknown",
+  "fix_layer": "llk|metalium|ttnn|models|unknown",
+  "correlation_method": "path_overlap|ownership_overlap|semantic_match|mixed",
+  "correlation_confidence": "low|medium|high",
+  "escape_type": "gate_coverage_gap|layer_escape_lower_to_higher|unknown",
+  "shift_left_target": "pr_gate|merge_gate|lower_layer_suite|owner_alerting|unknown",
+  "explanation": "string",
+  "captured_at_utc": "string"
+}
+```
+
+Interpretation requirements:
+
+- include "why classified this way" text
+- include shift-left recommendation candidate
+- include explicit evidence for both problem surface and fix surface
+- include confidence rule:
+  - high: deterministic path/component match or repeated historical correlation
+  - medium: partial overlap with supporting context
+  - low: weak/ambiguous signals (must be called out explicitly)
+- never block ticket close if enrichment temporarily unavailable; mark pending and retry
+
+---
+
+## 25) Expanded Test Strategy For Sparse Real-World Scenarios
+
+Real pipelines may not naturally produce all permutations. A synthetic test harness is required.
+
+### 25.1 Scenario Fixture Packs
+
+Create fixture packs for:
+
+- no stale Slack messages
+- stale Slack with open issue
+- stale Slack with closed issue
+- no existing ticket + persistent fingerprint
+- existing open ticket + no owner response
+- disable PR exists + same failure persists
+- disable PR exists + new failure appears
+- fix PR appears and resolves failure
+- false positive/noisy transient
+- thread shows active progress and disable should be deferred
+- thread stale with no owner response and disable should proceed
+- post-disable state where owner follow-up continues until fix merge
+- developer explicitly requests agent-authored small fix PR
+
+### 25.2 Mock/Replay Sources
+
+Mock inputs should include:
+
+- aggregate workflow data snapshots
+- Slack export JSON snapshots
+- issue/PR metadata snapshots
+- workflow run conclusions
+
+### 25.3 Permutation Matrix
+
+Must cover at least these cross products:
+
+- issue state (`none/open/closed`) x failure persistence (`new/stable/flaky`)
+- owner state (`unassigned/assigned/unresponsive/responding`)
+- action state (`none/disable/fix`) x verification state (`pending/pass/fail`)
+- thread progress (`none/investigating/fix_in_progress/blocked`) x disable decision (`defer/proceed`)
+- bug-escape mapping confidence (`low/medium/high`) x classification correctness (`expected/unexpected`)
+
+### 25.4 Test Gates
+
+Before production rollout:
+
+- all fixture packs pass deterministically in dry-run
+- at least one controlled live run per major lifecycle branch
+- escalation and notification suppression rules verified
+
+### 25.5 Thread Persona Simulation Tests (Required)
+
+Goal:
+
+- verify the triage loop can correctly interpret realistic developer responses in Slack threads, not just static fixture labels
+
+Execution mode:
+
+- run only in testing mode and only in `C0APK6215B5`
+- use bot-authored synthetic replies that emulate developer language patterns
+- never impersonate real users; messages must be clearly marked as simulation
+
+Required simulated persona reply types:
+
+1. active owner with concrete plan
+   - example: "Looking now, I will post PR in 2 hours."
+2. active owner with linked WIP PR
+   - example: "Fix in progress: <PR link>."
+3. blocked owner
+   - example: "Blocked on infra/hardware dependency."
+4. resolved claim with evidence
+   - example: "Should be fixed by <PR link>; please verify."
+5. vague/noise reply
+   - example: "Taking a look."
+6. conflicting replies from multiple participants
+   - one says "fixed", another says "still failing"
+
+Expected control-loop behavior:
+
+- active plan / WIP PR -> defer disable and schedule follow-up verification
+- blocked + stale -> continue reminder cadence, then proceed per SLA disable policy
+- resolved claim + PR link -> transition to verification path before closure
+- vague/noise only -> remain observe/escalate, do not falsely treat as progress
+- conflicting signals -> fail safe (observe/escalate) until objective evidence resolves conflict
+
+Timing variants that must be tested:
+
+- fresh progress reply within hold window
+- stale progress reply older than hold window
+- no new reply across 24h and 48h thresholds
+
+Assertions:
+
+- decision rationale records which thread message(s) influenced action
+- no duplicate warning/follow-up message for same phase without state change
+- no disable PR created while a high-confidence progress hold is active
+- assignment can be updated if thread evidence indicates a different active owner
+- all simulation artifacts are persisted for replay/debug
+
+---
+
+## 26) End-To-End State Machine (Unified)
+
+```mermaid
+flowchart TD
+    ingest[IngestAggregateFailures]
+    normalize[NormalizeFingerprint]
+    correlate[CorrelateIssuePRSlackState]
+    choose{SelectAction}
+    ticket[CreateOrUpdateTicket]
+    disable[DraftOrExtendDisablePR]
+    fix[DraftSmallFixPR]
+    kickoff[KickoffTargetedWorkflows]
+    verify{VerifyOutcome}
+    close[CloseOrReopenTicket]
+    notify[NotifyOrEscalate]
+    enrich[RecordBugEscapeAttribution]
+    loopback[NextTriageCycle]
+
+    ingest --> normalize --> correlate --> choose
+    choose --> ticket
+    choose --> disable
+    choose --> fix
+    disable --> kickoff --> verify
+    fix --> kickoff --> verify
+    ticket --> notify --> loopback
+    verify -->|pass| close --> enrich --> notify --> loopback
+    verify -->|fail_new_target| disable
+    verify -->|fail_ambiguous| ticket
+```
+
+---
+
+## 27) Fresh-Agent Validation Checklist For Full Feature Set
+
+A fresh agent must explicitly confirm all "yes" before claiming completion:
+
+- Aggregate failure ingestion implemented and tested
+- Ticket create/update/close and recurrence-new-issue behavior implemented and tested
+- Ticket label policy enforced (`CI auto triage` only; no overlap with `glean CI maintenance`)
+- Slack read/post/update thread lifecycle implemented and tested in test channels
+- Disable and small-fix selection logic implemented and tested
+- Assignment/follow-up/escalation loops implemented and tested
+- Post-disable continuity behavior implemented and tested
+- Bug-escape enrichment (issue->fix commit mapping) implemented and tested
+- Thread-progress-aware disable delay/proceed logic implemented and tested
+- Follow-up warning and post-disable owner ping lifecycle implemented and tested
+- Issue assignment after disable merge implemented and tested
+- Bug-escape problem-surface vs fix-surface correlation with confidence implemented and tested
+- Synthetic fixture/permutation suite implemented and passing
+
+Any "no" means not done.

--- a/tools/ci/ci-triage-autonomy-roadmap.md
+++ b/tools/ci/ci-triage-autonomy-roadmap.md
@@ -1,0 +1,535 @@
+# CI Triage Autonomy Roadmap
+
+## Context And Starting Point
+
+- Last pushed commit baseline: `35e66b7b72656a06eaeb9bec0f8cfd0dc5aae813`
+- Current branch has new automation scaffolding but has not been validated end-to-end.
+- Existing workflow path in `.github/workflows/triage-ci.yaml` already supports:
+  - Slack export and issue-closure enrichment
+  - Data gathering mode report generation
+  - Auto-disable mode entrypoint + artifacts
+
+This document lays out an implementation and testing plan to safely reach the end state:
+
+1. Fully autonomous repeated triage runs
+2. No duplicate disable PRs
+3. Resume/update prior disable PRs when new failures appear
+4. Terminal completion notification
+5. Post-facto bug-escape tracking tied to fixing commits
+6. Full ticket + Slack lifecycle automation with human approval boundary only at PR review/merge
+
+---
+
+## End-State Goals
+
+### A) Autonomous CI Maintenance Loop
+
+When triage runs repeatedly:
+
+- It should ingest deterministic failures from aggregate workflow data.
+- It should create/update/close tracking issues automatically in test repo pre-promotion, and create a new issue on recurrence.
+- It should post/update Slack lifecycle messages (and thread replies) without human intervention.
+- It should not create duplicate disable PRs for the same failure fingerprint.
+- It should continue working on an existing disable PR branch if checks fail due to additional failures.
+- It should re-kickoff targeted workflows after each incremental disable/fix action.
+- It should stop only at configured terminal states and emit one terminal notification.
+
+### B) Persistent Cross-Run Memory
+
+Each run should read prior run state and write updated state:
+
+- attempted actions
+- PR links and branch names
+- workflow run outcomes
+- terminal status (`completed`, `needs_followup`, `paused`, etc.)
+- owner follow-up/escalation metadata
+- issue lifecycle metadata (open/updated/closed + recurrence-linked new issue)
+- Slack lifecycle metadata (anchor message/thread update keys)
+
+### C) Human Approval Boundary
+
+Human involvement should be limited to review/merge boundaries:
+
+- automation drafts PRs and runs validations
+- automation keeps iterating while confidence below threshold
+- automation requests review only when PR readiness threshold is met
+- humans approve/merge or request changes; all other loop steps remain autonomous
+
+### D) Bug-Escape Attribution Store
+
+After resolution, capture:
+
+- which commit/PR fixed the issue
+- affected layer and fixing layer
+- whether this looks like:
+  - missing gate coverage (pr-gate/merge-gate shift-left gap)
+  - lower-layer regression escaping into higher-layer tests (example: llk/metalium change causing ttnn/models failure)
+
+This tracking is analytical/post-facto and should not block disable automation.
+
+---
+
+## Architecture Plan
+
+## 0) Trigger + Ingestion Layer
+
+Cycle starts from schedule/event triggers:
+
+- cron tick
+- workflow completion event
+- optional Slack/issue comment events
+
+Data ingestion pulls:
+
+- aggregate workflow failure clusters (`extract_failing_jobs.py`-style fingerprints)
+- latest Slack channel/thread context exports
+- current issue/PR state snapshots
+
+Hard rule: all downstream actions must reference deterministic failure fingerprint + evidence links.
+
+## 1) State Model (Single Source Of Truth)
+
+Create `build_ci/triage_state/ci_triage_state.json` artifact schema:
+
+```json
+{
+  "version": 1,
+  "updated_at_utc": "2026-03-26T00:00:00Z",
+  "items": [
+    {
+      "key": "fingerprint:<deterministic-id>",
+      "slack_ts": "1773931010.433769",
+      "failure_fingerprint": "workflow/job/test/signal hash",
+      "issue_numbers": [40111],
+      "status": "pr_open",
+      "ticket": {
+        "repo": "ebanerjeeTT/issue_dump",
+        "number": 0,
+        "url": ""
+      },
+      "slack": {
+        "channel_id": "C0APK6215B5",
+        "anchor_ts": "",
+        "last_thread_update_ts": ""
+      },
+      "disable_pr": {
+        "number": 0,
+        "url": "",
+        "branch": "",
+        "head_sha": ""
+      },
+      "attempts": 1,
+      "last_kickoff_runs": [],
+      "owner_state": "unassigned|assigned|responding|unresponsive",
+      "terminal_reason": "",
+      "history": []
+    }
+  ]
+}
+```
+
+Status enum:
+
+- `new`
+- `planned`
+- `pr_open`
+- `kickoff_running`
+- `kickoff_failed_new_failure`
+- `completed`
+- `needs_human`
+- `paused`
+
+Why this matters: state should drive decisions, not ad hoc scraping.
+
+---
+
+## 2) Controller Loop Behavior Per Run
+
+For each candidate/fingerprint:
+
+1. Load/reconcile state entry (or create new)
+2. Ensure ticket lifecycle state is current (create/update/close, and open a new issue on recurrence)
+3. Ensure Slack lifecycle state is current (anchor + threaded updates)
+4. Run action selector:
+   - small fix path
+   - disable path (SLA breach / blocker)
+   - stale validation refresh path
+   - observe-only path
+5. If `pr_open`:
+   - inspect latest workflow outcomes for that PR branch
+   - if passed: mark `completed`, send terminal notify
+   - if failed with new target: update same branch + commit + rerun kickoff
+6. If no PR exists and action is disable/fix:
+   - create draft PR
+   - kickoff targeted workflows
+   - set status to `kickoff_running`
+7. If readiness threshold met:
+   - request human review/approval
+8. After merge/decision:
+   - post-decision cleanup (ticket/slack updates, re-enable follow-up, reassignment/escalation)
+
+Apply hard limits:
+
+- max edits per item per run
+- max cumulative attempts before `needs_human`
+
+---
+
+## 3) Artifact Strategy
+
+Use two artifacts per run:
+
+- `triage-state`:
+  - `ci_triage_state.json`
+- `triage-actions`:
+  - planned actions
+  - execution results
+  - summary markdown
+  - action-selector trace (why fix vs disable vs refresh)
+  - ticket/slack lifecycle mutations
+
+At start of each run:
+
+- download the most recent successful `triage-state` artifact from this workflow
+- if absent, bootstrap new state
+
+At end of each run:
+
+- upload new state artifact
+- append compact changelog into run summary
+
+---
+
+## 4) Duplicate Prevention Rules
+
+Use multiple keys to avoid repeated PR creation:
+
+- primary idempotency key: failure fingerprint
+- secondary linkage: issue number set + channel id
+- PR body marker: `Auto-disable-source-ts: <ts>`
+
+Before creating a new PR:
+
+- check state entry status
+- check open PRs with marker
+- check closed PR history linked to same key
+
+If any active PR exists, resume that PR instead of opening another.
+
+---
+
+## 5) Ticket Lifecycle Automation
+
+For each stable failure fingerprint:
+
+1. create issue if none exists
+2. update issue with fresh evidence and state transitions every triage cycle
+3. close when objective pass window met (or obsolete with rationale)
+4. create a new linked issue on recurrence beyond hysteresis threshold
+5. enforce label policy: `CI auto triage`
+
+Pre-promotion routing:
+
+- issue create/update/close only in `ebanerjeeTT/issue_dump`; recurrence creates a new issue in the same repo
+
+## 6) Slack Lifecycle Automation
+
+For each active fingerprint lifecycle:
+
+1. create one anchor lifecycle message
+2. post state transitions in thread
+3. include issue/PR/workflow links and owner info
+4. suppress spam with keying (`fingerprint + phase + day`)
+5. send terminal-only summary notification on completion/escalation
+
+Thread replies become state input:
+
+- owner acknowledged
+- owner requested defer/changes
+- disputed signal / false positive hint
+- escalation required
+
+## 7) Resume-And-Extend Existing PR Branch
+
+When workflows fail after an existing disable change:
+
+1. checkout existing PR branch
+2. analyze latest failing runs (same protocol as disable command)
+3. apply minimal incremental disable
+4. commit with additive message (`ci: extend disable scope for #<issue>`)
+5. update PR body section:
+   - latest attempt number
+   - what new failing target was disabled
+6. rerun kickoff-workflows command
+7. persist state and run URLs
+
+This is the core capability needed for "keep running until CI is stabilized."
+
+---
+
+## 8) Action Selector (Fix vs Disable vs Refresh vs Observe)
+
+Action selector inputs:
+
+- failure persistence + blast radius
+- owner responsiveness and SLA age
+- fix confidence and scope estimate
+- previous attempts / disable debt
+
+Paths:
+
+- Path A: Auto Solve Ticket (small high-confidence fix)
+- Path B: Auto Disable After SLA breach
+- Path C: Refresh stale validation and rerun targeted checks
+- Observe-only when signal is too noisy/ambiguous
+
+## 9) Slack Notification Policy
+
+Channel target (for now): `C09EC0QNSB0`
+
+Send Slack messages only for terminal events:
+
+- completed success
+- escalated to `needs_human`
+
+Message fields:
+
+- issue number(s)
+- disable PR URL
+- latest kickoff run URLs
+- status and brief rationale
+
+Do not spam on intermediate loop iterations unless a run transitions state.
+
+---
+
+## 10) Bug Escape Tracking (Post-Facto Analytics)
+
+This should run as a separate, non-blocking stage after completion signals are observed.
+
+### Data to capture
+
+For each resolved item:
+
+- `source_issue_numbers`
+- `source_slack_ts`
+- `disable_pr` (if any)
+- `fix_pr` and `fix_commit_sha` (if a true fix later replaces disable)
+- `files_changed` and inferred component/layer
+- `failing_test_layer` (llk/metalium/ttnn/models)
+- `fix_layer` (same taxonomy)
+- `escape_type`
+
+### Escape taxonomy
+
+- `gate_coverage_gap`:
+  - signal suggests pr-gate/merge-gate should have caught this
+- `layer_escape_lower_to_higher`:
+  - fix touches lower layer; failing symptom appears in higher layer tests
+- `unknown`
+
+### Minimal first-pass heuristic
+
+- infer layer from file paths:
+  - `tt_metal/third_party/tt_llk/**` -> `llk`
+  - `tt_metal/**` -> `metalium`
+  - `ttnn/**` -> `ttnn`
+  - `models/**` -> `models`
+- infer failure layer from disabled test/workflow target path
+- classify `layer_escape_lower_to_higher` when fix layer is lower than failure layer
+
+Store this in:
+
+- `build_ci/triage_state/bug_escape_events.json`
+
+Add periodic rollup:
+
+- counts by escape type
+- top repeated components
+- unresolved attribution rate
+
+---
+
+## Implementation Phases
+
+## Phase 0: Stabilize Current Baseline
+
+- validate current workflow dry-run path
+- confirm artifacts and summary are produced reliably
+- verify no duplicate markdown sections
+
+Exit criteria:
+
+- two consecutive dry runs complete with deterministic outputs
+
+## Phase 1: State Persistence
+
+- implement state artifact download/load/write
+- reconcile state with live GitHub PR reality each run
+
+Exit criteria:
+
+- state survives across runs and recovers if artifact missing
+
+## Phase 2: Resume Existing PRs
+
+- implement "update existing PR branch" path
+- add PR body update section for attempt history
+
+Exit criteria:
+
+- simulated failed rerun updates same PR (no new PR)
+
+## Phase 3: Terminal Completion + Slack Notify
+
+- detect success terminal condition
+- send one Slack completion message
+- mark state `completed`
+
+Exit criteria:
+
+- rerun after completion does not trigger new disable actions
+
+## Phase 4: Failure Ingestion + Fingerprint Correlation + New-Issue Slack Bootstrap
+
+- ingest aggregate workflow failures
+- correlate with existing ticket/PR/Slack state
+- create new issue for unmatched high-confidence fingerprints
+- send initial Slack lifecycle notification/thread anchor for each newly created issue
+- fail closed on low-confidence signals
+
+Exit criteria:
+
+- deterministic fingerprint generation and replay stability
+- exactly-once issue-create + initial Slack notification per new fingerprint
+
+## Phase 5: Ticket Lifecycle Automation
+
+- update/close issues automatically in test repo and create a new issue on recurrence
+- enforce `CI auto triage` label policy
+- continue threaded Slack lifecycle updates for existing incidents
+
+Exit criteria:
+
+- full ticket lifecycle runs on controlled scenarios without manual edits
+
+## Phase 6: Slack Lifecycle + Reply-Aware Control
+
+- post anchor + threaded lifecycle updates automatically
+- consume thread replies as control signals
+- if owner confirms imminent fix, switch to defer/observe path and suppress disable PR creation for that cycle
+
+Exit criteria:
+
+- state transitions adapt correctly when humans reply in thread
+
+## Phase 7: Action Selector + SLA Paths
+
+- implement fix/disable/refresh/observe selector
+- enforce approval boundary and confidence thresholds
+- explicitly validate fix-vs-disable-vs-defer transitions from Slack thread input
+
+Exit criteria:
+
+- controlled fixtures cover Path A/B/C decisions deterministically
+
+## Phase 8: Bug Escape Tracking
+
+- capture fix commit mappings and escape classification
+- produce artifact + summary table
+
+Exit criteria:
+
+- can answer: "what fix commit resolved which issue, and was it an escape?"
+
+---
+
+## Detailed Test Plan
+
+## A) Unit Tests (Python scripts)
+
+Cover:
+
+- stale candidate filtering edge cases
+- state merge/reconciliation logic
+- duplicate detection with marker parsing
+- layer classification from path sets
+- escape type classification
+
+Add golden test fixtures:
+
+- representative Slack JSON
+- representative workflow outcomes
+- representative PR metadata
+
+## B) Integration Tests (Local/CI dry-run)
+
+1. No prior state:
+   - creates initial state correctly
+2. Prior state with open PR:
+   - does not create second PR
+3. Prior state completed:
+   - skips item
+4. Prior state kickoff failed with new target:
+   - produces branch update plan
+
+Use `auto-disable-dry-run=true` to validate decisioning without writes.
+
+## C) Controlled Live Tests (Small Scope)
+
+Run on one known stale issue:
+
+1. live PR creation and kickoff
+2. rerun with same input: verify no duplicate PR
+3. force scenario with additional failing target: verify same PR is extended
+4. success scenario: verify completion mark + Slack notification
+5. thread reply scenario: verify owner response changes selector behavior
+6. ticket lifecycle scenario: auto create + update + close + recurrence-new-issue
+
+## D) Regression Tests
+
+Ensure `data-gathering-mode=true` path remains unchanged:
+
+- report generation still works
+- summary output still single-write
+- artifacts unchanged
+
+---
+
+## Operational Safeguards
+
+- concurrency lock on workflow (`concurrency` group in GitHub Actions)
+- max actions per run
+- max attempts per item before escalation
+- allowlist of workflow names that can be dispatched
+- explicit audit log in state history
+
+---
+
+## Suggested Next Work Items (In Order)
+
+1. Add aggregate failure fingerprint ingestion + correlation
+2. Add ticket lifecycle create/update/close controller plus recurrence-new-issue policy
+3. Add Slack lifecycle sender + thread-reply parser
+4. Extend action selector (fix/disable/refresh/observe)
+5. Keep M0-M3 invariants while integrating expanded loop
+6. Add approval-boundary readiness checks before review requests
+7. Add bug-escape event capture + rollup artifact
+8. Add synthetic fixture suite and controlled live validations
+
+---
+
+## Definition Of Done
+
+System is done when all are true:
+
+- repeated triage runs do not create duplicate disable PRs
+- existing disable PRs are iteratively extended when new failures emerge
+- successful stabilization marks terminal completion and emits one Slack notification
+- aggregate failure ingestion continuously feeds new deterministic fingerprints
+- issues are auto-created/updated/closed with correct labels and evidence, and recurrence creates a new linked issue
+- Slack lifecycle is autonomous and thread replies influence decisions
+- action selector can choose fix vs disable vs refresh vs observe with auditable rationale
+- human involvement is limited to PR review/merge boundary
+- bug escape records map issue -> fixing commit/PR with classification
+- dashboards/artifacts can show "what escaped and where to shift left"

--- a/tools/ci/diagrams/ci-maintenance-workflow-ai-future.html
+++ b/tools/ci/diagrams/ci-maintenance-workflow-ai-future.html
@@ -1,0 +1,242 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Future AI-Driven CI Maintenance Workflow</title>
+  <style>
+    :root {
+      --bg: #0b1324;
+      --panel: #0f172a;
+      --node: #1e293b;
+      --node-border: #334155;
+      --text: #e5e7eb;
+      --muted: #94a3b8;
+      --start: #38bdf8;
+      --engine: #22c55e;
+      --decision: #f59e0b;
+      --human: #f472b6;
+      --line: #64748b;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      color: var(--text);
+      background: radial-gradient(circle at top, #13213d 0%, var(--bg) 52%);
+      padding: 24px;
+    }
+    .wrap {
+      max-width: 1500px;
+      margin: 0 auto;
+      background: color-mix(in oklab, var(--panel) 92%, black 8%);
+      border: 1px solid #1e293b;
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 22px 50px rgba(0, 0, 0, 0.35);
+    }
+    h1 { margin: 0 0 6px; font-size: 28px; }
+    .subtitle { margin: 0 0 18px; color: var(--muted); font-size: 14px; }
+    svg {
+      width: 100%;
+      height: auto;
+      background: linear-gradient(180deg, rgba(15,23,42,0.25) 0%, rgba(15,23,42,0.75) 100%);
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+    }
+    .node {
+      fill: var(--node);
+      stroke: var(--node-border);
+      stroke-width: 2;
+      rx: 12;
+      ry: 12;
+    }
+    .start { stroke: var(--start); }
+    .engine { stroke: var(--engine); }
+    .decision { stroke: var(--decision); }
+    .human { stroke: var(--human); }
+    .t { fill: var(--text); font-size: 13px; font-weight: 700; }
+    .s { fill: var(--muted); font-size: 11px; font-weight: 500; }
+    .line {
+      stroke: var(--line);
+      stroke-width: 2.5;
+      fill: none;
+      marker-end: url(#arrow);
+    }
+    .label { fill: #d1d5db; font-size: 11px; font-weight: 700; }
+    .legend {
+      margin-top: 14px;
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      border: 1px solid #22314f;
+      border-radius: 999px;
+      background: #0b1220;
+    }
+    .dot { width: 10px; height: 10px; border-radius: 999px; display: inline-block; }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Target State: Fully AI-Driven CI Maintenance (No BrAIn)</h1>
+    <p class="subtitle">
+      Autonomous loop using GitHub workflows + Cursor CLI + Slack notifications, with humans only for PR approval and exception handling.
+    </p>
+
+    <svg viewBox="0 0 1500 1740" role="img" aria-label="Future AI-driven CI maintenance flowchart">
+      <defs>
+        <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4" orient="auto">
+          <polygon points="0,0 10,4 0,8" fill="#64748b"></polygon>
+        </marker>
+      </defs>
+
+      <!-- Top -->
+      <rect class="node start" x="520" y="30" width="460" height="84"></rect>
+      <text class="t" x="750" y="62" text-anchor="middle">Scheduler/Event Trigger Starts AI Cycle</text>
+      <text class="s" x="750" y="84" text-anchor="middle">Cron + workflow completion + issue/PR comment events</text>
+      <text class="s" x="750" y="100" text-anchor="middle">No human-in-the-loop for routine triage steps</text>
+
+      <rect class="node engine" x="180" y="170" width="450" height="92"></rect>
+      <text class="t" x="405" y="202" text-anchor="middle">Run extract_failing_jobs.py</text>
+      <text class="s" x="405" y="224" text-anchor="middle">Find deterministic repeated failures on main</text>
+      <text class="s" x="405" y="241" text-anchor="middle">Candidate incidents for ticket create/update</text>
+
+      <rect class="node engine" x="870" y="170" width="450" height="92"></rect>
+      <text class="t" x="1095" y="202" text-anchor="middle">Run export_slack_channel.py</text>
+      <text class="s" x="1095" y="224" text-anchor="middle">Pull latest pipeline triage signal context</text>
+      <text class="s" x="1095" y="241" text-anchor="middle">Used for higher-quality owner recommendations/messages</text>
+
+      <rect class="node engine" x="520" y="320" width="460" height="92"></rect>
+      <text class="t" x="750" y="352" text-anchor="middle">AI Triage Engine Correlates Evidence</text>
+      <text class="s" x="750" y="374" text-anchor="middle">Logs + issue history + CODEOWNERS + recency + confidence checks</text>
+      <text class="s" x="750" y="391" text-anchor="middle">Determines: close, open, update, solve, disable, or wait</text>
+
+      <!-- Ticket hygiene loop -->
+      <rect class="node engine" x="90" y="480" width="420" height="102"></rect>
+      <text class="t" x="300" y="514" text-anchor="middle">Auto Close Tickets</text>
+      <text class="s" x="300" y="536" text-anchor="middle">Close only when true fix/pass criteria met</text>
+      <text class="s" x="300" y="553" text-anchor="middle">Loop until no additional eligible closures</text>
+      <text class="s" x="300" y="570" text-anchor="middle">Post closure reason + job links</text>
+
+      <rect class="node engine" x="540" y="480" width="420" height="102"></rect>
+      <text class="t" x="750" y="514" text-anchor="middle">Auto Create / Update Tickets</text>
+      <text class="s" x="750" y="536" text-anchor="middle">Create deterministic issues, refresh stale issues</text>
+      <text class="s" x="750" y="553" text-anchor="middle">Assign owners automatically</text>
+      <text class="s" x="750" y="570" text-anchor="middle">Maintain reproducible evidence in body/comments</text>
+
+      <rect class="node engine" x="990" y="480" width="420" height="102"></rect>
+      <text class="t" x="1200" y="514" text-anchor="middle">Auto Slack Notifications</text>
+      <text class="s" x="1200" y="536" text-anchor="middle">Draft + send pipeline channel updates</text>
+      <text class="s" x="1200" y="553" text-anchor="middle">Include issue links, owners, deadline, confidence</text>
+      <text class="s" x="1200" y="570" text-anchor="middle">Thread replies become AI action requests</text>
+
+      <rect class="node engine" x="520" y="610" width="460" height="54"></rect>
+      <text class="t" x="750" y="637" text-anchor="middle">Post-Slack State Collector</text>
+      <text class="s" x="750" y="656" text-anchor="middle">Reads thread updates + issue/PR state snapshots before action selection</text>
+
+      <rect class="node decision" x="520" y="700" width="460" height="84"></rect>
+      <text class="t" x="750" y="732" text-anchor="middle">Action Selector (hourly tick + optional Slack events)</text>
+      <text class="s" x="750" y="754" text-anchor="middle">Small fix request, stale validation, or SLA breach</text>
+      <text class="s" x="750" y="771" text-anchor="middle">SLA breach = incident unresolved past 48h threshold</text>
+
+      <!-- Action branches -->
+      <rect class="node engine" x="60" y="850" width="430" height="126"></rect>
+      <text class="t" x="275" y="884" text-anchor="middle">Path A: Auto Solve Ticket</text>
+      <text class="s" x="275" y="906" text-anchor="middle">Run Cursor CLI against focused prompt/rules</text>
+      <text class="s" x="275" y="923" text-anchor="middle">Generate patch + branch + draft PR</text>
+      <text class="s" x="275" y="940" text-anchor="middle">Apply low-risk policy constraints (scope whitelist)</text>
+      <text class="s" x="275" y="957" text-anchor="middle">Trigger targeted verification workflows</text>
+
+      <rect class="node engine" x="535" y="850" width="430" height="126"></rect>
+      <text class="t" x="750" y="884" text-anchor="middle">Path B: Auto Disable After SLA</text>
+      <text class="s" x="750" y="906" text-anchor="middle">If unresolved for 48h, disable minimum test/job scope</text>
+      <text class="s" x="750" y="923" text-anchor="middle">Open draft PR with explicit re-enable conditions</text>
+      <text class="s" x="750" y="940" text-anchor="middle">Notify owners + infra if disabled repeatedly</text>
+      <text class="s" x="750" y="957" text-anchor="middle">Track disable debt in issue metadata</text>
+
+      <rect class="node engine" x="1010" y="850" width="430" height="126"></rect>
+      <text class="t" x="1225" y="884" text-anchor="middle">Path C: Refresh Stale Validation</text>
+      <text class="s" x="1225" y="906" text-anchor="middle">Use (triage) Cursor CLI workflow + kickoff workflow logic</text>
+      <text class="s" x="1225" y="923" text-anchor="middle">Dispatch new targeted runs when old ones are stale</text>
+      <text class="s" x="1225" y="940" text-anchor="middle">Update PR/issue threads with fresh run URLs</text>
+      <text class="s" x="1225" y="957" text-anchor="middle">Keep feedback cycle current without manual reruns</text>
+
+      <!-- PR gate -->
+      <rect class="node decision" x="520" y="1080" width="460" height="84"></rect>
+      <text class="t" x="750" y="1112" text-anchor="middle">PR Ready + Confidence Above Threshold?</text>
+      <text class="s" x="750" y="1134" text-anchor="middle">Checks: tests status, policy compliance, change risk, drift</text>
+
+      <rect class="node human" x="520" y="1230" width="460" height="106"></rect>
+      <text class="t" x="750" y="1264" text-anchor="middle">Human Approval Boundary</text>
+      <text class="s" x="750" y="1286" text-anchor="middle">AI tags CI owners + your team only when review is needed</text>
+      <text class="s" x="750" y="1303" text-anchor="middle">Humans approve/merge PRs or request changes</text>
+      <text class="s" x="750" y="1320" text-anchor="middle">Everything else stays autonomous</text>
+
+      <rect class="node engine" x="520" y="1400" width="460" height="88"></rect>
+      <text class="t" x="750" y="1432" text-anchor="middle">AI Post-Merge / Post-Decision Cleanup</text>
+      <text class="s" x="750" y="1454" text-anchor="middle">Close or update issues, re-enable tests when fixed, reassign/escalate if blocked</text>
+      <text class="s" x="750" y="1471" text-anchor="middle">Persist state, metrics, and next actions</text>
+
+      <rect class="node start" x="520" y="1550" width="460" height="84"></rect>
+      <text class="t" x="750" y="1582" text-anchor="middle">Continuous Autonomous Loop</text>
+      <text class="s" x="750" y="1604" text-anchor="middle">Repeat on next cron tick or event trigger</text>
+      <text class="s" x="750" y="1620" text-anchor="middle">Goal: near-zero manual triage effort</text>
+
+      <!-- Connectors -->
+      <path class="line" d="M750,114 L750,150"></path>
+      <path class="line" d="M750,150 L405,150 L405,170"></path>
+      <path class="line" d="M750,150 L1095,150 L1095,170"></path>
+      <path class="line" d="M405,262 L405,300 L750,300 L750,320"></path>
+      <path class="line" d="M1095,262 L1095,300 L750,300 L750,320"></path>
+
+      <path class="line" d="M750,412 L750,448 L300,448 L300,480"></path>
+      <path class="line" d="M750,412 L750,480"></path>
+      <path class="line" d="M750,412 L750,448 L1200,448 L1200,480"></path>
+
+      <path class="line" d="M510,531 L540,531"></path>
+      <path class="line" d="M960,531 L990,531"></path>
+      <path class="line" d="M750,582 L750,610"></path>
+      <path class="line" d="M750,664 L750,700"></path>
+
+      <path class="line" d="M680,784 L275,850"></path>
+      <path class="line" d="M750,784 L750,850"></path>
+      <path class="line" d="M820,784 L1225,850"></path>
+      <text class="label" x="270" y="832">Fix request / small change</text>
+      <text class="label" x="760" y="832">SLA breach (48h unresolved)</text>
+      <text class="label" x="1080" y="832">Validation stale</text>
+
+      <!-- Combined fan-in to PR gate -->
+      <path class="line" d="M275,976 L275,1030 L750,1030"></path>
+      <path class="line" d="M750,976 L750,1030"></path>
+      <path class="line" d="M1225,976 L1225,1030 L750,1030"></path>
+      <path class="line" d="M750,1030 L750,1080"></path>
+
+      <path class="line" d="M750,1164 L750,1230"></path>
+      <path class="line" d="M750,1336 L750,1400"></path>
+      <path class="line" d="M750,1488 L750,1550"></path>
+
+      <!-- Retry loop from quality gate -->
+      <path class="line" d="M980,1122 L1460,1122 L1460,742 L980,742"></path>
+      <text class="label" x="1200" y="1112">NO: keep auto-iterating</text>
+
+      <!-- Positive label -->
+      <text class="label" x="786" y="1218">YES: request human approval</text>
+    </svg>
+
+    <div class="legend">
+      <div class="chip"><span class="dot" style="background:#38bdf8;"></span> Trigger / loop lifecycle</div>
+      <div class="chip"><span class="dot" style="background:#22c55e;"></span> AI-owned automated actions</div>
+      <div class="chip"><span class="dot" style="background:#f59e0b;"></span> Decision gates / policy checks</div>
+      <div class="chip"><span class="dot" style="background:#f472b6;"></span> Human approval boundary only</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/tools/ci/diagrams/ci-maintenance-workflow.html
+++ b/tools/ci/diagrams/ci-maintenance-workflow.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>CI Maintenance Workflow</title>
+  <style>
+    :root {
+      --bg: #0f172a;
+      --panel: #111827;
+      --node: #1f2937;
+      --node-border: #334155;
+      --text: #e5e7eb;
+      --muted: #94a3b8;
+      --accent: #38bdf8;
+      --yes: #22c55e;
+      --warn: #f59e0b;
+      --line: #64748b;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      background: radial-gradient(circle at top, #1e293b 0%, var(--bg) 50%);
+      color: var(--text);
+      padding: 24px;
+    }
+    .wrap {
+      max-width: 1400px;
+      margin: 0 auto;
+      background: color-mix(in oklab, var(--panel) 92%, black 8%);
+      border: 1px solid #1e293b;
+      border-radius: 16px;
+      padding: 20px;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.35);
+    }
+    h1 {
+      margin: 0 0 6px;
+      font-size: 28px;
+    }
+    .subtitle {
+      margin: 0 0 18px;
+      color: var(--muted);
+      font-size: 14px;
+    }
+    svg {
+      width: 100%;
+      height: auto;
+      background: linear-gradient(180deg, rgba(15,23,42,0.3) 0%, rgba(15,23,42,0.75) 100%);
+      border: 1px solid #1e293b;
+      border-radius: 12px;
+    }
+    .node {
+      fill: var(--node);
+      stroke: var(--node-border);
+      stroke-width: 2;
+      rx: 12;
+      ry: 12;
+    }
+    .node.start { stroke: var(--accent); }
+    .node.decision { stroke: var(--warn); }
+    .node.action { stroke: #7c3aed; }
+    .node.done { stroke: var(--yes); }
+    .t {
+      fill: var(--text);
+      font-size: 13px;
+      font-weight: 600;
+    }
+    .s {
+      fill: var(--muted);
+      font-size: 11px;
+      font-weight: 500;
+    }
+    .line {
+      stroke: var(--line);
+      stroke-width: 2.5;
+      fill: none;
+      marker-end: url(#arrow);
+    }
+    .label {
+      fill: #cbd5e1;
+      font-size: 11px;
+      font-weight: 700;
+    }
+    .legend {
+      margin-top: 14px;
+      display: flex;
+      gap: 16px;
+      flex-wrap: wrap;
+      color: var(--muted);
+      font-size: 12px;
+    }
+    .chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      padding: 6px 10px;
+      background: #0b1220;
+      border: 1px solid #1f2a44;
+      border-radius: 999px;
+    }
+    .dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 999px;
+      display: inline-block;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>Current CI Maintenance Workflow</h1>
+    <p class="subtitle">
+      Manual flow used today: failure extraction → ticket hygiene loops → Slack triage → solve/disable paths → optional workflow kickoff.
+    </p>
+
+    <svg viewBox="0 0 1400 1460" role="img" aria-label="CI maintenance flowchart">
+      <defs>
+        <marker id="arrow" markerWidth="10" markerHeight="8" refX="8" refY="4" orient="auto">
+          <polygon points="0,0 10,4 0,8" fill="#64748b"></polygon>
+        </marker>
+      </defs>
+
+      <!-- Nodes -->
+      <rect class="node start" x="500" y="30" width="400" height="78"></rect>
+      <text class="t" x="700" y="60" text-anchor="middle">Start Manual Triage Cycle</text>
+      <text class="s" x="700" y="83" text-anchor="middle">Usually done daily / during CI maintenance window</text>
+
+      <rect class="node" x="80" y="170" width="400" height="92"></rect>
+      <text class="t" x="280" y="202" text-anchor="middle">Run extract_failing_jobs.py</text>
+      <text class="s" x="280" y="224" text-anchor="middle">Build candidates of consistently failing CI jobs</text>
+      <text class="s" x="280" y="241" text-anchor="middle">Input for create/open-ticket flow</text>
+
+      <rect class="node" x="920" y="170" width="400" height="92"></rect>
+      <text class="t" x="1120" y="202" text-anchor="middle">Run export_slack_channel.py</text>
+      <text class="s" x="1120" y="224" text-anchor="middle">Fetch auto-triage pipeline channel logs</text>
+      <text class="s" x="1120" y="241" text-anchor="middle">Evidence for Slack draft context</text>
+
+      <rect class="node" x="80" y="330" width="400" height="94"></rect>
+      <text class="t" x="280" y="362" text-anchor="middle">Run ci-close-tickets command</text>
+      <text class="s" x="280" y="385" text-anchor="middle">Close stale/no-longer-actionable CI maintenance issues</text>
+      <text class="s" x="280" y="402" text-anchor="middle">Repeat until no more tickets are closed</text>
+
+      <rect class="node decision" x="520" y="344" width="360" height="66"></rect>
+      <text class="t" x="700" y="372" text-anchor="middle">Any tickets closed this pass?</text>
+      <text class="s" x="700" y="392" text-anchor="middle">Loop gate for close flow</text>
+
+      <rect class="node" x="920" y="330" width="400" height="94"></rect>
+      <text class="t" x="1120" y="362" text-anchor="middle">Run ci-create-tickets command</text>
+      <text class="s" x="1120" y="385" text-anchor="middle">Create deterministic issues for repeated failures</text>
+      <text class="s" x="1120" y="402" text-anchor="middle">Repeat until no more tickets are opened</text>
+
+      <rect class="node decision" x="520" y="488" width="360" height="66"></rect>
+      <text class="t" x="700" y="516" text-anchor="middle">Any tickets opened this pass?</text>
+      <text class="s" x="700" y="536" text-anchor="middle">Loop gate for open flow</text>
+
+      <rect class="node" x="500" y="620" width="400" height="84"></rect>
+      <text class="t" x="700" y="651" text-anchor="middle">Run ci-update-ticket command</text>
+      <text class="s" x="700" y="673" text-anchor="middle">Refresh stale ticket details with latest evidence</text>
+      <text class="s" x="700" y="689" text-anchor="middle">(close/update/no-change per ticket)</text>
+
+      <rect class="node" x="500" y="760" width="400" height="84"></rect>
+      <text class="t" x="700" y="791" text-anchor="middle">Run ci-draft-slack-ci-issue command</text>
+      <text class="s" x="700" y="813" text-anchor="middle">Generate copy-paste Slack summary for pipelines channel</text>
+      <text class="s" x="700" y="829" text-anchor="middle">Includes issue link, failure summary, owners, deadline</text>
+
+      <rect class="node" x="500" y="900" width="400" height="84"></rect>
+      <text class="t" x="700" y="931" text-anchor="middle">Post message in pipelines Slack channel</text>
+      <text class="s" x="700" y="953" text-anchor="middle">Developers react / ask for action in thread</text>
+      <text class="s" x="700" y="969" text-anchor="middle">This is where intervention requests come from</text>
+
+      <rect class="node decision" x="500" y="1040" width="400" height="74"></rect>
+      <text class="t" x="700" y="1070" text-anchor="middle">Which path is needed?</text>
+      <text class="s" x="700" y="1091" text-anchor="middle">Fix request vs stale/unfixed timeout</text>
+
+      <rect class="node action" x="70" y="1180" width="410" height="112"></rect>
+      <text class="t" x="275" y="1212" text-anchor="middle">Path A: run ci-solve-ticket command</text>
+      <text class="s" x="275" y="1234" text-anchor="middle">For small fixes (threshold tweaks / low-risk code changes)</text>
+      <text class="s" x="275" y="1251" text-anchor="middle">Draft PR + optional targeted workflows</text>
+      <text class="s" x="275" y="1268" text-anchor="middle">May need reruns if earlier workflows become stale</text>
+
+      <rect class="node action" x="500" y="1180" width="400" height="112"></rect>
+      <text class="t" x="700" y="1212" text-anchor="middle">Path B: run ci-disable-test command</text>
+      <text class="s" x="700" y="1234" text-anchor="middle">If not fixed in ~48 hours</text>
+      <text class="s" x="700" y="1251" text-anchor="middle">Disable minimum scope to unblock CI</text>
+      <text class="s" x="700" y="1268" text-anchor="middle">Draft PR + re-enable follow-up expectations</text>
+
+      <rect class="node action" x="920" y="1180" width="410" height="112"></rect>
+      <text class="t" x="1125" y="1212" text-anchor="middle">Optional: run ci-kickoff-workflows command</text>
+      <text class="s" x="1125" y="1234" text-anchor="middle">If you made changes and existing runs are stale</text>
+      <text class="s" x="1125" y="1251" text-anchor="middle">Create temporary pruned branch + dispatch targeted workflows</text>
+      <text class="s" x="1125" y="1268" text-anchor="middle">Post fresh run links back to PR</text>
+
+      <rect class="node done" x="500" y="1360" width="400" height="74"></rect>
+      <text class="t" x="700" y="1390" text-anchor="middle">Cycle Complete</text>
+      <text class="s" x="700" y="1411" text-anchor="middle">Repeat next triage interval</text>
+
+      <!-- Main lines -->
+      <path class="line" d="M700,108 L700,150"></path>
+      <path class="line" d="M700,150 L280,150 L280,170"></path>
+      <path class="line" d="M700,150 L1120,150 L1120,170"></path>
+
+      <path class="line" d="M280,262 L280,330"></path>
+      <path class="line" d="M480,377 L520,377"></path>
+      <path class="line" d="M880,377 L920,377"></path>
+      <path class="line" d="M1120,424 L1120,455 L880,455 L880,521"></path>
+
+      <path class="line" d="M700,554 L700,620"></path>
+      <path class="line" d="M700,704 L700,760"></path>
+      <path class="line" d="M700,844 L700,900"></path>
+      <path class="line" d="M700,984 L700,1040"></path>
+
+      <!-- Close-loop back -->
+      <path class="line" d="M700,344 L700,290 L280,290 L280,330"></path>
+      <text class="label" x="430" y="282">YES (keep closing)</text>
+      <text class="label" x="892" y="366">NO</text>
+
+      <!-- Open-loop back -->
+      <path class="line" d="M880,521 L1340,521 L1340,300 L1120,300 L1120,330"></path>
+      <text class="label" x="1180" y="294">YES (keep opening)</text>
+      <text class="label" x="720" y="604">NO</text>
+
+      <!-- Decision fan-out -->
+      <path class="line" d="M630,1114 L275,1180"></path>
+      <path class="line" d="M700,1114 L700,1180"></path>
+      <path class="line" d="M770,1114 L1125,1180"></path>
+      <text class="label" x="280" y="1148">Dev asks for small fix</text>
+      <text class="label" x="705" y="1154">Not fixed in 48h</text>
+      <text class="label" x="1030" y="1148">Need fresh workflows</text>
+
+      <!-- converge -->
+      <path class="line" d="M275,1292 L275,1330 L700,1330 L700,1360"></path>
+      <path class="line" d="M700,1292 L700,1360"></path>
+      <path class="line" d="M1125,1292 L1125,1330 L700,1330"></path>
+    </svg>
+
+    <div class="legend">
+      <div class="chip"><span class="dot" style="background:#38bdf8;"></span> Start / orchestration phase</div>
+      <div class="chip"><span class="dot" style="background:#f59e0b;"></span> Decision / loop gates</div>
+      <div class="chip"><span class="dot" style="background:#7c3aed;"></span> Ticket action paths</div>
+      <div class="chip"><span class="dot" style="background:#22c55e;"></span> End of one triage cycle</div>
+    </div>
+  </div>
+</body>
+</html>

--- a/tools/ci/extract_failing_jobs.py
+++ b/tools/ci/extract_failing_jobs.py
@@ -1,0 +1,454 @@
+#!/usr/bin/env python3
+"""
+Extract jobs that failed in the last N consecutive workflow runs.
+
+The script downloads workflow-data from the latest aggregate-workflow-data run,
+filters to workflows with N consecutive failures, then fetches run jobs from
+the GitHub API to find which specific jobs failed in all N runs.
+
+Workflows whose display name contains any keyword in
+``SKIP_WORKFLOW_NAME_KEYWORDS`` (case-insensitive substring match) are skipped:
+no per-run job downloads for those entries. The aggregate artifact is still
+downloaded as a single file upstream.
+
+Usage:
+  python tools/ci/extract_failing_jobs.py
+  python tools/ci/extract_failing_jobs.py t3000-unit-tests
+
+Optional env vars:
+  CONSECUTIVE_FAILURES   Number of consecutive failures required (default: 3)
+  GITHUB_OWNER           Default: tenstorrent
+  GITHUB_REPO            Default: tt-metal
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+from http.client import IncompleteRead
+from pathlib import Path
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+OWNER = os.environ.get("GITHUB_OWNER", "tenstorrent")
+REPO = os.environ.get("GITHUB_REPO", "tt-metal")
+WORKFLOW_FILE = "aggregate-workflow-data.yaml"
+ARTIFACT_NAME = "workflow-data"
+CONSECUTIVE_FAILURES = int(os.environ.get("CONSECUTIVE_FAILURES", "3"))
+
+# Substrings; if any appear in the workflow display name (case-insensitive), skip job fetches.
+SKIP_WORKFLOW_NAME_KEYWORDS: tuple[str, ...] = ("sanity",)
+
+
+def resolve_token() -> str | None:
+    if os.environ.get("GITHUB_TOKEN"):
+        return os.environ["GITHUB_TOKEN"]
+    try:
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    return None
+
+
+def download_workflow_data() -> tuple[list, int]:
+    print("Finding latest aggregate-workflow-data run...", file=sys.stderr)
+    result = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            f"--workflow={WORKFLOW_FILE}",
+            f"--repo={OWNER}/{REPO}",
+            "--status=completed",
+            "--limit=1",
+            "--json=databaseId,conclusion",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Failed to list workflow runs: {result.stderr}")
+
+    runs = json.loads(result.stdout)
+    if not runs:
+        raise RuntimeError("No completed runs found for aggregate-workflow-data")
+
+    run_id = runs[0]["databaseId"]
+    conclusion = runs[0]["conclusion"]
+    print(f"  Latest run: {run_id} (conclusion: {conclusion})", file=sys.stderr)
+    if conclusion != "success":
+        print(
+            f"  Warning: latest run did not succeed ({conclusion}); data may be stale.",
+            file=sys.stderr,
+        )
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        print(f"  Downloading '{ARTIFACT_NAME}' artifact...", file=sys.stderr)
+        result = subprocess.run(
+            [
+                "gh",
+                "run",
+                "download",
+                str(run_id),
+                f"--repo={OWNER}/{REPO}",
+                "-n",
+                ARTIFACT_NAME,
+                "-D",
+                tmpdir,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to download artifact: {result.stderr}")
+
+        json_file = Path(tmpdir) / "workflow-data.json"
+        if not json_file.exists():
+            json_files = list(Path(tmpdir).rglob("*.json"))
+            if not json_files:
+                raise RuntimeError("No JSON files found in downloaded artifact")
+            json_file = json_files[0]
+
+        print(
+            f"  Loaded workflow data ({json_file.stat().st_size / 1_000_000:.1f} MB)",
+            file=sys.stderr,
+        )
+        with open(json_file, encoding="utf-8") as f:
+            return json.load(f), int(run_id)
+
+
+def load_cache(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, encoding="utf-8") as f:
+            parsed = json.load(f)
+    except Exception:
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def gh_api_request(url: str, token: str | None, max_retries: int = 5) -> dict:
+    for attempt in range(max_retries):
+        req = Request(
+            url,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+        if token:
+            req.add_header("Authorization", f"Bearer {token}")
+
+        try:
+            with urlopen(req, timeout=30) as resp:
+                return json.loads(resp.read().decode())
+        except IncompleteRead:
+            if attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise
+        except HTTPError as err:
+            if err.code == 404:
+                return {"jobs": []}
+            if err.code in (502, 503, 504) and attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise
+        except URLError as err:
+            if attempt < max_retries - 1:
+                time.sleep(2 ** (attempt + 1))
+                continue
+            raise RuntimeError(f"Request failed: {err}") from err
+
+    raise RuntimeError(f"Exhausted retries for {url}")
+
+
+def fetch_jobs_for_run(run_id: int, token: str | None) -> list[dict]:
+    jobs: list[dict] = []
+    page = 1
+    per_page = 100
+
+    while True:
+        url = (
+            f"https://api.github.com/repos/{OWNER}/{REPO}"
+            f"/actions/runs/{run_id}/jobs?per_page={per_page}&page={page}"
+        )
+        data = gh_api_request(url, token)
+        batch = data.get("jobs", [])
+        jobs.extend(batch)
+
+        if len(batch) < per_page:
+            break
+        page += 1
+        time.sleep(0.5)
+
+    return jobs
+
+
+def extract_failing_jobs(
+    workflow_data: list,
+    token: str | None,
+    aggregate_run_id: int,
+    workflow_filter: str | None = None,
+    output_path: Path | None = None,
+    previous_cache: dict | None = None,
+    cache_output_path: Path | None = None,
+) -> dict:
+    results = []
+    api_calls = 0
+    cached_reused_workflows = 0
+    previous_cache = previous_cache or {}
+    previous_workflows = previous_cache.get("workflows", {})
+    if not isinstance(previous_workflows, dict):
+        previous_workflows = {}
+
+    def write_incremental() -> None:
+        if output_path is None:
+            return
+        payload = {
+            "description": ("Jobs that failed in all of the last " f"{CONSECUTIVE_FAILURES} workflow runs"),
+            "total_jobs_affected": len(results),
+            "jobs": results,
+        }
+        Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+        print(f"    Wrote {len(results)} jobs to {output_path}", file=sys.stderr)
+
+    def write_cache() -> None:
+        if cache_output_path is None:
+            return
+        cache_output_path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "version": 1,
+            "aggregate_run_id": aggregate_run_id,
+            "consecutive_failures": CONSECUTIVE_FAILURES,
+            "workflows": workflow_cache,
+        }
+        with open(cache_output_path, "w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2)
+
+    write_incremental()
+    workflow_cache: dict[str, dict] = {}
+
+    for workflow_name, runs in workflow_data:
+        if not runs:
+            continue
+
+        name_lower = str(workflow_name).lower()
+        skip_kw = next((kw for kw in SKIP_WORKFLOW_NAME_KEYWORDS if kw.lower() in name_lower), None)
+        if skip_kw is not None:
+            print(
+                f'  Skipping workflow "{workflow_name}" (name contains keyword {skip_kw!r}).',
+                file=sys.stderr,
+            )
+            continue
+
+        if workflow_filter:
+            yaml_path = runs[0].get("path", "")
+            yaml_name = yaml_path.rsplit("/", 1)[-1].removesuffix(".yaml").removesuffix(".yml")
+            if yaml_name != workflow_filter:
+                continue
+
+        sorted_runs = sorted(
+            runs,
+            key=lambda run: run.get("created_at", "") or run.get("run_started_at", ""),
+            reverse=True,
+        )
+        last_n = sorted_runs[:CONSECUTIVE_FAILURES]
+
+        if len(last_n) < CONSECUTIVE_FAILURES:
+            continue
+        if not all(run.get("conclusion") == "failure" for run in last_n):
+            continue
+
+        run_id_to_failed_jobs: dict[int, dict[str, str]] = {}
+        run_ids_for_cache = [int(r.get("id")) for r in last_n if r.get("id")]
+        if len(run_ids_for_cache) < CONSECUTIVE_FAILURES:
+            continue
+        yaml_path = runs[0].get("path", "")
+        workflow_key = f"{yaml_path}|{workflow_name}"
+        previous_entry = previous_workflows.get(workflow_key)
+        if isinstance(previous_entry, dict):
+            prev_run_ids = previous_entry.get("run_ids", [])
+            prev_jobs = previous_entry.get("jobs", [])
+            if (
+                isinstance(prev_run_ids, list)
+                and isinstance(prev_jobs, list)
+                and [int(x) for x in prev_run_ids] == run_ids_for_cache
+            ):
+                for item in prev_jobs:
+                    if isinstance(item, dict):
+                        results.append(item)
+                workflow_cache[workflow_key] = {
+                    "workflow_name": workflow_name,
+                    "yaml_path": yaml_path,
+                    "run_ids": run_ids_for_cache,
+                    "jobs": [item for item in prev_jobs if isinstance(item, dict)],
+                    "reused": True,
+                }
+                cached_reused_workflows += 1
+                print(
+                    f'  Reusing cached failing jobs for "{workflow_name}" (run ids unchanged).',
+                    file=sys.stderr,
+                )
+                write_incremental()
+                write_cache()
+                continue
+
+        print(
+            f'  Fetching jobs for "{workflow_name}" ({CONSECUTIVE_FAILURES} runs)...',
+            file=sys.stderr,
+        )
+        for run in last_n:
+            run_id = run.get("id")
+            if not run_id:
+                continue
+
+            jobs = fetch_jobs_for_run(run_id, token)
+            api_calls += 1
+            failed = {
+                job["name"]: job.get("html_url") or job.get("url", "")
+                for job in jobs
+                if job.get("conclusion") == "failure"
+            }
+            run_id_to_failed_jobs[run_id] = failed
+            time.sleep(0.3)
+
+        if len(run_id_to_failed_jobs) < CONSECUTIVE_FAILURES:
+            continue
+
+        run_ids = list(run_id_to_failed_jobs.keys())
+        jobs_failed_in_all = set(run_id_to_failed_jobs[run_ids[0]].keys())
+        for run_id in run_ids[1:]:
+            jobs_failed_in_all &= set(run_id_to_failed_jobs[run_id].keys())
+
+        workflow_jobs: list[dict] = []
+        for job_name in jobs_failed_in_all:
+            urls = [
+                run_id_to_failed_jobs[run_id][job_name]
+                for run in last_n
+                if (run_id := run.get("id")) in run_id_to_failed_jobs and job_name in run_id_to_failed_jobs[run_id]
+            ]
+            item = {
+                "job_name": job_name,
+                "workflow_name": workflow_name,
+                "consecutive_failures": CONSECUTIVE_FAILURES,
+                "failing_job_urls": urls,
+                "workflow_run_urls": [run.get("html_url") or run.get("url", "") for run in last_n],
+            }
+            results.append(item)
+            workflow_jobs.append(item)
+        workflow_cache[workflow_key] = {
+            "workflow_name": workflow_name,
+            "yaml_path": yaml_path,
+            "run_ids": run_ids_for_cache,
+            "jobs": workflow_jobs,
+            "reused": False,
+        }
+
+        write_incremental()
+        write_cache()
+
+    print(
+        (
+            f"Done. {api_calls} API calls made, {len(results)} consistently-failing jobs found, "
+            f"{cached_reused_workflows} workflows reused from cache."
+        ),
+        file=sys.stderr,
+    )
+    payload = {
+        "description": (f"Jobs that failed in all of the last {CONSECUTIVE_FAILURES} workflow runs"),
+        "total_jobs_affected": len(results),
+        "jobs": results,
+        "aggregate_run_id": aggregate_run_id,
+        "cached_reused_workflows": cached_reused_workflows,
+    }
+    write_cache()
+    return payload
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract jobs failing in last N runs.")
+    parser.add_argument("workflow_filter_positional", nargs="?", default=None)
+    parser.add_argument("--workflow-filter", default=None)
+    parser.add_argument(
+        "--output-json",
+        default=None,
+        help="Output path for failing jobs JSON (defaults to build_ci/ci_ticketing/create_tickets/failing_jobs.json)",
+    )
+    parser.add_argument(
+        "--cache-input",
+        default=None,
+        help="Optional previous cache JSON path or directory containing failing_jobs_cache.json",
+    )
+    parser.add_argument(
+        "--cache-output",
+        default=None,
+        help="Cache output path (defaults to build_ci/ci_ticketing/create_tickets/failing_jobs_cache.json)",
+    )
+    args = parser.parse_args()
+    workflow_filter = args.workflow_filter or args.workflow_filter_positional
+    project_root = Path(__file__).resolve().parents[2]
+    output_dir = project_root / "build_ci" / "ci_ticketing" / "create_tickets"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = Path(args.output_json) if args.output_json else (output_dir / "failing_jobs.json")
+    cache_output_path = Path(args.cache_output) if args.cache_output else (output_dir / "failing_jobs_cache.json")
+    cache_input_path: Path | None = None
+    if args.cache_input:
+        candidate = Path(args.cache_input)
+        if candidate.is_dir():
+            found = next(iter(candidate.rglob("failing_jobs_cache.json")), None)
+            if found:
+                cache_input_path = found
+        elif candidate.exists():
+            cache_input_path = candidate
+
+    token = resolve_token()
+    if not token:
+        print(
+            "Error: No GitHub token found.\n" "  Run `gh auth login` or set GITHUB_TOKEN.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    print("Authenticated with GitHub.", file=sys.stderr)
+    if workflow_filter:
+        print(f"Filtering to workflow: {workflow_filter}", file=sys.stderr)
+
+    previous_cache = load_cache(cache_input_path) if cache_input_path else {}
+    workflow_data, aggregate_run_id = download_workflow_data()
+    result = extract_failing_jobs(
+        workflow_data,
+        token,
+        aggregate_run_id,
+        workflow_filter,
+        output_path=output_path,
+        previous_cache=previous_cache,
+        cache_output_path=cache_output_path,
+    )
+
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(result, f, indent=2)
+
+    print(f"Wrote {output_path}", file=sys.stderr)
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/ci/issue_lifecycle_stage.py
+++ b/tools/ci/issue_lifecycle_stage.py
@@ -1,0 +1,581 @@
+#!/usr/bin/env python3
+"""Issue lifecycle stage: close/update stale CI auto-triage tickets."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.guarded import run_guarded_gh  # noqa: F401 – re-exported
+from tools.ci.common.markers import parse_json_after_marker  # noqa: F401 – re-exported
+from tools.ci.common.run_helper import run  # noqa: F401 – re-exported
+from tools.ci.common.state import load_state as _load_state_common, save_state  # noqa: F401
+from tools.ci.common.timestamps import now_iso, now_utc_dt as now_utc, parse_iso_utc  # noqa: F401
+
+RUN_JOB_URL_RE = re.compile(r"https://github\.com/tenstorrent/tt-metal/actions/runs/(\d+)/job/(\d+)")
+FINAL_MARKER = "===FINAL_ISSUE_LIFECYCLE_DECISION==="
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    return _load_state_common(path, schema="issue_lifecycle")
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Process stale CI auto-triage issues.")
+    p.add_argument("--state-json", required=True)
+    p.add_argument("--output-json", required=True)
+    p.add_argument("--summary-md", required=True)
+    p.add_argument("--issue-repo", default="ebanerjeeTT/issue_dump")
+    p.add_argument("--source-repo", default="tenstorrent/tt-metal")
+    p.add_argument("--processed-hours", type=float, default=24.0)
+    p.add_argument("--max-issues", type=int, default=3)
+    p.add_argument("--model", default="auto")
+    return p.parse_args()
+
+
+def list_open_ci_issues(issue_repo: str, issue_token: str) -> list[dict[str, Any]]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            issue_repo,
+            "--state",
+            "open",
+            "--label",
+            "CI auto triage",
+            "--limit",
+            "100",
+            "--json",
+            "number,title,updatedAt,url",
+        ],
+        github_token=issue_token,
+    )
+    payload = json.loads(proc.stdout or "[]")
+    return payload if isinstance(payload, list) else []
+
+
+def issue_view(issue_repo: str, issue_number: int, issue_token: str) -> dict[str, Any]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "view",
+            "--repo",
+            issue_repo,
+            str(issue_number),
+            "--json",
+            "number,title,body,url,labels,comments",
+        ],
+        github_token=issue_token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    return payload if isinstance(payload, dict) else {}
+
+
+def has_recent_lifecycle_comment(issue_payload: dict[str, Any], *, now: dt.datetime, hours: float) -> bool:
+    if hours <= 0:
+        return False
+    threshold = now - dt.timedelta(hours=hours)
+    comments = issue_payload.get("comments", [])
+    if not isinstance(comments, list):
+        return False
+    for row in comments[-30:]:
+        if not isinstance(row, dict):
+            continue
+        body = str(row.get("body", "")).strip()
+        if "Auto-triage lifecycle review" not in body and "Auto Triage Refresh" not in body:
+            continue
+        created = parse_iso_utc(str(row.get("createdAt", "")).strip())
+        if created and created >= threshold:
+            return True
+    return False
+
+
+def extract_latest_run_job_url(issue_payload: dict[str, Any]) -> tuple[int, int] | None:
+    corpus = [str(issue_payload.get("body", ""))]
+    comments = issue_payload.get("comments", [])
+    if isinstance(comments, list):
+        for row in comments[-20:]:
+            if isinstance(row, dict):
+                corpus.append(str(row.get("body", "")))
+    matches = []
+    for text in corpus:
+        matches.extend(RUN_JOB_URL_RE.findall(text))
+    if not matches:
+        return None
+    run_id, job_id = matches[-1]
+    return int(run_id), int(job_id)
+
+
+def run_view(run_id: int, source_repo: str, main_token: str) -> dict[str, Any]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "run",
+            "view",
+            "--repo",
+            source_repo,
+            str(run_id),
+            "--json",
+            "databaseId,url,workflowName,jobs,conclusion,headBranch,createdAt",
+        ],
+        github_token=main_token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    return payload if isinstance(payload, dict) else {}
+
+
+def find_job_name(run_payload: dict[str, Any], job_id: int) -> str:
+    jobs = run_payload.get("jobs", [])
+    if not isinstance(jobs, list):
+        return ""
+    for job in jobs:
+        if not isinstance(job, dict):
+            continue
+        if int(job.get("databaseId", 0) or 0) == job_id:
+            return str(job.get("name", "")).strip()
+    return ""
+
+
+def list_recent_runs_for_workflow(source_repo: str, workflow_name: str, main_token: str) -> list[dict[str, Any]]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "run",
+            "list",
+            "--repo",
+            source_repo,
+            "--workflow",
+            workflow_name,
+            "--branch",
+            "main",
+            "--status",
+            "completed",
+            "--limit",
+            "30",
+            "--json",
+            "databaseId,url,conclusion,createdAt",
+        ],
+        github_token=main_token,
+    )
+    payload = json.loads(proc.stdout or "[]")
+    return payload if isinstance(payload, list) else []
+
+
+def pick_latest_three_job_instances(
+    source_repo: str,
+    main_token: str,
+    workflow_runs: list[dict[str, Any]],
+    target_job_name: str,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for row in workflow_runs:
+        if not isinstance(row, dict):
+            continue
+        run_id = int(row.get("databaseId", 0) or 0)
+        if run_id <= 0:
+            continue
+        details = run_view(run_id, source_repo, main_token)
+        jobs = details.get("jobs", [])
+        if not isinstance(jobs, list):
+            continue
+        matched = None
+        for job in jobs:
+            if not isinstance(job, dict):
+                continue
+            name = str(job.get("name", "")).strip()
+            if name == target_job_name:
+                matched = job
+                break
+        if matched is None:
+            continue
+        selected.append(
+            {
+                "run_id": run_id,
+                "run_url": str(details.get("url", "")).strip(),
+                "run_conclusion": str(details.get("conclusion", "")).strip(),
+                "job_id": int(matched.get("databaseId", 0) or 0),
+                "job_name": str(matched.get("name", "")).strip(),
+                "job_conclusion": str(matched.get("conclusion", "")).strip(),
+                "job_url": str(matched.get("url", "")).strip(),
+            }
+        )
+        if len(selected) >= 3:
+            break
+    return selected
+
+
+def fetch_job_log_excerpt(source_repo: str, main_token: str, run_id: int, job_id: int) -> str:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "run",
+            "view",
+            "--repo",
+            source_repo,
+            str(run_id),
+            "--job",
+            str(job_id),
+            "--log",
+        ],
+        github_token=main_token,
+    )
+    text = proc.stdout or ""
+    lines = text.splitlines()
+    tail = "\n".join(lines[-220:])
+    if len(tail) > 12000:
+        tail = tail[-12000:]
+    return tail
+
+
+def agent_decide_issue_action(
+    *,
+    issue_payload: dict[str, Any],
+    target_job_name: str,
+    selected_runs: list[dict[str, Any]],
+    model: str,
+) -> dict[str, Any]:
+    issue_summary = {
+        "number": int(issue_payload.get("number", 0) or 0),
+        "title": str(issue_payload.get("title", "")).strip(),
+        "url": str(issue_payload.get("url", "")).strip(),
+        "body": str(issue_payload.get("body", ""))[:4000],
+    }
+    prompt_payload = {
+        "issue": issue_summary,
+        "target_job_name": target_job_name,
+        "recent_runs": selected_runs,
+        "policy": {
+            "scope": "CI auto triage lifecycle review",
+            "close_when": [
+                "problem is resolved/passing",
+                "root cause has changed from ticketed issue to a materially new failure",
+            ],
+            "update_when": [
+                "ticket still valid but body/links are stale",
+                "deterministic failure appears to continue",
+            ],
+            "unchanged_when": ["ticket remains valid and already current"],
+            "nd_hint": "transient infra flakes like disconnects may be non-deterministic and should not force close",
+            "minimal_update_rule": "prefer in-place minimal updates for last updated + refreshed links/signature",
+        },
+    }
+    prompt = (
+        "You are deciding CI issue lifecycle actions from ticket text and latest run evidence.\n"
+        "Token-efficiency rule: do one short pass and output only final JSON contract.\n"
+        "Use provided logs/runs to decide one action: close, update, unchanged.\n"
+        "At end print marker exactly on its own line:\n"
+        f"{FINAL_MARKER}\n"
+        "Then print only JSON object:\n"
+        "{\n"
+        '  "action": "close|update|unchanged",\n'
+        '  "confidence": "high|medium|low",\n'
+        '  "signal_mix": "clean|mixed|unknown",\n'
+        '  "reason": "brief",\n'
+        '  "comment": "brief markdown",\n'
+        '  "current_signature": "optional short signature",\n'
+        '  "most_recent_job_url": "optional url",\n'
+        '  "last_three_job_urls": ["url1","url2","url3"]\n'
+        "}\n\n"
+        f"Input JSON:\n{json.dumps(prompt_payload, ensure_ascii=True)}\n"
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model and model != "auto":
+        cmd.extend(["--model", model])
+    proc = run(cmd)
+    parsed = parse_json_after_marker(proc.stdout or "", FINAL_MARKER)
+    action = str(parsed.get("action", "")).strip().lower()
+    if action not in {"close", "update", "unchanged"}:
+        raise ValueError(f"invalid action from agent: {action}")
+    parsed["action"] = action
+    return parsed
+
+
+def update_issue_body_minimal(
+    existing_body: str,
+    *,
+    most_recent_job_url: str,
+    last_three_job_urls: list[str],
+    current_signature: str,
+) -> str:
+    body = existing_body.strip()
+    section = [
+        "## Auto Triage Refresh",
+        f"Last updated: {now_utc().date().isoformat()}",
+    ]
+    if most_recent_job_url:
+        section.append(f"Most recent failing job URL: {most_recent_job_url}")
+    if last_three_job_urls:
+        section.append("Last 3 reviewed job URLs:")
+        for link in last_three_job_urls[:3]:
+            section.append(f"- {link}")
+    if current_signature:
+        section.append(f"Current signature: `{current_signature[:300]}`")
+    new_section = "\n".join(section).strip()
+
+    marker = "## Auto Triage Refresh"
+    if marker in body:
+        head = body.split(marker, 1)[0].rstrip()
+        return f"{head}\n\n{new_section}\n"
+    if not body:
+        return f"{new_section}\n"
+    return f"{body}\n\n{new_section}\n"
+
+
+def comment_issue(issue_repo: str, issue_number: int, issue_token: str, body: str) -> None:
+    run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "comment",
+            "--repo",
+            issue_repo,
+            str(issue_number),
+            "--body",
+            body,
+        ],
+        github_token=issue_token,
+    )
+
+
+def close_issue(issue_repo: str, issue_number: int, issue_token: str) -> None:
+    run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "close",
+            "--repo",
+            issue_repo,
+            str(issue_number),
+        ],
+        github_token=issue_token,
+    )
+
+
+def edit_issue_body(issue_repo: str, issue_number: int, issue_token: str, body: str) -> None:
+    run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "edit",
+            "--repo",
+            issue_repo,
+            str(issue_number),
+            "--body",
+            body,
+        ],
+        github_token=issue_token,
+    )
+
+
+def summarize_md(result: dict[str, Any]) -> str:
+    lines = [
+        "## Issue Lifecycle Summary",
+        "",
+        f"- Candidates considered: {result.get('candidates_considered', 0)}",
+        f"- Processed: {result.get('processed_count', 0)}",
+        f"- Closed: {result.get('closed_count', 0)}",
+        f"- Updated: {result.get('updated_count', 0)}",
+        f"- Unchanged: {result.get('unchanged_count', 0)}",
+        "",
+        "## Decisions",
+    ]
+    for row in result.get("decisions", [])[:50]:
+        if not isinstance(row, dict):
+            continue
+        lines.append(f"- #{row.get('issue_number')} action=`{row.get('action')}` reason={row.get('reason','')[:140]}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    issue_token = os.environ.get("ISSUE_WRITE_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    main_token = os.environ.get("MAIN_REPO_READ_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    if not issue_token:
+        print("ISSUE_WRITE_TOKEN or GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+    if not main_token:
+        print("MAIN_REPO_READ_TOKEN or GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+
+    state_path = Path(args.state_json)
+    state = load_state(state_path)
+    lifecycle_state = state.setdefault("issue_lifecycle", {})
+    issues_state = lifecycle_state.setdefault("issues", {})
+    if not isinstance(issues_state, dict):
+        issues_state = {}
+        lifecycle_state["issues"] = issues_state
+
+    open_issues = list_open_ci_issues(args.issue_repo, issue_token)
+    now = now_utc()
+    threshold = dt.timedelta(hours=max(0.0, args.processed_hours))
+    candidates: list[dict[str, Any]] = []
+    for row in open_issues:
+        if not isinstance(row, dict):
+            continue
+        issue_number = int(row.get("number", 0) or 0)
+        if issue_number <= 0:
+            continue
+        tracked = issues_state.get(str(issue_number), {})
+        last_processed = parse_iso_utc(str(tracked.get("last_processed_utc", "")) if isinstance(tracked, dict) else "")
+        if last_processed and now - last_processed < threshold:
+            continue
+        candidates.append(row)
+    candidates.sort(key=lambda x: str(x.get("updatedAt", "")))
+    candidates = candidates[: max(0, args.max_issues)]
+
+    result: dict[str, Any] = {
+        "generated_at_utc": now_iso(),
+        "candidates_considered": len(candidates),
+        "processed_count": 0,
+        "closed_count": 0,
+        "updated_count": 0,
+        "unchanged_count": 0,
+        "decisions": [],
+        "skipped": [],
+    }
+
+    for issue_row in candidates:
+        issue_number = int(issue_row.get("number", 0) or 0)
+        try:
+            payload = issue_view(args.issue_repo, issue_number, issue_token)
+            target = extract_latest_run_job_url(payload)
+            if target is None:
+                result["skipped"].append({"issue_number": issue_number, "reason": "missing_run_job_url"})
+                continue
+            seed_run_id, seed_job_id = target
+            seed_run = run_view(seed_run_id, args.source_repo, main_token)
+            workflow_name = str(seed_run.get("workflowName", "")).strip()
+            target_job_name = find_job_name(seed_run, seed_job_id)
+            if not workflow_name or not target_job_name:
+                result["skipped"].append({"issue_number": issue_number, "reason": "unable_to_resolve_target_job"})
+                continue
+            workflow_runs = list_recent_runs_for_workflow(args.source_repo, workflow_name, main_token)
+            selected = pick_latest_three_job_instances(args.source_repo, main_token, workflow_runs, target_job_name)
+            if len(selected) < 3:
+                result["skipped"].append({"issue_number": issue_number, "reason": "fewer_than_three_runs"})
+                continue
+            for row in selected:
+                row["log_excerpt"] = fetch_job_log_excerpt(
+                    args.source_repo,
+                    main_token,
+                    int(row["run_id"]),
+                    int(row["job_id"]),
+                )
+            decision = agent_decide_issue_action(
+                issue_payload=payload,
+                target_job_name=target_job_name,
+                selected_runs=selected,
+                model=args.model,
+            )
+            action = str(decision.get("action", "unchanged"))
+            confidence = str(decision.get("confidence", "")).strip().lower()
+            signal_mix = str(decision.get("signal_mix", "")).strip().lower()
+            if action == "unchanged" and confidence == "medium" and signal_mix == "mixed":
+                action = "update"
+                if not str(decision.get("comment", "")).strip():
+                    decision["comment"] = (
+                        "Auto-triage lifecycle review: evidence is mixed at medium confidence. "
+                        "Keeping this issue open with a watching update until the signal becomes clearer."
+                    )
+            comment = str(decision.get("comment", "")).strip()
+            most_recent_job_url = str(decision.get("most_recent_job_url", "")).strip() or str(selected[0]["job_url"])
+            last_three_job_urls = [
+                str(x)
+                for x in (decision.get("last_three_job_urls") or [])
+                if isinstance(x, str) and x.startswith("http")
+            ] or [str(row["job_url"]) for row in selected[:3]]
+            current_signature = str(decision.get("current_signature", "")).strip()
+            if action == "close":
+                if has_recent_lifecycle_comment(payload, now=now, hours=max(0.0, args.processed_hours)):
+                    result["skipped"].append(
+                        {
+                            "issue_number": issue_number,
+                            "reason": "recent_lifecycle_comment_guard",
+                        }
+                    )
+                    issues_state[str(issue_number)] = {
+                        "last_processed_utc": now_iso(),
+                        "last_action": "unchanged",
+                        "last_reason": "recent_lifecycle_comment_guard",
+                    }
+                    continue
+                close_comment = comment or (
+                    "Auto-triage lifecycle review: closing as latest 3 runs suggest this ticket is no longer the "
+                    "right active failure signature.\n\n"
+                    f"Most recent reviewed job: {most_recent_job_url}"
+                )
+                comment_issue(args.issue_repo, issue_number, issue_token, close_comment)
+                close_issue(args.issue_repo, issue_number, issue_token)
+                result["closed_count"] += 1
+            elif action == "update":
+                if has_recent_lifecycle_comment(payload, now=now, hours=max(0.0, args.processed_hours)):
+                    result["skipped"].append(
+                        {
+                            "issue_number": issue_number,
+                            "reason": "recent_lifecycle_comment_guard",
+                        }
+                    )
+                    issues_state[str(issue_number)] = {
+                        "last_processed_utc": now_iso(),
+                        "last_action": "unchanged",
+                        "last_reason": "recent_lifecycle_comment_guard",
+                    }
+                    continue
+                updated_body = update_issue_body_minimal(
+                    str(payload.get("body", "")),
+                    most_recent_job_url=most_recent_job_url,
+                    last_three_job_urls=last_three_job_urls,
+                    current_signature=current_signature,
+                )
+                edit_issue_body(args.issue_repo, issue_number, issue_token, updated_body)
+                if comment:
+                    comment_issue(args.issue_repo, issue_number, issue_token, comment)
+                result["updated_count"] += 1
+            else:
+                result["unchanged_count"] += 1
+            issues_state[str(issue_number)] = {
+                "last_processed_utc": now_iso(),
+                "last_action": action,
+                "last_reason": str(decision.get("reason", ""))[:500],
+            }
+            result["processed_count"] += 1
+            result["decisions"].append(
+                {
+                    "issue_number": issue_number,
+                    "action": action,
+                    "reason": str(decision.get("reason", "")),
+                    "workflow_name": workflow_name,
+                    "target_job_name": target_job_name,
+                    "most_recent_job_url": most_recent_job_url,
+                }
+            )
+        except Exception as exc:
+            result["skipped"].append({"issue_number": issue_number, "reason": f"error:{exc}"})
+
+    save_state(state_path, state)
+    out_path = Path(args.output_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(result, indent=2), encoding="utf-8")
+    summary_path = Path(args.summary_md)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(summarize_md(result), encoding="utf-8")
+    print(json.dumps({"processed_count": result["processed_count"], "closed_count": result["closed_count"]}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/m4_create_issues_and_notify.py
+++ b/tools/ci/m4_create_issues_and_notify.py
@@ -1,0 +1,1243 @@
+#!/usr/bin/env python3
+"""M4: Create issues from deterministic aggregate failures and notify Slack."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.codeowners import codeowners_match, parse_codeowners  # noqa: F401 – re-exported
+from tools.ci.common.github import github_user_info  # noqa: F401 – re-exported
+from tools.ci.common.guarded import run_guarded_gh  # noqa: F401 – re-exported
+from tools.ci.common.markers import parse_agent_json_payload, strip_json_fence  # noqa: F401
+from tools.ci.common.run_helper import run  # noqa: F401 – re-exported
+from tools.ci.common.slack import post_slack_message, slack_api_form  # noqa: F401 – re-exported
+
+PRIMARY_REPO = "tenstorrent/tt-metal"
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+SLACK_CHANNEL_TEST = "C0APK6215B5"
+MARKER = "===FINAL_M4_REVIEW_DECISION==="
+PATH_PATTERN = re.compile(r"(?<![A-Za-z0-9_.-])((?:tt_metal|ttnn|models|tests|\\.github)/[A-Za-z0-9_./-]+)")
+MAX_OWNER_MENTIONS = 3
+JOB_OWNERS_PATH = Path(".github/actions/analyze-workflow-data/owners.json")
+
+
+def log(message: str) -> None:
+    print(f"[m4] {message}", flush=True)
+
+
+def parse_job_url(url: str) -> tuple[int, int]:
+    m = re.search(r"/actions/runs/(\d+)/job/(\d+)", url)
+    if not m:
+        raise ValueError(f"unsupported job URL format: {url}")
+    return int(m.group(1)), int(m.group(2))
+
+
+def load_candidates(path: Path) -> list[dict[str, Any]]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    jobs = payload.get("jobs", [])
+    if not isinstance(jobs, list):
+        return []
+    return [job for job in jobs if isinstance(job, dict)]
+
+
+def load_optional_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def write_job_log_file(*, job_url: str, read_token: str, out_path: Path) -> Path:
+    run_id, job_id = parse_job_url(job_url)
+    proc = run_guarded_gh(
+        ["gh", "run", "view", str(run_id), "--repo", PRIMARY_REPO, "--job", str(job_id), "--log-failed"],
+        github_token=read_token,
+    )
+    text = (proc.stdout or "").strip()
+    if not text:
+        proc = run_guarded_gh(
+            ["gh", "run", "view", str(run_id), "--repo", PRIMARY_REPO, "--job", str(job_id), "--log"],
+            github_token=read_token,
+        )
+        text = (proc.stdout or "").strip()
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(text, encoding="utf-8")
+    return out_path
+
+
+def parse_agent_json(text: str) -> dict[str, Any]:
+    parsed = _parse_agent_json_payload(text, marker=MARKER)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"expected JSON object for single decision payload, got {type(parsed).__name__}")
+    return parsed
+
+
+_parse_agent_json_payload = parse_agent_json_payload
+_strip_json_fence = strip_json_fence
+
+
+def load_command_spec(path: str, fallback: str) -> str:
+    p = Path(path)
+    if not p.exists():
+        return fallback
+    return p.read_text(encoding="utf-8")
+
+
+def fetch_recent_slack_messages(*, slack_token: str, channel_id: str, limit: int = 20) -> list[dict[str, Any]]:
+    from tools.ci.common.slack import slack_api_get_simple
+
+    payload = slack_api_get_simple(slack_token, "conversations.history", {"channel": channel_id, "limit": str(limit)})
+    if not payload.get("ok", False):
+        raise RuntimeError(f"Slack history fetch failed: {payload.get('error', 'unknown_error')}")
+    messages = payload.get("messages", [])
+    return messages if isinstance(messages, list) else []
+
+
+def build_open_issue_context(open_issues: list[dict[str, Any]], cap: int = 20) -> str:
+    lines: list[str] = []
+    for issue in open_issues[:cap]:
+        number = issue.get("number")
+        title = str(issue.get("title", "")).strip()
+        url = str(issue.get("url", "")).strip()
+        body = str(issue.get("body", "")).strip()
+        marker_match = re.search(r"Auto-triage-fingerprint:\s*([A-Za-z0-9_-]+)", body)
+        fp = marker_match.group(1) if marker_match else ""
+        lines.append(f"- #{number} {title} ({url}) fingerprint={fp}")
+    return "\n".join(lines) if lines else "(none)"
+
+
+def build_recent_slack_context(messages: list[dict[str, Any]], cap: int = 10) -> str:
+    lines: list[str] = []
+    for msg in messages[:cap]:
+        ts = str(msg.get("ts", "")).strip()
+        user = str(msg.get("user", "") or msg.get("bot_id", "")).strip()
+        text = str(msg.get("text", "")).strip().replace("\n", " ")
+        if len(text) > 220:
+            text = text[:220] + "..."
+        lines.append(f"- ts={ts} user={user} text={text}")
+    return "\n".join(lines) if lines else "(none)"
+
+
+def owners_for_paths(paths: list[str], rules: list[tuple[str, list[str]]]) -> set[str]:
+    owners: set[str] = set()
+    for path in paths:
+        matched: list[str] = []
+        for pattern, rule_owners in rules:
+            if codeowners_match(path, pattern):
+                matched = rule_owners
+        owners.update(matched)
+    return owners
+
+
+def _tokenize_owner_hint(value: str) -> list[str]:
+    tokens = re.split(r"[^a-z0-9]+", value.lower())
+    return [t for t in tokens if len(t) >= 3]
+
+
+def owners_from_workflow_name(
+    workflow_name: str, *, rules: list[tuple[str, list[str]]], workflow_root: Path
+) -> set[str]:
+    if not workflow_name.strip():
+        return set()
+    hint_tokens = set(_tokenize_owner_hint(workflow_name))
+    if not hint_tokens:
+        return set()
+    matched_paths: list[str] = []
+    for ext in ("*.yaml", "*.yml"):
+        for wf in workflow_root.glob(ext):
+            rel = wf.as_posix()
+            canonical_rel = f".github/workflows/{wf.name}"
+            file_tokens = set(_tokenize_owner_hint(wf.stem))
+            overlap = len(hint_tokens.intersection(file_tokens))
+            # Require at least 2 shared tokens (or 1 when workflow name itself
+            # has only one meaningful token), to avoid broad false matches.
+            required = 1 if len(hint_tokens) == 1 else 2
+            if overlap >= required:
+                matched_paths.append(rel)
+                matched_paths.append(canonical_rel)
+    if not matched_paths:
+        return set()
+    owners: set[str] = set()
+    for rel_path in matched_paths:
+        owners.update(owners_for_paths([rel_path], rules))
+    return owners
+
+
+def normalize_owner_component(value: str) -> str:
+    lowered = value.strip().lower()
+    lowered = lowered.replace("_", " ").replace("-", " ")
+    lowered = re.sub(r"[^a-z0-9/ ]+", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered).strip()
+    return lowered
+
+
+def load_job_owner_records(path: Path = JOB_OWNERS_PATH) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    contains = payload.get("contains", []) if isinstance(payload, dict) else []
+    return [x for x in contains if isinstance(x, dict)] if isinstance(contains, list) else []
+
+
+def owner_ids_from_owner_field(value: Any) -> set[str]:
+    out: set[str] = set()
+    if isinstance(value, dict):
+        uid = str(value.get("id", "")).strip()
+        if uid:
+            out.add(uid)
+    elif isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                uid = str(item.get("id", "")).strip()
+                if uid:
+                    out.add(uid)
+    return out
+
+
+def job_owner_ids_for_failure(
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_owner_records: list[dict[str, Any]],
+) -> set[str]:
+    if not job_owner_records:
+        return set()
+    candidates = {
+        normalize_owner_component(job_name),
+        normalize_owner_component(workflow_name),
+        normalize_owner_component(f"{workflow_name} / {job_name}"),
+    }
+    candidates = {c for c in candidates if c}
+    if not candidates:
+        return set()
+    matched: set[str] = set()
+    for rec in job_owner_records:
+        component = normalize_owner_component(str(rec.get("job-name-component", "")).strip())
+        if not component:
+            continue
+        is_match = component in candidates or any(component in c or c in component for c in candidates if len(c) >= 8)
+        if not is_match:
+            continue
+        matched.update(owner_ids_from_owner_field(rec.get("owner")))
+    return matched
+
+
+def parse_auto_triage_decision(decision: dict[str, Any]) -> dict[str, Any]:
+    used = bool(decision.get("auto_triage_used", False))
+    reason = str(decision.get("auto_triage_reason", "")).strip()
+    links_raw = decision.get("auto_triage_permalinks", [])
+    links: list[str] = []
+    if isinstance(links_raw, list):
+        for item in links_raw:
+            link = str(item).strip()
+            if link.startswith("https://tenstorrent.slack.com/archives/"):
+                links.append(link)
+    links = list(dict.fromkeys(links))[:3]
+    if used and links:
+        return {
+            "used": True,
+            "reason": reason or "agent selected relevant HIGH CONFIDENCE auto-triage context",
+            "selected_count": len(links),
+            "high_confidence_count": len(links),
+            "permalinks": links,
+        }
+    return {
+        "used": False,
+        "reason": reason or "agent did not find relevant HIGH CONFIDENCE auto-triage evidence",
+        "selected_count": len(links),
+        "high_confidence_count": 0,
+        "permalinks": links,
+    }
+
+
+def extract_repo_paths(text: str) -> list[str]:
+    out: list[str] = []
+    for m in PATH_PATTERN.finditer(text):
+        value = m.group(1).strip()
+        if value and value not in out:
+            out.append(value)
+    return out
+
+
+def slack_lookup_by_email(token: str, email: str) -> str | None:
+    try:
+        payload = slack_api_form(token, "users.lookupByEmail", {"email": email})
+    except Exception:
+        return None
+    if not payload.get("ok"):
+        return None
+    user = payload.get("user", {})
+    user_id = str(user.get("id", "")).strip()
+    return user_id or None
+
+
+def slack_list_members(token: str) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    cursor = ""
+    while True:
+        params = {"limit": "200"}
+        if cursor:
+            params["cursor"] = cursor
+        payload = slack_api_form(token, "users.list", params)
+        if not payload.get("ok"):
+            break
+        batch = payload.get("members", [])
+        if isinstance(batch, list):
+            members.extend([m for m in batch if isinstance(m, dict)])
+        cursor = str(payload.get("response_metadata", {}).get("next_cursor", "")).strip()
+        if not cursor:
+            break
+    return members
+
+
+def slack_lookup_by_username(token: str, username: str, members_cache: list[dict[str, Any]] | None) -> str | None:
+    if members_cache is None:
+        return None
+    target = username.strip().lower()
+    if not target:
+        return None
+    targets = {target}
+    if target.endswith("tt") and len(target) > 2:
+        targets.add(target[:-2])
+    for member in members_cache:
+        if member.get("deleted") or member.get("is_bot"):
+            continue
+        profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+        candidates = [
+            str(member.get("name", "")),
+            str(profile.get("display_name", "")),
+            str(profile.get("real_name", "")),
+        ]
+        if any(c.strip().lower() in targets for c in candidates if c.strip()):
+            uid = str(member.get("id", "")).strip()
+            if uid:
+                return uid
+    return None
+
+
+def slack_lookup_by_full_name(full_name: str, members_cache: list[dict[str, Any]] | None) -> str | None:
+    if members_cache is None:
+        return None
+    name = full_name.strip()
+    if not name:
+        return None
+    name_l = name.lower()
+    candidate_rows: list[tuple[str, str, str, str]] = []
+    for member in members_cache:
+        if member.get("deleted") or member.get("is_bot"):
+            continue
+        uid = str(member.get("id", "")).strip()
+        if not uid:
+            continue
+        profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+        row = (
+            uid,
+            str(member.get("name", "")).strip(),
+            str(profile.get("display_name", "")).strip(),
+            str(profile.get("real_name", "")).strip(),
+        )
+        candidate_rows.append(row)
+
+    # Exact match by full name first.
+    for uid, name_field, display_name, real_name in candidate_rows:
+        values = [name_field, display_name, real_name]
+        if any(v and v.lower() == name_l for v in values):
+            return uid
+
+    # Fuzzy fallback from working GH->Slack mapping pattern:
+    # if a >=3-char name token uniquely matches one Slack member, use it.
+    words = [w.lower() for w in re.split(r"\s+", name) if len(w) >= 3]
+    seen_words: set[str] = set()
+    for word in words:
+        if word in seen_words:
+            continue
+        seen_words.add(word)
+        matches: set[str] = set()
+        for uid, name_field, display_name, real_name in candidate_rows:
+            values_l = [name_field.lower(), display_name.lower(), real_name.lower()]
+            if any(word in v for v in values_l if v):
+                matches.add(uid)
+        if len(matches) == 1:
+            return next(iter(matches))
+    return None
+
+
+def recent_author_emails_for_paths(paths: list[str], *, limit_per_path: int = 5) -> set[str]:
+    emails: set[str] = set()
+    for path in paths:
+        try:
+            proc = run(
+                ["git", "log", f"-n{limit_per_path}", "--format=%ae", "--", path],
+                check=False,
+                capture=True,
+            )
+        except Exception:
+            continue
+        for line in (proc.stdout or "").splitlines():
+            email = line.strip()
+            if email and "@" in email:
+                emails.add(email)
+    return emails
+
+
+def render_owner_mentions(
+    *,
+    issue_token: str,
+    slack_token: str,
+    workflow_name: str,
+    job_name: str,
+    text_sources: list[str],
+    members_cache: list[dict[str, Any]] | None,
+    auto_triage_user_ids: list[str] | None = None,
+    job_owner_user_ids: list[str] | None = None,
+) -> tuple[str, list[str], dict[str, Any]]:
+    combined = "\n".join(text_sources + [workflow_name, job_name])
+    paths = extract_repo_paths(combined)
+    codeowners = parse_codeowners(Path(".github/CODEOWNERS"))
+    gh_usernames = owners_for_paths(paths, codeowners)
+    codeowners_weight = 2
+    if not gh_usernames:
+        gh_usernames = owners_from_workflow_name(
+            workflow_name,
+            rules=codeowners,
+            workflow_root=Path(".github/workflows"),
+        )
+        codeowners_weight = 1
+    score_by_uid: dict[str, int] = {}
+    unresolved_handles: list[str] = []
+    source_counts = {"codeowners": 0, "commit_history": 0, "auto_triage": 0, "job_owners": 0}
+
+    for username in sorted(gh_usernames):
+        # CODEOWNERS teams (org/team) are not direct users and cannot map
+        # to a single Slack user id.
+        if "/" in username:
+            unresolved_handles.append(username)
+            continue
+        info = github_user_info(issue_token, username)
+        email = str(info.get("email", "")).strip()
+        gh_name = str(info.get("name", "")).strip()
+        gh_login = str(info.get("login", username)).strip()
+        user_id = slack_lookup_by_email(slack_token, email) if email else None
+        if not user_id:
+            user_id = slack_lookup_by_username(slack_token, gh_login, members_cache)
+        if not user_id and gh_name:
+            user_id = slack_lookup_by_full_name(gh_name, members_cache)
+        if user_id:
+            score_by_uid[user_id] = score_by_uid.get(user_id, 0) + codeowners_weight
+            source_counts["codeowners"] += 1
+        else:
+            unresolved_handles.append(username)
+
+    # Supplement with recent path authors when CODEOWNERS is sparse.
+    for email in sorted(recent_author_emails_for_paths(paths)):
+        user_id = slack_lookup_by_email(slack_token, email)
+        if user_id:
+            # Recent commit authors are usually stronger relevance signals.
+            score_by_uid[user_id] = score_by_uid.get(user_id, 0) + 3
+            source_counts["commit_history"] += 1
+
+    for uid in auto_triage_user_ids or []:
+        if uid:
+            score_by_uid[uid] = score_by_uid.get(uid, 0) + 1
+            source_counts["auto_triage"] += 1
+
+    pipeline_reorg_related = any("pipeline_reorg/" in p for p in paths)
+    job_owner_weight = 4 if pipeline_reorg_related else 2
+    for uid in job_owner_user_ids or []:
+        if uid:
+            score_by_uid[uid] = score_by_uid.get(uid, 0) + job_owner_weight
+            source_counts["job_owners"] += 1
+
+    ranked_uids = sorted(score_by_uid.items(), key=lambda kv: (-kv[1], kv[0]))
+    top_uids = [uid for uid, _ in ranked_uids[:MAX_OWNER_MENTIONS]]
+    mentions = " ".join(f"<@{uid}>" for uid in top_uids)
+    selection_meta: dict[str, Any] = {
+        "selection_method": "weighted_top3",
+        "selected_owner_count": len(top_uids),
+        "candidate_owner_count": len(score_by_uid),
+        "source_counts": source_counts,
+    }
+    return mentions, unresolved_handles, selection_meta
+
+
+def normalize_slack_text(
+    *,
+    slack_text: str,
+    issue_url: str,
+    owner_mentions: str,
+) -> str:
+    text = slack_text
+    text = re.sub(
+        r"Issue:\s*https://github\.com/tenstorrent/tt-metal/issues/TBD",
+        f"Issue: {issue_url}",
+        text,
+        flags=re.IGNORECASE,
+    )
+    text = re.sub(r"Issue:\s*TBD", f"Issue: {issue_url}", text, flags=re.IGNORECASE)
+    text = re.sub(r"Likely owners:\s*.+", f"Likely owners: {owner_mentions}", text, flags=re.IGNORECASE)
+    if issue_url not in text:
+        text = text.rstrip() + f"\nIssue: {issue_url}"
+    if "Likely owners:" not in text:
+        owner_text = owner_mentions if owner_mentions else "(owner resolution pending)"
+        text = text.rstrip() + f"\nLikely owners: {owner_text}"
+    return text
+
+
+def find_exact_previous_decision(
+    review_entries: list[dict[str, Any]],
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_urls: list[str],
+) -> dict[str, Any] | None:
+    for entry in review_entries:
+        if not isinstance(entry, dict):
+            continue
+        if str(entry.get("workflow_name", "")).strip() != workflow_name:
+            continue
+        if str(entry.get("job_name", "")).strip() != job_name:
+            continue
+        prev_decision = entry.get("decision")
+        if not isinstance(prev_decision, dict):
+            continue
+        cached_reason = str(prev_decision.get("reason", "")).lower()
+        if "only log head excerpts provided" in cached_reason:
+            continue
+        if "prompt exceeded os argument length" in cached_reason:
+            continue
+        prev_urls = entry.get("job_urls")
+        if isinstance(prev_urls, list) and [str(u).strip() for u in prev_urls] == job_urls:
+            return prev_decision
+    return None
+
+
+def decision_key(workflow_name: str, job_name: str, job_urls: list[str]) -> str:
+    return json.dumps(
+        {"workflow_name": workflow_name, "job_name": job_name, "job_urls": job_urls},
+        sort_keys=True,
+    )
+
+
+def sanitize_for_path(value: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9._-]+", "-", value.strip())
+    sanitized = sanitized.strip("-")
+    return sanitized or "item"
+
+
+def agent_review_and_prepare_outputs(
+    *,
+    workflow_name: str,
+    job_name: str,
+    job_urls: list[str],
+    log_paths: list[str],
+    open_issue_context: str,
+    recent_slack_context: str,
+    model: str,
+) -> dict[str, Any]:
+    create_ticket_spec = load_command_spec(
+        ".cursor/commands/ci/ci-create-tickets.md",
+        "Create deterministic tickets only when the same terminal failure appears in all 3 logs.",
+    )
+    slack_draft_spec = load_command_spec(
+        ".cursor/commands/ci/ci-draft-slack-ci-issue.md",
+        "Draft concise Slack incident updates with direct links.",
+    )
+    log_sections: list[str] = []
+    for idx, (url, path) in enumerate(zip(job_urls, log_paths, strict=False), start=1):
+        log_sections.append(f"Run {idx} URL: {url}\nRun {idx} local log path: {path}")
+    prompt = (
+        "You are the M4 reviewer for deterministic CI failures.\n"
+        "You MUST manually compare all three logs and determine if terminal failure signatures are the same.\n"
+        "You MUST also review existing open issues and recent Slack messages before drafting outputs.\n"
+        "CRITICAL: logs are available as local files below; inspect those files directly instead of relying on excerpts in this prompt.\n"
+        "Use shell/read tools to inspect those paths and determine the terminal failure signature.\n"
+        "Criteria: deterministic only if the same job failed 3 times in a row with semantically identical terminal failure.\n\n"
+        f"Workflow: {workflow_name}\n"
+        f"Job: {job_name}\n"
+        "Open issues context:\n"
+        f"{open_issue_context}\n\n"
+        "Recent Slack messages context:\n"
+        f"{recent_slack_context}\n\n"
+        "Ticket command guidance:\n"
+        f"{create_ticket_spec}\n\n"
+        "Slack draft guidance:\n"
+        f"{slack_draft_spec}\n\n"
+        "Decide if all three runs share one identical terminal failure signature.\n"
+        "If yes, draft issue title/body and draft initial Slack message text.\n"
+        "If uncertain, set create_issue=false and draft_slack=false.\n\n"
+        + "Log file references:\n"
+        + "\n".join(f"- {section}" for section in log_sections)
+        + "\n\nOutput marker exactly on its own line:\n"
+        + MARKER
+        + "\nThen output compact JSON only:\n"
+        + (
+            '{"deterministic":false,"confidence":"low|medium|high","signature":"","error_excerpt":"","reason":"",'
+            '"create_issue":false,"draft_slack":false,"issue_title":"","issue_body":"","slack_text":""}'
+        )
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    proc = run(cmd)
+    return parse_agent_json(proc.stdout or "")
+
+
+def parse_batch_agent_json(text: str) -> list[dict[str, Any]]:
+    parsed = _parse_agent_json_payload(text, marker=MARKER)
+    decisions = parsed.get("decisions", []) if isinstance(parsed, dict) else []
+    return decisions if isinstance(decisions, list) else []
+
+
+def agent_review_batch_prepare_outputs(
+    *,
+    jobs: list[dict[str, Any]],
+    open_issue_context: str,
+    recent_slack_context: str,
+    auto_triage_slack_json_path: str,
+    model: str,
+) -> list[dict[str, Any]]:
+    create_ticket_spec = load_command_spec(
+        ".cursor/commands/ci/ci-create-tickets.md",
+        "Create deterministic tickets only when the same terminal failure appears in all 3 logs.",
+    )
+    slack_draft_spec = load_command_spec(
+        ".cursor/commands/ci/ci-draft-slack-ci-issue.md",
+        "Draft concise Slack incident updates with direct links.",
+    )
+    sections: list[str] = []
+    for idx, job in enumerate(jobs, start=1):
+        workflow_name = str(job.get("workflow_name", "")).strip()
+        job_name = str(job.get("job_name", "")).strip()
+        job_urls = job.get("job_urls", [])
+        log_paths = job.get("log_paths", [])
+        if not isinstance(job_urls, list) or not isinstance(log_paths, list):
+            continue
+        lines = [f"[JOB {idx}]", f"Workflow: {workflow_name}", f"Job: {job_name}"]
+        for run_idx, (url, path) in enumerate(zip(job_urls, log_paths, strict=False), start=1):
+            lines.append(f"Run {run_idx} URL: {url}")
+            lines.append(f"Run {run_idx} local log path: {path}")
+        lines.append(f"Auto-triage export JSON path (full, uncurated): {auto_triage_slack_json_path}")
+        sections.append("\n".join(lines))
+    prompt = (
+        "You are the M4 reviewer for deterministic CI failures.\n"
+        "For EACH provided job, manually compare all three logs and determine if terminal failure signatures are the same.\n"
+        "You MUST review existing open issues and recent Slack messages before drafting outputs.\n"
+        "You MUST independently inspect the full auto-triage JSON export file and decide whether any "
+        "HIGH CONFIDENCE triage thread is relevant for each job. Do not rely on any pre-curated triage snippets.\n"
+        "CRITICAL: logs are available as local files below; inspect those files directly.\n"
+        "Use shell/read tools to inspect those paths and determine terminal failure signatures.\n"
+        "Criteria: deterministic only if the same job failed 3 times in a row with semantically identical terminal failure.\n\n"
+        "Open issues context:\n"
+        f"{open_issue_context}\n\n"
+        "Recent Slack messages context:\n"
+        f"{recent_slack_context}\n\n"
+        "Ticket command guidance:\n"
+        f"{create_ticket_spec}\n\n"
+        "Slack draft guidance:\n"
+        f"{slack_draft_spec}\n\n"
+        "Jobs to review:\n"
+        + "\n\n".join(sections)
+        + "\n\nOutput marker exactly on its own line:\n"
+        + MARKER
+        + "\nThen output compact JSON only:\n"
+        + '{"decisions":[{"workflow_name":"","job_name":"","job_urls":[],"deterministic":false,"confidence":"low|medium|high","signature":"","error_excerpt":"","reason":"","create_issue":false,"draft_slack":false,"issue_title":"","issue_body":"","slack_text":"","auto_triage_used":false,"auto_triage_reason":"","auto_triage_permalinks":[]}]}'
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    if model != "auto":
+        cmd[1:1] = ["--model", model]
+    proc = run(cmd)
+    return parse_batch_agent_json(proc.stdout or "")
+
+
+def fingerprint_for(workflow_name: str, job_name: str, signature: str) -> str:
+    raw = f"{workflow_name}\n{job_name}\n{signature.strip().lower()}".encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def job_identity_key(workflow_name: str, job_name: str) -> str:
+    raw = f"{workflow_name}\n{job_name}".strip().lower().encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:16]
+
+
+def issue_marker(fingerprint: str) -> str:
+    return f"Auto-triage-fingerprint: {fingerprint}"
+
+
+def issue_job_identity_marker(job_key: str) -> str:
+    return f"Auto-triage-job-key: {job_key}"
+
+
+def list_open_issue_bodies(*, issue_token: str) -> list[dict[str, Any]]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "list",
+            "--repo",
+            ISSUE_REPO_TEST,
+            "--state",
+            "open",
+            "--limit",
+            "200",
+            "--json",
+            "number,title,body,url",
+        ],
+        github_token=issue_token,
+    )
+    parsed = json.loads(proc.stdout or "[]")
+    return parsed if isinstance(parsed, list) else []
+
+
+def find_existing_issue_for_fingerprint(open_issues: list[dict[str, Any]], fingerprint: str) -> str | None:
+    marker = issue_marker(fingerprint)
+    for issue in open_issues:
+        body = str(issue.get("body", ""))
+        if marker in body:
+            return str(issue.get("url", "")).strip() or None
+    return None
+
+
+def find_existing_issue_for_job_identity(
+    open_issues: list[dict[str, Any]],
+    *,
+    workflow_name: str,
+    job_name: str,
+) -> str | None:
+    marker = issue_job_identity_marker(job_identity_key(workflow_name, job_name))
+    workflow_l = workflow_name.lower()
+    job_l = job_name.lower()
+    for issue in open_issues:
+        body = str(issue.get("body", ""))
+        title = str(issue.get("title", ""))
+        url = str(issue.get("url", "")).strip() or None
+        if marker in body:
+            return url
+        combined = f"{title}\n{body}".lower()
+        # Legacy fallback for older issues that predate job-key marker.
+        if workflow_l in combined and job_l in combined:
+            return url
+    return None
+
+
+def find_existing_issue_for_title(open_issues: list[dict[str, Any]], title: str) -> str | None:
+    wanted = title.strip().lower()
+    if not wanted:
+        return None
+    for issue in open_issues:
+        existing_title = str(issue.get("title", "")).strip().lower()
+        if existing_title == wanted:
+            return str(issue.get("url", "")).strip() or None
+    return None
+
+
+def create_issue(
+    *,
+    issue_token: str,
+    title: str,
+    body: str,
+) -> str:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "create",
+            "--repo",
+            ISSUE_REPO_TEST,
+            "--title",
+            title,
+            "--body",
+            body,
+            "--label",
+            "CI auto triage",
+        ],
+        github_token=issue_token,
+    )
+    return (proc.stdout or "").strip().splitlines()[-1].strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="M4 deterministic issue + Slack bootstrap automation.")
+    parser.add_argument(
+        "--failing-jobs-json",
+        default="build_ci/ci_ticketing/create_tickets/failing_jobs.json",
+    )
+    parser.add_argument(
+        "--output-json",
+        default="build_ci/ci_ticketing/create_tickets/m4_issue_and_slack_result.json",
+    )
+    parser.add_argument(
+        "--review-cache-json",
+        default="build_ci/ci_ticketing/create_tickets/m4_review_cache.json",
+    )
+    parser.add_argument(
+        "--previous-artifact-dir",
+        default="build_ci/m4_cache_prev",
+    )
+    parser.add_argument(
+        "--downloaded-logs-dir",
+        default="build_ci/ci_ticketing/create_tickets/downloaded_logs",
+    )
+    parser.add_argument("--max-candidates", type=int, default=20)
+    parser.add_argument("--max-new-issues", type=int, default=1)
+    parser.add_argument(
+        "--max-agent-reviews",
+        type=int,
+        default=0,
+        help="Deprecated: review count is no longer capped; retained for compatibility.",
+    )
+    parser.add_argument("--model", default="auto")
+    parser.add_argument(
+        "--auto-triage-slack-json",
+        default="build_ci/raw_data/slack_C0APK6215B5_last_14_days.json",
+    )
+    args = parser.parse_args()
+
+    read_token = os.environ.get("AGGREGATE_READ_TOKEN", "").strip()
+    issue_token = os.environ.get("ISSUE_WRITE_TOKEN", "").strip()
+    slack_token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not read_token:
+        print("AGGREGATE_READ_TOKEN is required", file=sys.stderr)
+        return 2
+    if not issue_token:
+        print("ISSUE_WRITE_TOKEN is required", file=sys.stderr)
+        return 2
+    if not slack_token:
+        print("SLACK_BOT_TOKEN is required", file=sys.stderr)
+        return 2
+    if not os.environ.get("CURSOR_API_KEY", "").strip():
+        print("CURSOR_API_KEY is required", file=sys.stderr)
+        return 2
+
+    jobs_path = Path(args.failing_jobs_json)
+    if not jobs_path.exists():
+        print(f"Missing failing jobs input: {jobs_path}", file=sys.stderr)
+        return 2
+    candidates = load_candidates(jobs_path)
+    if not candidates:
+        log("No failing jobs found; nothing to do.")
+        Path(args.output_json).parent.mkdir(parents=True, exist_ok=True)
+        Path(args.output_json).write_text(json.dumps({"created": [], "skipped": []}, indent=2), encoding="utf-8")
+        return 0
+
+    previous_dir = Path(args.previous_artifact_dir)
+    prev_review_path = previous_dir / "m4_review_cache.json"
+    if not prev_review_path.exists():
+        matches = list(previous_dir.rglob("m4_review_cache.json"))
+        if matches:
+            prev_review_path = matches[0]
+    prev_review_payload = load_optional_json(prev_review_path) or {}
+    prev_review_version = int(prev_review_payload.get("version", 1)) if isinstance(prev_review_payload, dict) else 1
+    prev_review_entries = prev_review_payload.get("entries", [])
+    if not isinstance(prev_review_entries, list):
+        prev_review_entries = []
+    if prev_review_version < 2:
+        prev_review_entries = []
+        log("Ignoring prior m4 review cache (version < 2).")
+    open_issues = list_open_issue_bodies(issue_token=issue_token)
+    recent_slack_messages = fetch_recent_slack_messages(
+        slack_token=slack_token, channel_id=SLACK_CHANNEL_TEST, limit=20
+    )
+    auto_triage_json_path = str(Path(args.auto_triage_slack_json))
+    job_owner_records = load_job_owner_records()
+    slack_members_cache = slack_list_members(slack_token)
+    open_issue_context = build_open_issue_context(open_issues)
+    recent_slack_context = build_recent_slack_context(recent_slack_messages)
+    created: list[dict[str, Any]] = []
+    skipped: list[dict[str, Any]] = []
+    review_cache_entries: list[dict[str, Any]] = []
+    max_new_issues = max(args.max_new_issues, 0)
+    max_agent_reviews = max(args.max_agent_reviews, 0)
+    fresh_agent_reviews = 0
+    fresh_agent_calls = 0
+    prepared: list[dict[str, Any]] = []
+    for candidate in candidates[: max(args.max_candidates, 0)]:
+        job_name = str(candidate.get("job_name", "")).strip()
+        workflow_name = str(candidate.get("workflow_name", "")).strip()
+        urls_raw = candidate.get("failing_job_urls", [])
+        if not job_name or not workflow_name or not isinstance(urls_raw, list):
+            continue
+        job_urls = [str(u).strip() for u in urls_raw if str(u).strip()][:3]
+        if len(job_urls) < 3:
+            skipped.append({"job_name": job_name, "reason": "requires_3_failing_runs"})
+            continue
+        prepared.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+            }
+        )
+
+    logs_root = Path(args.downloaded_logs_dir)
+    if logs_root.exists():
+        shutil.rmtree(logs_root)
+    logs_root.mkdir(parents=True, exist_ok=True)
+    decisions_by_key: dict[str, dict[str, Any]] = {}
+    reused_cache_keys: set[str] = set()
+    to_review: list[dict[str, Any]] = []
+
+    for item in prepared:
+        workflow_name = item["workflow_name"]
+        job_name = item["job_name"]
+        job_urls = item["job_urls"]
+        existing_by_identity = find_existing_issue_for_job_identity(
+            open_issues,
+            workflow_name=workflow_name,
+            job_name=job_name,
+        )
+        if existing_by_identity:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_job_identity:{existing_by_identity}",
+                }
+            )
+            continue
+        key = decision_key(workflow_name, job_name, job_urls)
+        prior = find_exact_previous_decision(
+            prev_review_entries,
+            workflow_name=workflow_name,
+            job_name=job_name,
+            job_urls=job_urls,
+        )
+        if prior:
+            decisions_by_key[key] = prior
+            reused_cache_keys.add(key)
+            log(f"Reused cached review decision for workflow={workflow_name} job={job_name}")
+            continue
+        job_slug = sanitize_for_path(f"{workflow_name}-{job_name}")[:120]
+        log_paths: list[str] = []
+        log_fetch_error = ""
+        for idx, url in enumerate(job_urls, start=1):
+            log_path = logs_root / job_slug / f"run{idx}.log"
+            try:
+                write_job_log_file(job_url=url, read_token=read_token, out_path=log_path)
+                log_paths.append(str(log_path))
+            except Exception as exc:
+                log_fetch_error = str(exc)
+                break
+        if log_fetch_error:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "log_fetch_failed",
+                    "details": log_fetch_error[:500],
+                }
+            )
+            log(
+                "Skipped candidate due to log fetch failure "
+                f"workflow={workflow_name} job={job_name}: {log_fetch_error[:220]}"
+            )
+            continue
+        to_review.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+                "log_paths": log_paths,
+            }
+        )
+
+    if to_review:
+        log(f"Running batched agent review for {len(to_review)} jobs")
+        try:
+            batch_decisions = agent_review_batch_prepare_outputs(
+                jobs=to_review,
+                open_issue_context=open_issue_context,
+                recent_slack_context=recent_slack_context,
+                auto_triage_slack_json_path=auto_triage_json_path,
+                model=args.model,
+            )
+            fresh_agent_calls += 1
+            batch_map: dict[str, dict[str, Any]] = {}
+            for decision in batch_decisions:
+                if not isinstance(decision, dict):
+                    continue
+                workflow_name = str(decision.get("workflow_name", "")).strip()
+                job_name = str(decision.get("job_name", "")).strip()
+                job_urls = decision.get("job_urls", [])
+                if not workflow_name or not job_name or not isinstance(job_urls, list):
+                    continue
+                normalized_urls = [str(u).strip() for u in job_urls if str(u).strip()][:3]
+                batch_map[decision_key(workflow_name, job_name, normalized_urls)] = decision
+            for review_item in to_review:
+                key = decision_key(
+                    review_item["workflow_name"],
+                    review_item["job_name"],
+                    review_item["job_urls"],
+                )
+                decision = batch_map.get(key)
+                if not decision:
+                    decision = {
+                        "deterministic": False,
+                        "confidence": "low",
+                        "signature": "",
+                        "error_excerpt": "",
+                        "reason": "Batch review did not return a decision for this job.",
+                        "create_issue": False,
+                        "draft_slack": False,
+                        "issue_title": "",
+                        "issue_body": "",
+                        "slack_text": "",
+                    }
+                decisions_by_key[key] = decision
+                fresh_agent_reviews += 1
+        except OSError as exc:
+            if exc.errno != 7:
+                raise
+            for review_item in to_review:
+                key = decision_key(
+                    review_item["workflow_name"],
+                    review_item["job_name"],
+                    review_item["job_urls"],
+                )
+                decisions_by_key[key] = {
+                    "deterministic": False,
+                    "confidence": "low",
+                    "signature": "",
+                    "error_excerpt": "",
+                    "reason": "Prompt exceeded OS argument length while sending batched file references to agent.",
+                    "create_issue": False,
+                    "draft_slack": False,
+                    "issue_title": "",
+                    "issue_body": "",
+                    "slack_text": "",
+                }
+                fresh_agent_reviews += 1
+            fresh_agent_calls += 1
+
+    for item in prepared:
+        if len(created) >= max_new_issues:
+            skipped.append({"reason": f"max_new_issues_reached:{max_new_issues}"})
+            break
+        workflow_name = item["workflow_name"]
+        job_name = item["job_name"]
+        job_urls = item["job_urls"]
+        auto_triage_user_ids: list[str] = []
+        job_owner_user_ids = sorted(
+            job_owner_ids_for_failure(
+                workflow_name=workflow_name,
+                job_name=job_name,
+                job_owner_records=job_owner_records,
+            )
+        )
+        key = decision_key(workflow_name, job_name, job_urls)
+        decision = decisions_by_key.get(key)
+        if not decision:
+            continue
+        auto_triage_selection = parse_auto_triage_decision(decision)
+        reused_cache = key in reused_cache_keys
+        review_cache_entries.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "job_urls": job_urls,
+                "decision": decision,
+                "reused_cache": reused_cache,
+            }
+        )
+        deterministic = bool(decision.get("deterministic", False))
+        confidence = str(decision.get("confidence", "low")).strip().lower()
+        signature = str(decision.get("signature", "")).strip()
+        excerpt = str(decision.get("error_excerpt", "")).strip()
+        reason = str(decision.get("reason", "")).strip()
+        create_issue_flag = bool(decision.get("create_issue", False))
+        draft_slack_flag = bool(decision.get("draft_slack", False))
+        issue_title = str(decision.get("issue_title", "")).strip()
+        issue_body_from_agent = str(decision.get("issue_body", "")).strip()
+        slack_text = str(decision.get("slack_text", "")).strip()
+        if not deterministic or confidence != "high" or not signature or not create_issue_flag:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "agent_rejected_or_low_confidence",
+                    "decision": decision,
+                }
+            )
+            log(
+                "Skipped candidate "
+                f"workflow={workflow_name} job={job_name}: {reason[:220] if reason else 'rejected_or_low_confidence'}"
+            )
+            continue
+
+        # Re-check identity here because open_issues mutates within this run
+        # after each created issue, and prepared candidates may contain repeats.
+        existing_by_identity = find_existing_issue_for_job_identity(
+            open_issues,
+            workflow_name=workflow_name,
+            job_name=job_name,
+        )
+        if existing_by_identity:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_job_identity_postcreate:{existing_by_identity}",
+                }
+            )
+            continue
+
+        fp = fingerprint_for(workflow_name, job_name, signature)
+        existing = find_existing_issue_for_fingerprint(open_issues, fp)
+        if existing:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked:{existing}",
+                    "fingerprint": fp,
+                }
+            )
+            continue
+
+        if not issue_title:
+            issue_title = f"CI auto triage: deterministic failure in {job_name}"
+        existing_by_title = find_existing_issue_for_title(open_issues, issue_title)
+        if existing_by_title:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": f"already_tracked_title:{existing_by_title}",
+                    "issue_title": issue_title,
+                }
+            )
+            continue
+        if not issue_body_from_agent:
+            issue_body_from_agent = (
+                f"Workflow: `{workflow_name}`\n"
+                f"Job: `{job_name}`\n\n"
+                f"Failure signature: `{signature}`\n\n"
+                f"Error excerpt:\n"
+                f"```\n{excerpt or reason or 'No excerpt captured'}\n```\n\n"
+                f"Failing job URLs (last 3):\n" + "\n".join(f"- {url}" for url in job_urls)
+            )
+        marker = issue_marker(fp)
+        job_marker = issue_job_identity_marker(job_identity_key(workflow_name, job_name))
+        issue_body = issue_body_from_agent
+        if marker not in issue_body:
+            issue_body = issue_body.rstrip() + "\n\n" + marker + "\n"
+        if job_marker not in issue_body:
+            issue_body = issue_body.rstrip() + "\n" + job_marker + "\n"
+        if not draft_slack_flag:
+            skipped.append(
+                {
+                    "job_name": job_name,
+                    "workflow_name": workflow_name,
+                    "reason": "agent_declined_slack_draft",
+                    "fingerprint": fp,
+                    "decision": decision,
+                }
+            )
+            continue
+        issue_url = create_issue(issue_token=issue_token, title=issue_title, body=issue_body)
+        open_issues.append({"url": issue_url, "title": issue_title, "body": issue_body})
+        if not slack_text:
+            slack_text = (
+                f"CI auto triage detected a deterministic failure (3x in a row) for `{job_name}` in `{workflow_name}`.\n"
+                f"Issue: {issue_url}\n"
+                f"Fingerprint: `{fp}`\n"
+                f"Latest run: {job_urls[0]}"
+            )
+        owner_mentions, unresolved_handles, owner_selection = render_owner_mentions(
+            issue_token=issue_token,
+            slack_token=slack_token,
+            workflow_name=workflow_name,
+            job_name=job_name,
+            text_sources=[issue_body, excerpt, reason, signature],
+            members_cache=slack_members_cache,
+            auto_triage_user_ids=auto_triage_user_ids,
+            job_owner_user_ids=job_owner_user_ids,
+        )
+        slack_text = normalize_slack_text(
+            slack_text=slack_text,
+            issue_url=issue_url,
+            owner_mentions=owner_mentions,
+        )
+        if auto_triage_selection.get("used") and auto_triage_selection.get("permalinks"):
+            permalink = str(auto_triage_selection.get("permalinks", [""])[0]).strip()
+            if permalink and permalink not in slack_text:
+                slack_text = slack_text.rstrip() + f"\nRelated auto-triage thread: {permalink}"
+        else:
+            reason = str(auto_triage_selection.get("reason", "")).strip()
+            if reason:
+                slack_text = slack_text.rstrip() + f"\nAuto-triage context: not used ({reason})."
+        if unresolved_handles:
+            slack_text = (
+                slack_text.rstrip()
+                + "\nUnresolved GitHub owner handles: "
+                + ", ".join(f"@{h}" for h in unresolved_handles)
+            )
+        slack_ts = post_slack_message(slack_token=slack_token, channel_id=SLACK_CHANNEL_TEST, text=slack_text)
+        recent_slack_messages.insert(0, {"ts": slack_ts, "user": "m4-auto-triage", "text": slack_text})
+        open_issue_context = build_open_issue_context(open_issues)
+        created.append(
+            {
+                "workflow_name": workflow_name,
+                "job_name": job_name,
+                "fingerprint": fp,
+                "issue_url": issue_url,
+                "slack_channel": SLACK_CHANNEL_TEST,
+                "slack_ts": slack_ts,
+                "job_urls": job_urls,
+                "agent_decision": decision,
+                "owner_mentions": owner_mentions,
+                "unresolved_owner_handles": unresolved_handles,
+                "owner_selection": owner_selection,
+                "auto_triage_selection": auto_triage_selection,
+            }
+        )
+        log(f"Created issue and posted Slack bootstrap: {issue_url} (ts={slack_ts})")
+
+    output = {
+        "created": created,
+        "skipped": skipped,
+        "candidate_count": len(candidates),
+        "processed_count": min(len(candidates), max(args.max_candidates, 0)),
+        "max_new_issues": max_new_issues,
+        "max_agent_reviews": max_agent_reviews,
+        "fresh_agent_reviews": fresh_agent_reviews,
+        "fresh_agent_calls": fresh_agent_calls,
+    }
+    out_path = Path(args.output_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    review_cache_payload = {
+        "version": 2,
+        "entries": review_cache_entries,
+    }
+    review_cache_path = Path(args.review_cache_json)
+    review_cache_path.parent.mkdir(parents=True, exist_ok=True)
+    review_cache_path.write_text(json.dumps(review_cache_payload, indent=2), encoding="utf-8")
+    print(json.dumps({"created_count": len(created), "skipped_count": len(skipped)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/m5_manage_issue_lifecycle.py
+++ b/tools/ci/m5_manage_issue_lifecycle.py
@@ -1,0 +1,798 @@
+#!/usr/bin/env python3
+"""M5 lifecycle manager: thread-aware follow-ups, assignment, and post-disable messaging."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import hashlib
+import re
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.codeowners import codeowners_match  # noqa: F401 – re-exported
+from tools.ci.common.github import github_user_info  # noqa: F401 – re-exported
+from tools.ci.common.guarded import run_guarded_gh  # noqa: F401 – re-exported
+from tools.ci.common.markers import parse_json_after_marker  # noqa: F401 – re-exported
+from tools.ci.common.run_helper import run  # noqa: F401 – re-exported
+from tools.ci.common.slack import post_slack_message, slack_api_form  # noqa: F401 – re-exported
+from tools.ci.common.timestamps import now_utc  # noqa: F401 – re-exported
+from tools.ci.slack_thread_agent_analysis import analyze_thread_with_agent
+
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+SLACK_CHANNEL_TEST = "C0APK6215B5"
+ISSUE_URL_RE = re.compile(r"https://github\.com/ebanerjeeTT/issue_dump/issues/(\d+)")
+
+
+def now_unix() -> float:
+    import time
+
+    return time.time()
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Run M5 lifecycle automation over Slack + triage state.")
+    p.add_argument("--slack-json", required=True)
+    p.add_argument("--state-json", required=True)
+    p.add_argument("--output-json", required=True)
+    p.add_argument("--summary-md", required=True)
+    p.add_argument("--channel-id", default=SLACK_CHANNEL_TEST)
+    p.add_argument("--warning-hours", type=float, default=24.0)
+    p.add_argument("--final-warning-hours", type=float, default=40.0)
+    p.add_argument("--disable-hours", type=float, default=48.0)
+    p.add_argument("--progress-hold-hours", type=float, default=24.0)
+    return p.parse_args()
+
+
+def parse_codeowners(path: Path) -> list[tuple[str, list[str]]]:
+    from tools.ci.common.codeowners import parse_codeowners as _parse
+
+    return _parse(path, keep_teams=False)
+
+
+def extract_repo_paths(text: str) -> list[str]:
+    path_re = re.compile(r"(?<![A-Za-z0-9_.-])((?:tt_metal|ttnn|models|tests|\\.github)/[A-Za-z0-9_./-]+)")
+    out: list[str] = []
+    for m in path_re.finditer(text):
+        path = m.group(1).strip()
+        if path and path not in out:
+            out.append(path)
+    return out
+
+
+def candidate_github_owners_from_text(text: str, rules: list[tuple[str, list[str]]]) -> list[str]:
+    paths = extract_repo_paths(text)
+    owners: list[str] = []
+    seen: set[str] = set()
+    for path in paths:
+        matched: list[str] = []
+        for pattern, ows in rules:
+            if codeowners_match(path, pattern):
+                matched = ows
+        for ow in matched:
+            low = ow.lower()
+            if low in seen:
+                continue
+            seen.add(low)
+            owners.append(ow)
+    return owners
+
+
+def post_slack_thread_message(*, slack_token: str, channel: str, thread_ts: str, text: str) -> str:
+    return post_slack_message(slack_token=slack_token, channel_id=channel, text=text, thread_ts=thread_ts)
+
+
+def slack_lookup_by_email(token: str, email: str) -> str | None:
+    if not email:
+        return None
+    try:
+        payload = slack_api_form(token, "users.lookupByEmail", {"email": email})
+    except Exception:
+        return None
+    if not payload.get("ok"):
+        return None
+    uid = str(payload.get("user", {}).get("id", "")).strip()
+    return uid or None
+
+
+def slack_auth_user_id(token: str) -> str | None:
+    try:
+        payload = slack_api_form(token, "auth.test", {})
+    except Exception:
+        return None
+    if not payload.get("ok"):
+        return None
+    user_id = str(payload.get("user_id", "")).strip()
+    return user_id or None
+
+
+def slack_user_profile(token: str, user_id: str) -> dict[str, Any]:
+    if not user_id:
+        return {}
+    try:
+        payload = slack_api_form(token, "users.info", {"user": user_id})
+    except Exception:
+        return {}
+    if not payload.get("ok"):
+        return {}
+    user = payload.get("user", {})
+    if not isinstance(user, dict):
+        return {}
+    profile = user.get("profile", {})
+    if not isinstance(profile, dict):
+        profile = {}
+    return {
+        "user_id": str(user.get("id", "")).strip(),
+        "real_name": str(profile.get("real_name", "")).strip(),
+        "display_name": str(profile.get("display_name", "")).strip(),
+        "email": str(profile.get("email", "")).strip(),
+    }
+
+
+def thread_owner_claim_via_agent(
+    *,
+    top_level_text: str,
+    thread_replies: list[dict[str, Any]],
+    bot_user_ids: set[str],
+    model: str,
+) -> dict[str, Any]:
+    curated_replies = []
+    for reply in thread_replies[-16:]:
+        if not isinstance(reply, dict):
+            continue
+        curated_replies.append(
+            {
+                "ts": str(reply.get("ts", "")).strip(),
+                "user": str(reply.get("user", "")).strip(),
+                "text": str(reply.get("text", "")).strip(),
+            }
+        )
+    prompt_payload = {
+        "top_level_text": top_level_text[:1600],
+        "thread_replies": curated_replies,
+        "bot_user_ids": sorted(bot_user_ids),
+        "task": (
+            "Determine whether a non-bot thread reply contains a clear ownership claim "
+            "(e.g., the person says they are working on it / will fix)."
+        ),
+    }
+    prompt = (
+        "You are classifying CI triage thread ownership claims.\n"
+        "Token-efficiency rule: do one short pass and output only final JSON contract.\n"
+        "Rules:\n"
+        "- Only consider non-bot replies (exclude user ids in bot_user_ids).\n"
+        "- Return claimed=true only for explicit self-ownership/fix intent.\n"
+        "- Do not infer from vague or generic text.\n"
+        "- Prefer precision over recall.\n"
+        "At end print marker exactly on its own line:\n"
+        "===FINAL_OWNER_CLAIM_JSON===\n"
+        "Then print only JSON object:\n"
+        "{\n"
+        '  "claimed": true|false,\n'
+        '  "slack_user_id": "U123" or "",\n'
+        '  "confidence": "high|medium|low",\n'
+        '  "reason": "short reason"\n'
+        "}\n\n"
+        f"Input JSON:\n{json.dumps(prompt_payload, ensure_ascii=True)}\n"
+    )
+    cmd = ["agent", "--trust", "-p", prompt]
+    model_name = model.strip()
+    if model_name and model_name != "auto":
+        cmd.extend(["--model", model_name])
+    proc = run(cmd)
+    parsed = parse_json_after_marker(proc.stdout or "", "===FINAL_OWNER_CLAIM_JSON===")
+    claimed = bool(parsed.get("claimed", False))
+    user_id = str(parsed.get("slack_user_id", "")).strip()
+    if claimed and not user_id:
+        return {"claimed": False, "slack_user_id": "", "confidence": "low", "reason": "claimed_without_user_id"}
+    return {
+        "claimed": claimed,
+        "slack_user_id": user_id,
+        "confidence": str(parsed.get("confidence", "low")).strip() or "low",
+        "reason": str(parsed.get("reason", "unspecified")).strip() or "unspecified",
+    }
+
+
+def github_search_login(token: str, query: str) -> str | None:
+    q = query.strip()
+    if not q:
+        return None
+    req = urllib.request.Request(
+        f"https://api.github.com/search/users?q={urllib.parse.quote(q)}&per_page=1",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": "tt-metal-m5-lifecycle",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            payload = json.loads(resp.read().decode("utf-8"))
+    except Exception:
+        return None
+    items = payload.get("items", [])
+    if not isinstance(items, list) or not items:
+        return None
+    first = items[0]
+    if not isinstance(first, dict):
+        return None
+    login = str(first.get("login", "")).strip()
+    return login or None
+
+
+def github_login_from_slack_profile(token: str, profile: dict[str, Any]) -> str | None:
+    email = str(profile.get("email", "")).strip()
+    real_name = str(profile.get("real_name", "")).strip()
+    display_name = str(profile.get("display_name", "")).strip()
+    if email:
+        login = github_search_login(token, f"{email} in:email")
+        if login:
+            return login
+    if real_name:
+        login = github_search_login(token, f'"{real_name}" in:fullname')
+        if login:
+            return login
+    if display_name:
+        login = github_search_login(token, f"{display_name} in:login")
+        if login:
+            return login
+    return None
+
+
+def load_state(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "updated_at_utc": now_utc(), "items": []}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("state must be object")
+    if not isinstance(payload.get("items"), list):
+        payload["items"] = []
+    return payload
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state["updated_at_utc"] = now_utc()
+    path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def issue_assignees(issue_token: str, issue_number: int) -> list[str]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "view",
+            "--repo",
+            ISSUE_REPO_TEST,
+            str(issue_number),
+            "--json",
+            "assignees",
+        ],
+        github_token=issue_token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    rows = payload.get("assignees", [])
+    out: list[str] = []
+    if isinstance(rows, list):
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            login = str(row.get("login", "")).strip()
+            if login:
+                out.append(login)
+    return out
+
+
+def assign_issue(issue_token: str, issue_number: int, github_login: str) -> bool:
+    run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "edit",
+            "--repo",
+            ISSUE_REPO_TEST,
+            str(issue_number),
+            "--add-assignee",
+            github_login,
+        ],
+        github_token=issue_token,
+    )
+    return True
+
+
+def pr_merge_info(issue_token: str, pr_url: str) -> dict[str, Any]:
+    m = re.search(r"github\.com/([^/]+/[^/]+)/pull/(\d+)", pr_url)
+    if not m:
+        return {"merged": False, "reason": "bad_pr_url"}
+    repo = m.group(1)
+    number = m.group(2)
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "pr",
+            "view",
+            "--repo",
+            repo,
+            number,
+            "--json",
+            "state,mergedAt",
+        ],
+        github_token=issue_token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    merged = bool(payload.get("mergedAt"))
+    state = str(payload.get("state", "")).strip().upper()
+    return {"merged": merged, "state": state, "merged_at": payload.get("mergedAt")}
+
+
+def message_by_ts(slack_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    out: dict[str, dict[str, Any]] = {}
+    messages = slack_payload.get("messages", [])
+    if not isinstance(messages, list):
+        return out
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        ts = str(msg.get("ts", "")).strip()
+        if ts:
+            out[ts] = msg
+    return out
+
+
+def message_replies(msg: dict[str, Any]) -> list[dict[str, Any]]:
+    replies = msg.get("thread_replies")
+    if not isinstance(replies, list):
+        replies = msg.get("replies")
+    if not isinstance(replies, list):
+        return []
+    return [row for row in replies if isinstance(row, dict)]
+
+
+def infer_notification_state_from_thread_replies(
+    notif: dict[str, Any],
+    thread_replies: list[dict[str, Any]],
+) -> None:
+    if not isinstance(notif, dict):
+        return
+    warning_24_prefix = "CI auto triage follow-up: this issue is still unresolved after"
+    warning_final_prefix = "CI auto triage final warning: issue remains unresolved near disable SLA threshold."
+    post_disable_prefix = "disable PR merged for this incident"
+    for reply in thread_replies:
+        text = str(reply.get("text", "")).strip()
+        ts = str(reply.get("ts", "")).strip()
+        if not text or not ts:
+            continue
+        if warning_24_prefix in text and not notif.get("warning_24h_sent_ts"):
+            notif["warning_24h_sent_ts"] = ts
+        if warning_final_prefix in text and not notif.get("warning_final_sent_ts"):
+            notif["warning_final_sent_ts"] = ts
+        if post_disable_prefix in text and not notif.get("post_disable_followup_sent_ts"):
+            notif["post_disable_followup_sent_ts"] = ts
+
+
+def issue_numbers_from_text(text: str) -> list[int]:
+    nums: list[int] = []
+    for m in ISSUE_URL_RE.finditer(text):
+        value = int(m.group(1))
+        if value not in nums:
+            nums.append(value)
+    return nums
+
+
+def summary_md(data: dict[str, Any]) -> str:
+    lines = [
+        "## M5 Lifecycle Summary",
+        "",
+        f"- Warning messages posted: {len(data.get('warnings_posted', []))}",
+        f"- Final warnings posted: {len(data.get('final_warnings_posted', []))}",
+        f"- Post-disable follow-ups posted: {len(data.get('post_disable_followups', []))}",
+        f"- Issue assignments added: {len(data.get('assignments_added', []))}",
+        f"- Fix requests detected: {len(data.get('fix_requests_detected', []))}",
+        "",
+        "## Notes",
+    ]
+    for note in data.get("notes", [])[:20]:
+        lines.append(f"- {note}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    issue_token = os.environ.get("ISSUE_WRITE_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    slack_token = os.environ.get("SLACK_BOT_TOKEN", "").strip()
+    if not issue_token:
+        print("ISSUE_WRITE_TOKEN or GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+    if not slack_token:
+        print("SLACK_BOT_TOKEN is required", file=sys.stderr)
+        return 2
+    if args.channel_id != SLACK_CHANNEL_TEST:
+        print(f"Refusing non-test Slack channel for bootstrap: {args.channel_id}", file=sys.stderr)
+        return 2
+
+    slack_payload = json.loads(Path(args.slack_json).read_text(encoding="utf-8"))
+    state_path = Path(args.state_json)
+    state = load_state(state_path)
+    by_ts = message_by_ts(slack_payload)
+    rules = parse_codeowners(Path(".github/CODEOWNERS"))
+    now = now_unix()
+    bot_user_id = slack_auth_user_id(slack_token)
+    bot_user_ids: set[str] = {bot_user_id} if bot_user_id else set()
+    slack_profile_cache: dict[str, dict[str, Any]] = {}
+    slack_to_github_cache: dict[str, str | None] = {}
+    owner_claim_cache: dict[str, dict[str, Any]] = {}
+    thread_analysis_cache: dict[str, dict[str, Any]] = {}
+    m5_agent_model = os.environ.get("M5_AGENT_MODEL", "").strip() or "auto"
+
+    output: dict[str, Any] = {
+        "generated_at_utc": now_utc(),
+        "warnings_posted": [],
+        "final_warnings_posted": [],
+        "post_disable_followups": [],
+        "assignments_added": [],
+        "fix_requests_detected": [],
+        "notes": [],
+    }
+
+    for item in state.get("items", []):
+        if not isinstance(item, dict):
+            continue
+        ts = str(item.get("slack_ts", "")).strip()
+        if not ts:
+            continue
+        msg = by_ts.get(ts)
+        if not msg:
+            output["notes"].append(f"missing_source_message_for_ts:{ts}")
+            continue
+        issue_numbers = item.get("issue_numbers", [])
+        issue_number = int(issue_numbers[0]) if isinstance(issue_numbers, list) and issue_numbers else 0
+        if issue_number <= 0:
+            output["notes"].append(f"missing_issue_number_for_ts:{ts}")
+            continue
+
+        top_text = str(msg.get("text", ""))
+        thread_replies = message_replies(msg)
+        thread_fingerprint = hashlib.sha256(
+            json.dumps(
+                [{"ts": r.get("ts"), "user": r.get("user"), "text": r.get("text")} for r in thread_replies[-16:]],
+                sort_keys=True,
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        analysis_cache_key = f"{ts}:{thread_fingerprint}:progress_fix"
+        analysis = thread_analysis_cache.get(analysis_cache_key)
+        if analysis is None:
+            try:
+                analysis = analyze_thread_with_agent(
+                    top_level_text=top_text,
+                    thread_replies=thread_replies,
+                    bot_user_ids=bot_user_ids,
+                    hold_hours_after_progress=args.progress_hold_hours,
+                    include_owner_claim=False,
+                    model=m5_agent_model,
+                )
+            except Exception as exc:
+                output["notes"].append(f"thread_progress_fix_agent_error_issue_{issue_number}:{exc}")
+                analysis = {
+                    "progress_state": "no_progress",
+                    "confidence": "low",
+                    "defer_disable": False,
+                    "progress_reason": "agent_failed",
+                    "fix_request_requested": False,
+                    "fix_request_reason": "agent_failed",
+                }
+            thread_analysis_cache[analysis_cache_key] = analysis
+        progress = {
+            "progress_state": analysis.get("progress_state", "no_progress"),
+            "confidence": analysis.get("confidence", "low"),
+            "defer_disable": bool(analysis.get("defer_disable", False)),
+            "reason": analysis.get("progress_reason", "unspecified"),
+        }
+        fix_request = {
+            "requested": bool(analysis.get("fix_request_requested", False)),
+            "reason": analysis.get("fix_request_reason", "unspecified"),
+        }
+        if fix_request.get("requested"):
+            output["fix_requests_detected"].append(
+                {"source_slack_ts": ts, "issue_number": issue_number, "reason": fix_request.get("reason", "")}
+            )
+
+        age_hours = max(0.0, (now - float(ts)) / 3600.0)
+        notif = item.setdefault("notification", {})
+        if not isinstance(notif, dict):
+            notif = {}
+            item["notification"] = notif
+        infer_notification_state_from_thread_replies(notif, thread_replies)
+
+        issue_closed = bool(msg.get("issue_closed", False))
+        if issue_closed:
+            output["notes"].append(f"skip_closed_issue:{issue_number}")
+            continue
+
+        assignees = issue_assignees(issue_token, issue_number)
+        if not assignees:
+            claim_cache_key = f"{ts}:{thread_fingerprint}"
+            claim = owner_claim_cache.get(claim_cache_key)
+            if claim is None:
+                try:
+                    claim = thread_owner_claim_via_agent(
+                        top_level_text=top_text,
+                        thread_replies=thread_replies,
+                        bot_user_ids=bot_user_ids,
+                        model=m5_agent_model,
+                    )
+                except Exception as exc:
+                    reason = f"agent_owner_claim_failed:{exc}"
+                    claim = {"claimed": False, "reason": reason}
+                    output["notes"].append(f"thread_owner_claim_agent_error_issue_{issue_number}:{exc}")
+                owner_claim_cache[claim_cache_key] = claim
+            if claim.get("claimed"):
+                claim_user_id = str(claim.get("slack_user_id", "")).strip()
+                github_login = slack_to_github_cache.get(claim_user_id)
+                if github_login is None and claim_user_id not in slack_to_github_cache:
+                    profile = slack_profile_cache.get(claim_user_id)
+                    if profile is None:
+                        profile = slack_user_profile(slack_token, claim_user_id)
+                        slack_profile_cache[claim_user_id] = profile
+                    github_login = github_login_from_slack_profile(issue_token, profile)
+                    slack_to_github_cache[claim_user_id] = github_login
+                if github_login:
+                    try:
+                        assign_issue(issue_token, issue_number, github_login)
+                        output["assignments_added"].append(
+                            {
+                                "issue_number": issue_number,
+                                "assigned_github_login": github_login,
+                                "source": "thread_owner_claim",
+                                "source_slack_user_id": claim_user_id,
+                            }
+                        )
+                        post_slack_thread_message(
+                            slack_token=slack_token,
+                            channel=args.channel_id,
+                            thread_ts=ts,
+                            text=(
+                                f"Acknowledged — assigning this incident to <@{claim_user_id}> "
+                                f"(GitHub: @{github_login}) based on thread ownership signal."
+                            ),
+                        )
+                        assignees = [github_login]
+                    except Exception as exc:
+                        output["notes"].append(f"thread_claim_assignment_failed_issue_{issue_number}:{exc}")
+                        post_slack_thread_message(
+                            slack_token=slack_token,
+                            channel=args.channel_id,
+                            thread_ts=ts,
+                            text=(
+                                "I detected an ownership claim but could not auto-assign this GitHub issue. "
+                                "Please self-assign the issue in GitHub, or post your exact GitHub handle here "
+                                "so assignment can be retried."
+                            ),
+                        )
+                else:
+                    output["notes"].append(
+                        f"thread_claim_no_github_match_issue_{issue_number}:slack_user={claim_user_id}"
+                    )
+                    post_slack_thread_message(
+                        slack_token=slack_token,
+                        channel=args.channel_id,
+                        thread_ts=ts,
+                        text=(
+                            "I detected an ownership claim but could not map your Slack identity to a GitHub login. "
+                            "Please self-assign the issue in GitHub, or reply with your GitHub handle."
+                        ),
+                    )
+
+        # Stage warnings unless thread has active high-confidence progress.
+        if not bool(progress.get("defer_disable", False)):
+            if age_hours >= args.warning_hours and not notif.get("warning_24h_sent_ts"):
+                warning_text = (
+                    f"CI auto triage follow-up: this issue is still unresolved after {int(args.warning_hours)}h. "
+                    f"If unresolved by {int(args.disable_hours)}h, a disable PR may be proposed."
+                )
+                posted_ts = post_slack_thread_message(
+                    slack_token=slack_token,
+                    channel=args.channel_id,
+                    thread_ts=ts,
+                    text=warning_text,
+                )
+                notif["warning_24h_sent_ts"] = posted_ts
+                output["warnings_posted"].append(
+                    {"source_slack_ts": ts, "issue_number": issue_number, "posted_ts": posted_ts}
+                )
+            if age_hours >= args.final_warning_hours and not notif.get("warning_final_sent_ts"):
+                warning_text = (
+                    "CI auto triage final warning: issue remains unresolved near disable SLA threshold. "
+                    "Please post status or fix PR link to defer disable."
+                )
+                posted_ts = post_slack_thread_message(
+                    slack_token=slack_token,
+                    channel=args.channel_id,
+                    thread_ts=ts,
+                    text=warning_text,
+                )
+                notif["warning_final_sent_ts"] = posted_ts
+                output["final_warnings_posted"].append(
+                    {"source_slack_ts": ts, "issue_number": issue_number, "posted_ts": posted_ts}
+                )
+
+        # Post-disable follow-up + assignment when disable PR merged.
+        disable_pr = item.get("disable_pr", {})
+        pr_url = str(disable_pr.get("url", "")).strip() if isinstance(disable_pr, dict) else ""
+        if pr_url and not notif.get("post_disable_followup_sent_ts"):
+            info = pr_merge_info(issue_token, pr_url)
+            if info.get("merged"):
+                assigned_login = assignees[0] if assignees else ""
+                if not assigned_login:
+                    owners = candidate_github_owners_from_text(top_text, rules)
+                    if owners:
+                        try:
+                            assign_issue(issue_token, issue_number, owners[0])
+                            assigned_login = owners[0]
+                            output["assignments_added"].append(
+                                {"issue_number": issue_number, "assigned_github_login": assigned_login}
+                            )
+                        except Exception as exc:
+                            output["notes"].append(f"assignment_failed_issue_{issue_number}:{exc}")
+                mention = ""
+                if assigned_login:
+                    info_user = github_user_info(issue_token, assigned_login)
+                    slack_uid = slack_lookup_by_email(slack_token, str(info_user.get("email", "")).strip())
+                    if slack_uid:
+                        mention = f"<@{slack_uid}> "
+                followup = (
+                    f"{mention}disable PR merged for this incident ({pr_url}). "
+                    "Please follow through on root-cause fix and post fix PR link; "
+                    "we should re-enable once stable."
+                ).strip()
+                posted_ts = post_slack_thread_message(
+                    slack_token=slack_token,
+                    channel=args.channel_id,
+                    thread_ts=ts,
+                    text=followup,
+                )
+                notif["post_disable_followup_sent_ts"] = posted_ts
+                output["post_disable_followups"].append(
+                    {"source_slack_ts": ts, "issue_number": issue_number, "posted_ts": posted_ts, "pr_url": pr_url}
+                )
+
+    # Ad-hoc assignment path for unresolved Slack issues not yet represented in triage state.
+    tracked_issue_numbers = {
+        int(row.get("issue_number", 0))
+        for row in output.get("assignments_added", [])
+        if isinstance(row, dict) and int(row.get("issue_number", 0) or 0) > 0
+    }
+    for msg in slack_payload.get("messages", []):
+        if not isinstance(msg, dict):
+            continue
+        if bool(msg.get("issue_closed", False)):
+            continue
+        top_text = str(msg.get("text", "")).strip()
+        if not top_text:
+            continue
+        issue_numbers = issue_numbers_from_text(top_text)
+        if not issue_numbers:
+            continue
+        issue_number = issue_numbers[0]
+        if issue_number in tracked_issue_numbers:
+            continue
+        assignees = issue_assignees(issue_token, issue_number)
+        if assignees:
+            continue
+        ts = str(msg.get("ts", "")).strip()
+        if not ts:
+            continue
+        thread_replies = message_replies(msg)
+        if not thread_replies:
+            continue
+        thread_fingerprint = hashlib.sha256(
+            json.dumps(
+                [{"ts": r.get("ts"), "user": r.get("user"), "text": r.get("text")} for r in thread_replies[-16:]],
+                sort_keys=True,
+                ensure_ascii=True,
+            ).encode("utf-8")
+        ).hexdigest()
+        claim_cache_key = f"{ts}:{thread_fingerprint}"
+        claim = owner_claim_cache.get(claim_cache_key)
+        if claim is None:
+            try:
+                claim = thread_owner_claim_via_agent(
+                    top_level_text=top_text,
+                    thread_replies=thread_replies,
+                    bot_user_ids=bot_user_ids,
+                    model=m5_agent_model,
+                )
+            except Exception as exc:
+                reason = f"agent_owner_claim_failed:{exc}"
+                claim = {"claimed": False, "reason": reason}
+                output["notes"].append(f"ad_hoc_owner_claim_agent_error_issue_{issue_number}:{exc}")
+            owner_claim_cache[claim_cache_key] = claim
+        if not claim.get("claimed"):
+            continue
+        claim_user_id = str(claim.get("slack_user_id", "")).strip()
+        github_login = slack_to_github_cache.get(claim_user_id)
+        if github_login is None and claim_user_id not in slack_to_github_cache:
+            profile = slack_profile_cache.get(claim_user_id)
+            if profile is None:
+                profile = slack_user_profile(slack_token, claim_user_id)
+                slack_profile_cache[claim_user_id] = profile
+            github_login = github_login_from_slack_profile(issue_token, profile)
+            slack_to_github_cache[claim_user_id] = github_login
+        if not github_login:
+            output["notes"].append(
+                f"ad_hoc_thread_claim_no_github_match_issue_{issue_number}:slack_user={claim_user_id}"
+            )
+            post_slack_thread_message(
+                slack_token=slack_token,
+                channel=args.channel_id,
+                thread_ts=ts,
+                text=(
+                    "Ownership claim detected, but I could not map this Slack user to a GitHub login. "
+                    "Please self-assign the issue or reply with your GitHub handle."
+                ),
+            )
+            continue
+        try:
+            assign_issue(issue_token, issue_number, github_login)
+            output["assignments_added"].append(
+                {
+                    "issue_number": issue_number,
+                    "assigned_github_login": github_login,
+                    "source": "ad_hoc_thread_owner_claim",
+                    "source_slack_user_id": claim_user_id,
+                }
+            )
+            post_slack_thread_message(
+                slack_token=slack_token,
+                channel=args.channel_id,
+                thread_ts=ts,
+                text=(
+                    f"Acknowledged — assigning this incident to <@{claim_user_id}> "
+                    f"(GitHub: @{github_login}) based on thread ownership signal."
+                ),
+            )
+            tracked_issue_numbers.add(issue_number)
+        except Exception as exc:
+            output["notes"].append(f"ad_hoc_thread_claim_assignment_failed_issue_{issue_number}:{exc}")
+            post_slack_thread_message(
+                slack_token=slack_token,
+                channel=args.channel_id,
+                thread_ts=ts,
+                text=(
+                    "Ownership claim detected, but auto-assignment failed. "
+                    "Please self-assign this issue in GitHub, or reply with your GitHub handle to retry."
+                ),
+            )
+
+    save_state(state_path, state)
+    out_path = Path(args.output_json)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    sm = Path(args.summary_md)
+    sm.parent.mkdir(parents=True, exist_ok=True)
+    sm.write_text(summary_md(output), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "warnings_posted": len(output["warnings_posted"]),
+                "final_warnings_posted": len(output["final_warnings_posted"]),
+                "post_disable_followups": len(output["post_disable_followups"]),
+                "fix_requests_detected": len(output["fix_requests_detected"]),
+            }
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/m6_bug_escape_enrichment.py
+++ b/tools/ci/m6_bug_escape_enrichment.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""M6 bug-escape enrichment for CI triage issues in test repo."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.guarded import run_guarded_gh  # noqa: F401 – re-exported
+from tools.ci.common.run_helper import run  # noqa: F401 – re-exported
+from tools.ci.common.timestamps import now_utc  # noqa: F401 – re-exported
+
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+PRIMARY_REPO = "tenstorrent/tt-metal"
+LAYER_ORDER = {"llk": 1, "metalium": 2, "ttnn": 3, "models": 4, "infra": 5, "unknown": 99}
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(description="Build bug-escape enrichment records for closed CI triage issues.")
+    p.add_argument("--state-json", required=True)
+    p.add_argument("--output-json", required=True)
+    p.add_argument("--summary-md", required=True)
+    p.add_argument("--issue-repo", default=ISSUE_REPO_TEST)
+    return p.parse_args()
+
+
+def infer_layer_from_text(text: str) -> str:
+    t = text.lower()
+    if "llk" in t:
+        return "llk"
+    if "metalium" in t or "tt_metal" in t or "llrt" in t:
+        return "metalium"
+    if "ttnn" in t:
+        return "ttnn"
+    if "model" in t:
+        return "models"
+    if "infra" in t or "pipeline" in t:
+        return "infra"
+    return "unknown"
+
+
+def infer_layer_from_paths(paths: list[str]) -> str:
+    joined = "\n".join(paths)
+    return infer_layer_from_text(joined)
+
+
+def classify_escape_type(*, failure_layer: str, fix_layer: str) -> tuple[str, str]:
+    if failure_layer == "unknown" or fix_layer == "unknown":
+        return ("unknown", "low")
+    if LAYER_ORDER.get(fix_layer, 99) < LAYER_ORDER.get(failure_layer, 99):
+        return ("layer_escape_lower_to_higher", "high")
+    if failure_layer != fix_layer:
+        return ("gate_coverage_gap", "medium")
+    return ("unknown", "medium")
+
+
+def issue_numbers_from_state(path: Path) -> list[int]:
+    if not path.exists():
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    items = payload.get("items", []) if isinstance(payload, dict) else []
+    out: list[int] = []
+    seen: set[int] = set()
+    for item in items if isinstance(items, list) else []:
+        if not isinstance(item, dict):
+            continue
+        numbers = item.get("issue_numbers", [])
+        if not isinstance(numbers, list):
+            continue
+        for n in numbers:
+            try:
+                num = int(n)
+            except Exception:
+                continue
+            if num <= 0 or num in seen:
+                continue
+            seen.add(num)
+            out.append(num)
+    return out
+
+
+def issue_view(repo: str, issue_number: int, token: str) -> dict[str, Any]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "issue",
+            "view",
+            "--repo",
+            repo,
+            str(issue_number),
+            "--json",
+            "state,title,body,url,closedAt,labels,closedByPullRequestsReferences",
+        ],
+        github_token=token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    return payload if isinstance(payload, dict) else {}
+
+
+def pr_view(repo: str, pr_number: int, token: str) -> dict[str, Any]:
+    proc = run_guarded_gh(
+        [
+            "gh",
+            "pr",
+            "view",
+            "--repo",
+            repo,
+            str(pr_number),
+            "--json",
+            "number,url,mergeCommit,files",
+        ],
+        github_token=token,
+    )
+    payload = json.loads(proc.stdout or "{}")
+    return payload if isinstance(payload, dict) else {}
+
+
+def summarize(events: list[dict[str, Any]]) -> str:
+    high = sum(1 for e in events if e.get("correlation_confidence") == "high")
+    medium = sum(1 for e in events if e.get("correlation_confidence") == "medium")
+    low = sum(1 for e in events if e.get("correlation_confidence") == "low")
+    lines = [
+        "## M6 Bug Escape Enrichment",
+        "",
+        f"- Events captured: {len(events)}",
+        f"- High confidence: {high}",
+        f"- Medium confidence: {medium}",
+        f"- Low confidence: {low}",
+        "",
+        "## Sample",
+    ]
+    for event in events[:5]:
+        lines.append(
+            f"- issue #{event.get('issue_number')} -> PR {event.get('fix_pr_number')} "
+            f"| {event.get('failure_layer')} -> {event.get('fix_layer')} "
+            f"| {event.get('escape_type')} ({event.get('correlation_confidence')})"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    token = os.environ.get("ISSUE_WRITE_TOKEN", "").strip() or os.environ.get("GITHUB_TOKEN", "").strip()
+    if not token:
+        print("ISSUE_WRITE_TOKEN or GITHUB_TOKEN is required", file=sys.stderr)
+        return 2
+    issues = issue_numbers_from_state(Path(args.state_json))
+    events: list[dict[str, Any]] = []
+    for issue_number in issues:
+        issue = issue_view(args.issue_repo, issue_number, token)
+        if str(issue.get("state", "")).upper() != "CLOSED":
+            continue
+        refs = issue.get("closedByPullRequestsReferences", [])
+        if not isinstance(refs, list) or not refs:
+            continue
+        pr_ref = refs[0] if isinstance(refs[0], dict) else {}
+        pr_number = int(pr_ref.get("number", 0) or 0)
+        if pr_number <= 0:
+            continue
+        pr = pr_view(PRIMARY_REPO, pr_number, token)
+        files = pr.get("files", []) if isinstance(pr, dict) else []
+        paths: list[str] = []
+        if isinstance(files, list):
+            for f in files:
+                if not isinstance(f, dict):
+                    continue
+                path = str(f.get("path", "")).strip()
+                if path:
+                    paths.append(path)
+        failure_layer = infer_layer_from_text(f"{issue.get('title','')}\n{issue.get('body','')}")
+        fix_layer = infer_layer_from_paths(paths)
+        escape_type, confidence = classify_escape_type(failure_layer=failure_layer, fix_layer=fix_layer)
+        merge_commit = pr.get("mergeCommit", {}) if isinstance(pr, dict) else {}
+        fix_sha = str(merge_commit.get("oid", "")).strip() if isinstance(merge_commit, dict) else ""
+        events.append(
+            {
+                "fingerprint": "",
+                "issue_number": issue_number,
+                "disable_pr_number": 0,
+                "fix_pr_number": pr_number,
+                "fix_commit_sha": fix_sha,
+                "problem_surface": {
+                    "layer": failure_layer,
+                    "component": "",
+                    "source": "issue_text",
+                },
+                "fix_surface": {
+                    "layer": fix_layer,
+                    "component": "",
+                    "source": "changed_files",
+                },
+                "failure_layer": failure_layer,
+                "fix_layer": fix_layer,
+                "correlation_method": "path_overlap" if fix_layer != "unknown" else "semantic_match",
+                "correlation_confidence": confidence,
+                "escape_type": escape_type,
+                "shift_left_target": "lower_layer_suite"
+                if escape_type == "layer_escape_lower_to_higher"
+                else "merge_gate",
+                "explanation": f"Issue resolved by PR #{pr_number}; inferred {failure_layer} -> {fix_layer}.",
+                "captured_at_utc": now_utc(),
+                "issue_url": str(issue.get("url", "")).strip(),
+                "fix_pr_url": str(pr.get("url", "")).strip(),
+            }
+        )
+    output_path = Path(args.output_json)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps({"events": events}, indent=2), encoding="utf-8")
+    summary_path = Path(args.summary_md)
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(summarize(events), encoding="utf-8")
+    print(json.dumps({"event_count": len(events)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/testing_owner_resolution_session.py
+++ b/tools/ci/testing_owner_resolution_session.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""Testing-mode owner resolution session for triage-ci workflow.
+
+This script:
+- extracts individual GitHub usernames from CODEOWNERS,
+- dynamically resolves Slack member ids (no hardcoded ids),
+- posts a test ping message in a Slack testing channel,
+- reads recent channel messages to measure mention quality,
+- writes JSON + markdown artifacts.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.codeowners import parse_codeowners_logins as parse_codeowners_users
+from tools.ci.common.slack import slack_api_form, slack_api_get_simple as slack_api_get
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run dynamic GitHub->Slack owner resolution testing session.")
+    parser.add_argument("--codeowners-path", required=True)
+    parser.add_argument("--slack-channel-id", required=True)
+    parser.add_argument("--max-codeowners", type=int, default=10)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--summary-md", required=True)
+    return parser.parse_args()
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing required env var: {name}")
+    return value
+
+
+def github_api_get(token: str, endpoint: str) -> dict[str, Any]:
+    from tools.ci.common.github import github_api_get as _gh_get
+
+    try:
+        return _gh_get(token, endpoint, user_agent="tt-metal-ci-triage-testing")
+    except urllib.error.HTTPError as exc:
+        return {"_error": f"http_{exc.code}"}
+    except Exception as exc:  # noqa: BLE001
+        return {"_error": f"request_failed:{exc}"}
+
+
+def slack_list_members(token: str) -> list[dict[str, Any]]:
+    members: list[dict[str, Any]] = []
+    cursor = ""
+    while True:
+        params = {"limit": "500"}
+        if cursor:
+            params["cursor"] = cursor
+        payload = slack_api_get(token, "users.list", params)
+        if not payload.get("ok"):
+            break
+        batch = payload.get("members", [])
+        if isinstance(batch, list):
+            members.extend([x for x in batch if isinstance(x, dict)])
+        cursor = str(payload.get("response_metadata", {}).get("next_cursor", "")).strip()
+        if not cursor:
+            break
+    return members
+
+
+def slack_lookup_by_email(token: str, email: str) -> str | None:
+    if not email:
+        return None
+    try:
+        payload = slack_api_form(token, "users.lookupByEmail", {"email": email})
+    except Exception:  # noqa: BLE001
+        return None
+    if not payload.get("ok"):
+        return None
+    uid = str(payload.get("user", {}).get("id", "")).strip()
+    return uid or None
+
+
+def normalize_name(value: str) -> str:
+    lowered = value.strip().lower()
+    lowered = re.sub(r"[^a-z0-9]+", " ", lowered)
+    lowered = re.sub(r"\s+", " ", lowered).strip()
+    return lowered
+
+
+def slack_lookup_in_members(
+    *, members: list[dict[str, Any]], github_login: str, github_name: str
+) -> tuple[str | None, str]:
+    login = github_login.strip().lower()
+    names_to_match = set()
+    if github_name.strip():
+        names_to_match.add(normalize_name(github_name))
+    if login:
+        names_to_match.add(normalize_name(login))
+        if login.endswith("tt") and len(login) > 2:
+            names_to_match.add(normalize_name(login[:-2]))
+
+    exact_matches: list[str] = []
+    for member in members:
+        if member.get("deleted") or member.get("is_bot"):
+            continue
+        uid = str(member.get("id", "")).strip()
+        if not uid:
+            continue
+        profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+        values = [
+            normalize_name(str(member.get("name", ""))),
+            normalize_name(str(profile.get("display_name", ""))),
+            normalize_name(str(profile.get("real_name", ""))),
+            normalize_name(str(profile.get("real_name_normalized", ""))),
+            normalize_name(str(profile.get("display_name_normalized", ""))),
+        ]
+        if any(v and v in names_to_match for v in values):
+            exact_matches.append(uid)
+
+    if len(set(exact_matches)) == 1:
+        return exact_matches[0], "members_exact"
+
+    # Unique token match from full name words (>=3 chars).
+    if github_name.strip():
+        tokens = [t for t in normalize_name(github_name).split(" ") if len(t) >= 3]
+        for token in tokens:
+            candidate_ids: set[str] = set()
+            for member in members:
+                if member.get("deleted") or member.get("is_bot"):
+                    continue
+                uid = str(member.get("id", "")).strip()
+                if not uid:
+                    continue
+                profile = member.get("profile", {}) if isinstance(member.get("profile"), dict) else {}
+                values = [
+                    normalize_name(str(member.get("name", ""))),
+                    normalize_name(str(profile.get("display_name", ""))),
+                    normalize_name(str(profile.get("real_name", ""))),
+                ]
+                if any(token in v for v in values if v):
+                    candidate_ids.add(uid)
+            if len(candidate_ids) == 1:
+                return next(iter(candidate_ids)), f"members_unique_token:{token}"
+
+    return None, "unresolved"
+
+
+def resolve_github_to_slack(
+    *, github_token: str, slack_token: str, members: list[dict[str, Any]], github_login: str
+) -> dict[str, Any]:
+    gh = github_api_get(github_token, f"/users/{urllib.parse.quote(github_login)}")
+    if gh.get("_error"):
+        return {"github_login": github_login, "resolved": False, "reason": str(gh["_error"])}
+    email = str(gh.get("email", "")).strip()
+    name = str(gh.get("name", "")).strip()
+    login = str(gh.get("login", github_login)).strip() or github_login
+
+    by_email = slack_lookup_by_email(slack_token, email)
+    if by_email:
+        return {
+            "github_login": login,
+            "github_name": name,
+            "github_email": email,
+            "slack_user_id": by_email,
+            "resolved": True,
+            "method": "lookupByEmail",
+        }
+
+    by_members, method = slack_lookup_in_members(members=members, github_login=login, github_name=name)
+    if by_members:
+        return {
+            "github_login": login,
+            "github_name": name,
+            "github_email": email,
+            "slack_user_id": by_members,
+            "resolved": True,
+            "method": method,
+        }
+
+    return {
+        "github_login": login,
+        "github_name": name,
+        "github_email": email,
+        "resolved": False,
+        "reason": method,
+    }
+
+
+def post_test_message(*, slack_token: str, channel_id: str, resolved_user_ids: list[str], unresolved: list[str]) -> str:
+    mentions = " ".join(f"<@{uid}>" for uid in resolved_user_ids) if resolved_user_ids else "(none)"
+    text_lines = [
+        "CI triage testing mode: dynamic CODEOWNERS owner-resolution probe.",
+        f"Resolved mentions: {mentions}",
+    ]
+    if unresolved:
+        text_lines.append("Unresolved GitHub handles: " + ", ".join(f"@{u}" for u in unresolved))
+    payload = slack_api_form(
+        slack_token,
+        "chat.postMessage",
+        {"channel": channel_id, "text": "\n".join(text_lines)},
+    )
+    if not payload.get("ok"):
+        raise RuntimeError(f"chat.postMessage failed: {payload.get('error', 'unknown_error')}")
+    return str(payload.get("ts", "")).strip()
+
+
+def analyze_recent_channel_messages(*, slack_token: str, channel_id: str, limit: int = 40) -> dict[str, Any]:
+    payload = slack_api_get(
+        slack_token,
+        "conversations.history",
+        {"channel": channel_id, "limit": str(limit)},
+    )
+    if not payload.get("ok"):
+        raise RuntimeError(f"conversations.history failed: {payload.get('error', 'unknown_error')}")
+    messages = payload.get("messages", [])
+    if not isinstance(messages, list):
+        messages = []
+    likely_owner_msgs = 0
+    likely_owner_with_mentions = 0
+    likely_owner_pending = 0
+    for msg in messages:
+        if not isinstance(msg, dict):
+            continue
+        text = str(msg.get("text", ""))
+        if "Likely owners:" not in text:
+            continue
+        likely_owner_msgs += 1
+        if "<@" in text:
+            likely_owner_with_mentions += 1
+        if "(owner resolution pending)" in text:
+            likely_owner_pending += 1
+    return {
+        "recent_messages_scanned": len(messages),
+        "likely_owner_messages": likely_owner_msgs,
+        "likely_owner_messages_with_mentions": likely_owner_with_mentions,
+        "likely_owner_messages_pending": likely_owner_pending,
+    }
+
+
+def build_markdown(result: dict[str, Any]) -> str:
+    summary = result["summary"]
+    lines = [
+        "## Owner Resolution Testing Report",
+        "",
+        f"- CODEOWNERS users scanned: {summary['codeowners_users_scanned']}",
+        f"- Resolution attempts: {summary['attempted']}",
+        f"- Resolved users: {summary['resolved']}",
+        f"- Unresolved users: {summary['unresolved']}",
+        f"- Resolution rate: {summary['resolution_rate_percent']:.1f}%",
+        f"- Slack test message ts: `{summary['test_message_ts']}`",
+        "",
+        "## Recent Channel Readback",
+        "",
+        f"- Messages scanned: {summary['recent_messages_scanned']}",
+        f"- `Likely owners:` messages: {summary['likely_owner_messages']}",
+        f"- With `<@U...>` mentions: {summary['likely_owner_messages_with_mentions']}",
+        f"- With `(owner resolution pending)`: {summary['likely_owner_messages_pending']}",
+        "",
+    ]
+    if result["unresolved_github_logins"]:
+        lines.append("## Unresolved GitHub Handles")
+        lines.append("")
+        for login in result["unresolved_github_logins"]:
+            lines.append(f"- `@{login}`")
+        lines.append("")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    slack_token = require_env("SLACK_BOT_TOKEN")
+    github_token = require_env("GITHUB_TOKEN")
+
+    codeowners_path = Path(args.codeowners_path)
+    if not codeowners_path.exists():
+        raise RuntimeError(f"missing CODEOWNERS path: {codeowners_path}")
+
+    gh_users = parse_codeowners_users(codeowners_path)
+    max_users = max(args.max_codeowners, 1)
+    selected_users = gh_users[:max_users]
+
+    members = slack_list_members(slack_token)
+    attempts: list[dict[str, Any]] = []
+    resolved_ids: list[str] = []
+    unresolved_logins: list[str] = []
+
+    for login in selected_users:
+        item = resolve_github_to_slack(
+            github_token=github_token,
+            slack_token=slack_token,
+            members=members,
+            github_login=login,
+        )
+        attempts.append(item)
+        if item.get("resolved"):
+            uid = str(item.get("slack_user_id", "")).strip()
+            if uid and uid not in resolved_ids:
+                resolved_ids.append(uid)
+        else:
+            unresolved_logins.append(str(item.get("github_login", login)))
+
+    test_message_ts = post_test_message(
+        slack_token=slack_token,
+        channel_id=args.slack_channel_id,
+        resolved_user_ids=resolved_ids,
+        unresolved=unresolved_logins,
+    )
+    readback = analyze_recent_channel_messages(
+        slack_token=slack_token,
+        channel_id=args.slack_channel_id,
+        limit=40,
+    )
+
+    attempted = len(selected_users)
+    resolved = len(resolved_ids)
+    unresolved = len(unresolved_logins)
+    resolution_rate_percent = (100.0 * resolved / attempted) if attempted else 0.0
+
+    result = {
+        "slack_channel_id": args.slack_channel_id,
+        "attempts": attempts,
+        "resolved_slack_ids": resolved_ids,
+        "unresolved_github_logins": unresolved_logins,
+        "summary": {
+            "codeowners_users_scanned": len(gh_users),
+            "attempted": attempted,
+            "resolved": resolved,
+            "unresolved": unresolved,
+            "resolution_rate_percent": resolution_rate_percent,
+            "test_message_ts": test_message_ts,
+            **readback,
+        },
+    }
+
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    summary_md = Path(args.summary_md)
+    summary_md.parent.mkdir(parents=True, exist_ok=True)
+    summary_md.write_text(build_markdown(result), encoding="utf-8")
+    print(json.dumps({"attempted": attempted, "resolved": resolved, "unresolved": unresolved}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/testing_thread_persona_session.py
+++ b/tools/ci/testing_thread_persona_session.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Testing-mode thread persona simulation for CI triage behavior."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.slack import post_slack_message
+from tools.ci.slack_thread_agent_analysis import analyze_thread_with_agent
+
+
+def parse_args() -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Post simulated developer thread replies and evaluate triage interpretation."
+    )
+    p.add_argument("--slack-channel-id", required=True)
+    p.add_argument("--output-json", required=True)
+    p.add_argument("--summary-md", required=True)
+    return p.parse_args()
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing env var: {name}")
+    return value
+
+
+def post_message(*, token: str, channel: str, text: str, thread_ts: str | None = None) -> str:
+    return post_slack_message(slack_token=token, channel_id=channel, text=text, thread_ts=thread_ts)
+
+
+def build_summary(result: dict[str, Any]) -> str:
+    lines = [
+        "## Thread Persona Simulation Session",
+        "",
+        f"- Anchor thread ts: `{result.get('anchor_ts','')}`",
+        f"- Personas simulated: {len(result.get('scenarios', []))}",
+        "",
+        "## Scenario Results",
+    ]
+    for row in result.get("scenarios", []):
+        lines.append(
+            f"- `{row['name']}` -> state `{row['progress_state']}`, defer_disable={row['defer_disable']}, "
+            f"fix_request={row['fix_request_requested']}"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    token = require_env("SLACK_BOT_TOKEN")
+    anchor_text = (
+        "CI triage testing-mode thread persona simulation anchor. "
+        "This is synthetic test data and not a real incident."
+    )
+    anchor_ts = post_message(token=token, channel=args.slack_channel_id, text=anchor_text)
+
+    scenarios = [
+        ("active_plan", "Looking now, I will post PR in 2 hours."),
+        ("wip_pr", "Fix in progress: https://github.com/tenstorrent/tt-metal/pull/12345"),
+        ("blocked", "Blocked on infra/hardware dependency."),
+        ("resolved_claim", "Should be fixed by https://github.com/tenstorrent/tt-metal/pull/12346; please verify."),
+        ("vague", "Taking a look."),
+        ("fix_request", "Can agent fix this and draft a fix PR if possible?"),
+    ]
+
+    outputs: list[dict[str, Any]] = []
+    for name, text in scenarios:
+        ts = post_message(token=token, channel=args.slack_channel_id, text=text, thread_ts=anchor_ts)
+        analysis = analyze_thread_with_agent(
+            top_level_text=anchor_text,
+            thread_replies=[{"ts": ts, "text": text}],
+            include_owner_claim=False,
+            model="auto",
+        )
+        outputs.append(
+            {
+                "name": name,
+                "reply_ts": ts,
+                "reply_text": text,
+                "progress_state": analysis.get("progress_state"),
+                "defer_disable": bool(analysis.get("defer_disable", False)),
+                "progress_reason": analysis.get("progress_reason", ""),
+                "fix_request_requested": bool(analysis.get("fix_request_requested", False)),
+                "fix_request_reason": analysis.get("fix_request_reason", ""),
+            }
+        )
+
+    result = {"anchor_ts": anchor_ts, "scenarios": outputs}
+    out_json = Path(args.output_json)
+    out_json.parent.mkdir(parents=True, exist_ok=True)
+    out_json.write_text(json.dumps(result, indent=2), encoding="utf-8")
+
+    out_md = Path(args.summary_md)
+    out_md.parent.mkdir(parents=True, exist_ok=True)
+    out_md.write_text(build_summary(result), encoding="utf-8")
+    print(json.dumps({"anchor_ts": anchor_ts, "scenario_count": len(outputs)}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/testing_triage_e2e_session.py
+++ b/tools/ci/testing_triage_e2e_session.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Testing-mode end-to-end Slack thread exercises on real CI issues."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from tools.ci.common.codeowners import parse_codeowners_logins
+from tools.ci.common.github import github_api_get
+from tools.ci.common.slack import post_slack_message, slack_api_get_simple
+from tools.ci.slack_thread_agent_analysis import analyze_thread_with_agent
+
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+ISSUE_URL_RE = re.compile(r"https://github\.com/ebanerjeeTT/issue_dump/issues/(\d+)")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run testing-mode triage E2E thread exercises.")
+    parser.add_argument("--slack-channel-id", required=True)
+    parser.add_argument("--max-threads", type=int, default=3)
+    parser.add_argument("--output-json", required=True)
+    parser.add_argument("--summary-md", required=True)
+    return parser.parse_args()
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        raise RuntimeError(f"missing env var: {name}")
+    return value
+
+
+def gh_api_get(token: str, endpoint: str) -> dict[str, Any]:
+    return github_api_get(token, endpoint, user_agent="tt-metal-testing-triage-e2e")
+
+
+def post_thread_message(*, token: str, channel: str, thread_ts: str, text: str) -> str:
+    return post_slack_message(slack_token=token, channel_id=channel, text=text, thread_ts=thread_ts)
+
+
+def read_channel_messages(token: str, channel_id: str, limit: int = 120) -> list[dict[str, Any]]:
+    payload = slack_api_get_simple(token, "conversations.history", {"channel": channel_id, "limit": str(limit)})
+    if not payload.get("ok"):
+        raise RuntimeError(f"conversations.history failed: {payload.get('error', 'unknown_error')}")
+    messages = payload.get("messages", [])
+    return [x for x in messages if isinstance(x, dict)] if isinstance(messages, list) else []
+
+
+def read_thread_messages(token: str, channel_id: str, thread_ts: str) -> list[dict[str, Any]]:
+    payload = slack_api_get_simple(token, "conversations.replies", {"channel": channel_id, "ts": thread_ts, "limit": "100"})
+    if not payload.get("ok"):
+        raise RuntimeError(f"conversations.replies failed: {payload.get('error', 'unknown_error')}")
+    messages = payload.get("messages", [])
+    return [x for x in messages if isinstance(x, dict)] if isinstance(messages, list) else []
+
+
+def parse_issue_number(text: str) -> int:
+    m = ISSUE_URL_RE.search(text)
+    if not m:
+        return 0
+    return int(m.group(1))
+
+
+def find_real_issue_threads(messages: list[dict[str, Any]], limit: int) -> list[dict[str, Any]]:
+    threads: list[dict[str, Any]] = []
+    for msg in messages:
+        text = str(msg.get("text", ""))
+        issue_number = parse_issue_number(text)
+        if issue_number <= 0:
+            continue
+        ts = str(msg.get("ts", "")).strip()
+        if not ts:
+            continue
+        threads.append(
+            {
+                "thread_ts": ts,
+                "issue_number": issue_number,
+                "top_text": text,
+                "top_permalink": f"https://tenstorrent.slack.com/archives/C0APK6215B5/p{ts.replace('.', '')}",
+            }
+        )
+        if len(threads) >= limit:
+            break
+    return threads
+
+
+def choose_mock_dev_reply(idx: int, github_login: str) -> str:
+    options = [
+        f"Testing-mode mock dev reply from @{github_login}: looking now, I will post PR in 2 hours.",
+        f"Testing-mode mock dev reply from @{github_login}: can agent fix this and draft a fix PR if possible?",
+        f"Testing-mode mock dev reply from @{github_login}: blocked on infra/hardware dependency.",
+        f"Testing-mode mock dev reply from @{github_login}: should be fixed by https://github.com/tenstorrent/tt-metal/pull/12346; please verify.",
+    ]
+    return options[idx % len(options)]
+
+
+def build_bot_response(
+    *, issue_number: int, progress: dict[str, Any], fix_request: dict[str, Any], mock_github_owner: str
+) -> str:
+    mock_pr = f"https://github.com/ebanerjeeTT/tt-metal/pull/mock-{issue_number}"
+    if fix_request.get("requested"):
+        return (
+            "Testing-mode bot response: fix request detected in thread. "
+            f"Mock draft PR: {mock_pr} | Mock assignment note: would assign issue #{issue_number} to @{mock_github_owner}."
+        )
+    if bool(progress.get("defer_disable", False)):
+        return (
+            "Testing-mode bot response: high-confidence progress detected, disabling is deferred for now. "
+            "Please post concrete PR updates in-thread."
+        )
+    return (
+        "Testing-mode bot response: unresolved/blocked signal detected. "
+        "If still unresolved by SLA, disable path would be considered."
+    )
+
+
+def issue_exists(token: str, issue_number: int) -> bool:
+    try:
+        payload = gh_api_get(token, f"/repos/{ISSUE_REPO_TEST}/issues/{issue_number}")
+    except Exception:
+        return False
+    return int(payload.get("number", 0) or 0) == issue_number
+
+
+def build_summary(payload: dict[str, Any]) -> str:
+    lines = [
+        "## Triage E2E Testing Session",
+        "",
+        f"- Real issue threads selected: {len(payload.get('threads', []))}",
+        f"- Mock dev replies posted: {payload.get('mock_dev_reply_count', 0)}",
+        f"- Bot follow-up replies posted: {payload.get('bot_followup_count', 0)}",
+        "",
+        "## Thread Cases",
+    ]
+    for row in payload.get("threads", []):
+        lines.append(
+            f"- issue #{row.get('issue_number')} | state `{row.get('progress_state')}` | "
+            f"fix_request={row.get('fix_request_requested')} | thread `{row.get('thread_ts')}`"
+        )
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    slack_token = require_env("SLACK_BOT_TOKEN")
+    github_token = require_env("GITHUB_TOKEN")
+    messages = read_channel_messages(slack_token, args.slack_channel_id, limit=160)
+    threads = find_real_issue_threads(messages, args.max_threads)
+    mock_devs = parse_codeowners_logins(Path(".github/CODEOWNERS"))
+    if not mock_devs:
+        mock_devs = ["ebanerjeeTT"]
+
+    results: list[dict[str, Any]] = []
+    mock_dev_reply_count = 0
+    bot_followup_count = 0
+    for idx, thread in enumerate(threads):
+        issue_number = int(thread["issue_number"])
+        if not issue_exists(github_token, issue_number):
+            continue
+        thread_ts = str(thread["thread_ts"])
+        mock_dev_login = mock_devs[idx % len(mock_devs)]
+        mock_reply = choose_mock_dev_reply(idx, mock_dev_login)
+        mock_ts = post_thread_message(
+            token=slack_token,
+            channel=args.slack_channel_id,
+            thread_ts=thread_ts,
+            text=mock_reply,
+        )
+        mock_dev_reply_count += 1
+        thread_messages = read_thread_messages(slack_token, args.slack_channel_id, thread_ts)
+        thread_replies = [m for m in thread_messages if str(m.get("ts", "")).strip() != thread_ts]
+        analysis = analyze_thread_with_agent(
+            top_level_text=thread["top_text"],
+            thread_replies=thread_replies,
+            include_owner_claim=False,
+            model="auto",
+        )
+        progress = {
+            "progress_state": analysis.get("progress_state", "no_progress"),
+            "defer_disable": bool(analysis.get("defer_disable", False)),
+        }
+        fix_request = {"requested": bool(analysis.get("fix_request_requested", False))}
+        bot_text = build_bot_response(
+            issue_number=issue_number,
+            progress=progress,
+            fix_request=fix_request,
+            mock_github_owner=mock_dev_login,
+        )
+        bot_ts = post_thread_message(
+            token=slack_token,
+            channel=args.slack_channel_id,
+            thread_ts=thread_ts,
+            text=bot_text,
+        )
+        bot_followup_count += 1
+        # Read thread again to ensure response is visible in API readback.
+        thread_messages_after = read_thread_messages(slack_token, args.slack_channel_id, thread_ts)
+        results.append(
+            {
+                "thread_ts": thread_ts,
+                "issue_number": issue_number,
+                "top_permalink": thread["top_permalink"],
+                "mock_dev_reply_ts": mock_ts,
+                "bot_followup_ts": bot_ts,
+                "progress_state": progress.get("progress_state"),
+                "defer_disable": bool(progress.get("defer_disable", False)),
+                "fix_request_requested": bool(fix_request.get("requested", False)),
+                "thread_message_count_after": len(thread_messages_after),
+                "mock_dev_login": mock_dev_login,
+            }
+        )
+
+    output = {
+        "threads": results,
+        "mock_dev_reply_count": mock_dev_reply_count,
+        "bot_followup_count": bot_followup_count,
+    }
+    output_json = Path(args.output_json)
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(output, indent=2), encoding="utf-8")
+    summary_md = Path(args.summary_md)
+    summary_md.parent.mkdir(parents=True, exist_ok=True)
+    summary_md.write_text(build_summary(output), encoding="utf-8")
+    print(json.dumps({"threads": len(results), "mock_dev_reply_count": mock_dev_reply_count}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/tt-auto-triage-port-and-rollout-plan.md
+++ b/tools/ci/tt-auto-triage-port-and-rollout-plan.md
@@ -1,0 +1,278 @@
+# TT Auto Triage Port + Progressive Production Rollout Plan
+
+## Goal
+
+Move the current CI triage system from this large branch into `tt-auto-triage` in reviewable vertical slices, then deploy safely to production (`tenstorrent/tt-metal` + real Slack channels) with controlled blast radius.
+
+This plan assumes:
+
+- We cannot merge this full branch directly into `tt-metal`.
+- We need manager-approved bounds before real side effects.
+- We should optimize for small PRs, clear ownership, and reversible rollout.
+
+---
+
+## Deployment Principles
+
+- Keep each PR vertically scoped (code + tests + docs for one capability).
+- Default all new production paths to **read-only or dry-run** first.
+- Gate all write side effects behind explicit flags and hard caps.
+- Require measurable acceptance criteria before enabling next slice.
+- Preserve kill-switches at every stage.
+
+---
+
+## Pre-Work (Manager + Policy Alignment)
+
+Complete before opening production-side PRs:
+
+1. Confirm allowed side effects by environment:
+   - Issue create/update/close permissions.
+   - Draft PR create/update permissions.
+   - Workflow dispatch permissions.
+   - Slack channels and mention policy.
+2. Confirm production safety guardrails:
+   - Max new issues/run.
+   - Max Slack posts/run and per-thread.
+   - Max PR actions/run.
+3. Confirm on-call/ownership:
+   - Who monitors first canaries.
+   - Who can disable the system quickly.
+4. Confirm final target architecture:
+   - `tt-auto-triage` owns orchestration logic.
+   - `tt-metal` remains the source system for CI signals.
+
+---
+
+## Target Repo Structure in `tt-auto-triage`
+
+Port to a minimal, explicit layout:
+
+- `workflows/` (or `.github/workflows/`): triage orchestration workflow(s)
+- `actions/`: composite actions (`auto-disable-stale-ci`, report generation, etc.)
+- `tools/ci/`: Python runtime and helper scripts
+- `docs/`: runbooks, policy, rollout notes
+- `tests/`: unit tests for parsing, state, and decision contracts
+
+Avoid carrying over unrelated `tt-metal` files; move only required automation code.
+
+---
+
+## Vertical Slice Plan (PR-by-PR)
+
+### Slice 0: Bootstrap + Safety Skeleton
+
+Scope:
+
+- Create base repo scaffolding in `tt-auto-triage`.
+- Add `guarded_gh.py` policy wrapper and tests.
+- Add workflow skeleton with `workflow_dispatch`, run-scope, and kill-switch input.
+
+Acceptance:
+
+- CI passes.
+- Guard wrapper blocks disallowed commands.
+- Workflow can run in no-op/read-only mode.
+
+### Slice 1: Shared State + Artifact Restore
+
+Scope:
+
+- Port `ci_triage_state.json` schema management.
+- Port `load_previous_triage_state.py`.
+- Add artifact upload/download/restore steps to all stateful jobs.
+
+Acceptance:
+
+- Repeated runs preserve and reuse state.
+- Missing artifact path fails closed to safe defaults (no duplicate spam).
+
+### Slice 2: Slack Ingestion + Enrichment (Read-only)
+
+Scope:
+
+- Port Slack channel/thread export scripts.
+- Port issue-status enrichment against target issue repo.
+- Produce artifacts only; no issue/PR/slack side effects beyond exports.
+
+Acceptance:
+
+- Deterministic JSON artifacts generated.
+- Enrichment success/failure behavior visible in summary.
+
+### Slice 3: Agent-First Slack Analysis Layer
+
+Scope:
+
+- Port `slack_thread_agent_analysis.py`.
+- Replace deterministic Slack interpretation in all active paths.
+- Add strict output contract checks and marker parsing.
+
+Acceptance:
+
+- All Slack interpretation paths call agent analyzer.
+- Contract parse failures degrade safely (no write action).
+
+### Slice 4: Draft PR Stage (Fork/Test-only Side Effects)
+
+Scope:
+
+- Port stale selector + disable planning + execute pipeline.
+- Keep target repo/channel in test scope initially.
+- Preserve dedupe markers (`Auto-disable-source-ts`) and PR update path.
+
+Acceptance:
+
+- New PR create works under caps.
+- Existing PR update creates a new commit and changelog comment.
+- No duplicate PRs for same source ts.
+
+### Slice 5: Issue Creation Stage (M4)
+
+Scope:
+
+- Port deterministic failure extraction + issue/slack bootstrap flow.
+- Preserve job/fingerprint dedupe markers (`Auto-triage-job-key`, fingerprint).
+
+Acceptance:
+
+- No duplicate issues for same failing job identity.
+- Slack bootstrap messages tie to created issue deterministically.
+
+### Slice 6: Thread Lifecycle Stage (M5)
+
+Scope:
+
+- Port follow-up warning cadence and owner-claim assignment.
+- Keep unassigned-only assignment rule.
+- Preserve no-noise fallback from Slack thread history.
+
+Acceptance:
+
+- No repeated warning/final/post-disable messages when historical markers exist.
+- Assignment failures post remediation guidance only once per gate window.
+
+### Slice 7: Issue Lifecycle Stage
+
+Scope:
+
+- Port issue close/update/unchanged review with main-repo evidence.
+- Preserve processed-hours gating and fallback dedupe using recent lifecycle comments.
+
+Acceptance:
+
+- Re-runs inside processed window do not reprocess same issue.
+- Mixed medium-confidence defaults to update/watching behavior.
+
+### Slice 8: Testing Harness + Mock Sessions
+
+Scope:
+
+- Port testing sessions (owner resolution, persona simulation, E2E thread test).
+- Keep explicit testing-mode boundaries and low token defaults.
+
+Acceptance:
+
+- Test mode can run independently.
+- Reports are generated and uploaded every run.
+
+### Slice 9: Unified Summary + Operational Runbook
+
+Scope:
+
+- Ensure always-on run summary job.
+- Add operator docs: escalation, kill-switch, rollback.
+
+Acceptance:
+
+- Every run has a human-readable summary.
+- On-call can disable side effects in under 5 minutes.
+
+---
+
+## Progressive Production Rollout
+
+## Phase A: Read-only Production Canary
+
+- Real data sources (`tenstorrent/tt-metal`, production Slack read channels).
+- No issue/PR/slack write side effects.
+- Validate classification quality + candidate volume.
+
+Exit criteria:
+
+- Stable for 3-5 runs.
+- No critical parsing/contract failures.
+
+## Phase B: Limited Write Canary
+
+- Enable only one write path at a time with caps:
+  - First issue lifecycle comments/updates only.
+  - Then thread follow-ups.
+  - Then draft PR creation/update.
+- Set hard limits to 1 action/run per path.
+
+Exit criteria:
+
+- No duplicate/noisy posts.
+- Team confirms signal quality and acceptable cadence.
+
+## Phase C: Controlled Expansion
+
+- Raise limits gradually (1 -> 3 -> 5).
+- Enable full run-scope path for scheduled runs.
+- Keep daily review of summaries and action logs.
+
+Exit criteria:
+
+- Two weeks with no trust-breaking noise events.
+- Error budget and rollback drills pass.
+
+---
+
+## PR Sizing and Review Strategy
+
+- Keep PRs to ~300-600 LOC where possible.
+- Include tests/docs in same PR for each slice.
+- Use feature flags so code can merge before activation.
+- Require one “operator review” and one “code review” for side-effect paths.
+
+Recommended branch naming in `tt-auto-triage`:
+
+- `slice/00-bootstrap-safety`
+- `slice/01-state-restore`
+- `slice/02-slack-ingestion`
+- ...
+- `slice/09-summary-runbook`
+
+---
+
+## Production Safeguards to Keep Enabled
+
+- `guarded_gh.py` as the only github execution path.
+- Run-scope input for isolated testing.
+- Hard caps for actions per run.
+- Cross-run state restore in every stateful job.
+- Fallback dedupe from Slack thread and issue comment history.
+- Always-on unified summary.
+
+---
+
+## Rollback Plan
+
+If noise or bad actions occur:
+
+1. Disable workflow dispatch/schedule immediately.
+2. Rotate or revoke write tokens.
+3. Set all write-path flags to false/no-op.
+4. Keep read-only data collection enabled for diagnosis.
+5. Post incident note in ops channel with affected actions and mitigation.
+
+---
+
+## Day-1 Execution Checklist (Tomorrow)
+
+- Manager policy bounds documented.
+- Create `tt-auto-triage` repo and baseline CI.
+- Land Slice 0 + Slice 1.
+- Run one read-only canary from `tt-auto-triage`.
+- Review summary with manager before enabling any production writes.

--- a/tools/tests/ci/test_m4_marker_parsing.py
+++ b/tools/tests/ci/test_m4_marker_parsing.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import pytest
+
+import tools.ci.m4_create_issues_and_notify as mod
+
+
+def test_parse_batch_agent_json_accepts_raw_json_without_marker():
+    text = (
+        '{"decisions":[{"workflow_name":"wf","job_name":"job","job_urls":["u1","u2","u3"],'
+        '"deterministic":true,"confidence":"high","signature":"abc","error_excerpt":"x",'
+        '"reason":"ok","create_issue":true,"draft_slack":true,"issue_title":"t","issue_body":"b","slack_text":"s"}]}'
+    )
+    decisions = mod.parse_batch_agent_json(text)
+    assert isinstance(decisions, list)
+    assert len(decisions) == 1
+    assert decisions[0]["workflow_name"] == "wf"
+
+
+def test_parse_batch_agent_json_missing_marker_has_actionable_error():
+    with pytest.raises(ValueError) as exc:
+        mod.parse_batch_agent_json("agent output without marker and without json payload")
+    message = str(exc.value)
+    assert "marker not found" in message
+    assert "output excerpt" in message
+
+
+def test_find_existing_issue_for_job_identity_matches_newly_created_body_marker():
+    workflow_name = "aggregate-workflow-data"
+    job_name = "Galaxy Qwen3-32B long context demo tests"
+    job_key = mod.job_identity_key(workflow_name, job_name)
+    marker = mod.issue_job_identity_marker(job_key)
+    open_issues = [{"url": "https://github.com/ebanerjeeTT/issue_dump/issues/999", "body": f"foo\n{marker}\nbar"}]
+    existing = mod.find_existing_issue_for_job_identity(
+        open_issues,
+        workflow_name=workflow_name,
+        job_name=job_name,
+    )
+    assert existing == "https://github.com/ebanerjeeTT/issue_dump/issues/999"
+
+
+def test_find_existing_issue_for_title_matches_case_insensitive_exact():
+    open_issues = [
+        {
+            "url": "https://github.com/ebanerjeeTT/issue_dump/issues/854",
+            "title": "[CI] Galaxy Qwen3-32B long context demo: trace buffer size exceeds allocated region",
+        }
+    ]
+    existing = mod.find_existing_issue_for_title(
+        open_issues,
+        "[ci] galaxy qwen3-32b long context demo: trace buffer size exceeds allocated region",
+    )
+    assert existing == "https://github.com/ebanerjeeTT/issue_dump/issues/854"
+
+
+def test_slack_lookup_by_full_name_exact_and_unique_word_match():
+    members = [
+        {
+            "id": "U1",
+            "name": "utku",
+            "profile": {"display_name": "Utku Aydonat", "real_name": "Utku Aydonat"},
+        },
+        {
+            "id": "U2",
+            "name": "other",
+            "profile": {"display_name": "Ali User", "real_name": "Ali User"},
+        },
+    ]
+    assert mod.slack_lookup_by_full_name("Utku Aydonat", members) == "U1"
+    assert mod.slack_lookup_by_full_name("Utku", members) == "U1"
+
+
+def test_slack_lookup_by_username_accepts_tt_suffix_variants():
+    members = [
+        {
+            "id": "U1",
+            "name": "aliu",
+            "profile": {"display_name": "Aliu", "real_name": "Ali User"},
+        }
+    ]
+    assert mod.slack_lookup_by_username("", "aliuTT", members) == "U1"
+
+
+def test_owners_from_workflow_name_matches_codeowners_workflow_rules(tmp_path):
+    wf_root = tmp_path / ".github" / "workflows"
+    wf_root.mkdir(parents=True)
+    (wf_root / "t3000-unit-tests-impl.yaml").write_text("name: test\n", encoding="utf-8")
+    rules = [(".github/workflows/t3000-unit-tests-impl.yaml", ["aliuTT", "cfjchu"])]
+    owners = mod.owners_from_workflow_name(
+        "T3K T3000 unit tests",
+        rules=rules,
+        workflow_root=wf_root,
+    )
+    assert owners == {"aliuTT", "cfjchu"}
+
+
+def test_render_owner_mentions_caps_to_top_three(monkeypatch):
+    monkeypatch.setattr(mod, "parse_codeowners", lambda _path: [("tests/", ["u1", "u2", "u3", "u4"])])
+    monkeypatch.setattr(mod, "extract_repo_paths", lambda _text: ["tests/foo.py"])
+    monkeypatch.setattr(mod, "owners_for_paths", lambda _paths, _rules: {"u1", "u2", "u3", "u4"})
+    monkeypatch.setattr(mod, "owners_from_workflow_name", lambda *_args, **_kwargs: set())
+    monkeypatch.setattr(
+        mod,
+        "github_user_info",
+        lambda _token, username: {"login": username, "name": username, "email": ""},
+    )
+    username_to_uid = {"u1": "U1", "u2": "U2", "u3": "U3", "u4": "U4"}
+    monkeypatch.setattr(mod, "slack_lookup_by_username", lambda *_args: username_to_uid[_args[1]])
+    monkeypatch.setattr(mod, "slack_lookup_by_full_name", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "recent_author_emails_for_paths", lambda _paths: set())
+    monkeypatch.setattr(mod, "slack_lookup_by_email", lambda *_args, **_kwargs: None)
+
+    mentions, unresolved, selection = mod.render_owner_mentions(
+        issue_token="x",
+        slack_token="y",
+        workflow_name="wf",
+        job_name="job",
+        text_sources=["x"],
+        members_cache=[],
+    )
+    tokens = [tok for tok in mentions.split(" ") if tok.strip()]
+    assert len(tokens) == 3
+    assert unresolved == []
+    assert selection["selected_owner_count"] == 3
+
+
+def test_parse_auto_triage_decision_includes_permalinks_and_reason():
+    decision = {
+        "auto_triage_used": True,
+        "auto_triage_reason": "matched HIGH CONFIDENCE thread",
+        "auto_triage_permalinks": [
+            "https://tenstorrent.slack.com/archives/C0APK6215B5/p1775000000123456",
+            "https://example.com/not-allowed",
+        ],
+    }
+    meta = mod.parse_auto_triage_decision(decision)
+    assert meta["used"] is True
+    assert meta["reason"] == "matched HIGH CONFIDENCE thread"
+    assert meta["permalinks"] == ["https://tenstorrent.slack.com/archives/C0APK6215B5/p1775000000123456"]
+
+
+def test_job_owner_ids_for_failure_matches_owners_json_entries():
+    records = [
+        {
+            "job-name-component": "t3000-unit-tests / t3k ttnn tests",
+            "owner": {"id": "UBHPP2NDP", "name": "Joseph Chu"},
+        }
+    ]
+    ids = mod.job_owner_ids_for_failure(
+        workflow_name="(T3K) T3000 unit tests",
+        job_name="t3000-unit-tests / t3k_ttnn_tests",
+        job_owner_records=records,
+    )
+    assert ids == {"UBHPP2NDP"}

--- a/tools/tests/ci/test_m5_lifecycle_helpers.py
+++ b/tools/tests/ci/test_m5_lifecycle_helpers.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from tools.ci.m5_manage_issue_lifecycle import (
+    candidate_github_owners_from_text,
+    issue_numbers_from_text,
+    message_replies,
+    parse_json_after_marker,
+    parse_codeowners,
+)
+
+
+def test_candidate_github_owners_from_text_uses_last_matching_rule(tmp_path: Path) -> None:
+    codeowners = tmp_path / "CODEOWNERS"
+    codeowners.write_text(
+        "\n".join(
+            [
+                "ttnn/* @alice",
+                "ttnn/special/* @bob",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    rules = parse_codeowners(codeowners)
+    text = "Failure path: ttnn/special/op/foo.py"
+    owners = candidate_github_owners_from_text(text, rules)
+    assert owners == ["bob"]
+
+
+def test_parse_json_after_marker_success() -> None:
+    text = 'noise\n===FINAL_OWNER_CLAIM_JSON===\n{"claimed": true, "slack_user_id": "U123"}\n'
+    parsed = parse_json_after_marker(text, "===FINAL_OWNER_CLAIM_JSON===")
+    assert parsed["claimed"] is True
+    assert parsed["slack_user_id"] == "U123"
+
+
+def test_parse_json_after_marker_missing_marker_raises() -> None:
+    text = '{"claimed": false}'
+    try:
+        parse_json_after_marker(text, "===FINAL_OWNER_CLAIM_JSON===")
+    except ValueError as exc:
+        assert "marker not found" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for missing marker")
+
+
+def test_issue_numbers_from_text_parses_issue_dump_urls() -> None:
+    text = (
+        "Investigate https://github.com/ebanerjeeTT/issue_dump/issues/851 and "
+        "https://github.com/ebanerjeeTT/issue_dump/issues/858"
+    )
+    assert issue_numbers_from_text(text) == [851, 858]
+
+
+def test_message_replies_supports_legacy_replies_key() -> None:
+    msg = {"replies": [{"ts": "1.0", "user": "U1", "text": "working on it"}]}
+    out = message_replies(msg)
+    assert len(out) == 1
+    assert out[0]["user"] == "U1"

--- a/tools/tests/ci/test_m6_bug_escape_enrichment.py
+++ b/tools/tests/ci/test_m6_bug_escape_enrichment.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from tools.ci.m6_bug_escape_enrichment import classify_escape_type, infer_layer_from_text
+
+
+def test_classify_escape_type_detects_lower_to_higher_escape() -> None:
+    escape_type, confidence = classify_escape_type(failure_layer="models", fix_layer="llk")
+    assert escape_type == "layer_escape_lower_to_higher"
+    assert confidence == "high"
+
+
+def test_infer_layer_from_text_prefers_specific_signals() -> None:
+    assert infer_layer_from_text("TT_FATAL in tt_metal/llrt/something.cpp") == "metalium"
+    assert infer_layer_from_text("flaky model pipeline error") == "models"
+    assert infer_layer_from_text("something unknown") == "unknown"

--- a/tools/tests/ci/test_slice_05_m4_issues.py
+++ b/tools/tests/ci/test_slice_05_m4_issues.py
@@ -1,0 +1,79 @@
+"""Contract tests for Slice 5: M4 issue creation and notification.
+
+Validates that M4 correctly processes failing jobs JSON, deduplicates
+against open issues, and produces expected creation/skip records.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import tools.ci.m4_create_issues_and_notify as m4
+
+
+def test_job_identity_key_is_deterministic():
+    key1 = m4.job_identity_key("wf-A", "job-B")
+    key2 = m4.job_identity_key("wf-A", "job-B")
+    assert key1 == key2
+    assert isinstance(key1, str)
+    assert len(key1) > 0
+
+
+def test_issue_job_identity_marker_contains_key():
+    key = m4.job_identity_key("workflow", "job")
+    marker = m4.issue_job_identity_marker(key)
+    assert key in marker
+    assert "Auto-triage-job-key" in marker
+
+
+def test_find_existing_issue_for_job_identity_returns_none_when_no_match():
+    result = m4.find_existing_issue_for_job_identity(
+        [{"url": "u1", "body": "no markers here"}],
+        workflow_name="wf",
+        job_name="job",
+    )
+    assert result is None
+
+
+def test_parse_batch_agent_json_with_decisions_key():
+    payload = json.dumps({
+        "decisions": [
+            {
+                "workflow_name": "wf",
+                "job_name": "job",
+                "job_urls": ["u1"],
+                "deterministic": True,
+                "confidence": "high",
+                "signature": "sig",
+                "error_excerpt": "err",
+                "reason": "r",
+                "create_issue": True,
+                "draft_slack": True,
+                "issue_title": "title",
+                "issue_body": "body",
+                "slack_text": "text",
+            }
+        ]
+    })
+    result = m4.parse_batch_agent_json(payload)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert result[0]["workflow_name"] == "wf"
+
+
+def test_extract_repo_paths_finds_known_prefixes():
+    text = "Error in tt_metal/llrt/foo.cpp and tests/unit/test_bar.py"
+    paths = m4.extract_repo_paths(text)
+    assert any("tt_metal" in p for p in paths)
+    assert any("tests" in p for p in paths)
+
+
+def test_owners_for_paths_uses_last_matching_rule():
+    rules = [
+        ("*", ["default"]),
+        ("tests/", ["test_owner"]),
+    ]
+    owners = m4.owners_for_paths(["tests/foo.py"], rules)
+    assert "test_owner" in owners

--- a/tools/tests/ci/test_slice_06_m5_lifecycle.py
+++ b/tools/tests/ci/test_slice_06_m5_lifecycle.py
@@ -1,0 +1,64 @@
+"""Contract tests for Slice 6: M5 issue lifecycle management.
+
+Validates thread follow-up logic, assignment cadence, and
+state-driven lifecycle transitions.
+"""
+
+from __future__ import annotations
+
+from tools.ci.m5_manage_issue_lifecycle import (
+    candidate_github_owners_from_text,
+    extract_repo_paths,
+    issue_numbers_from_text,
+    message_replies,
+    parse_codeowners,
+)
+
+
+def test_extract_repo_paths_detects_known_prefixes():
+    text = "See tt_metal/device/foo.h and ttnn/ops/bar.cpp"
+    paths = extract_repo_paths(text)
+    assert any("tt_metal" in p for p in paths)
+    assert any("ttnn" in p for p in paths)
+
+
+def test_candidate_github_owners_deduplicates():
+    rules = [
+        ("tt_metal/", ["owner_a", "owner_b"]),
+        ("ttnn/", ["owner_a", "owner_c"]),
+    ]
+    owners = candidate_github_owners_from_text(
+        "error in tt_metal/foo.cpp and ttnn/bar.cpp",
+        rules,
+    )
+    assert len(set(owners)) == len(owners)
+    assert "owner_a" in owners
+
+
+def test_parse_codeowners_drops_teams(tmp_path):
+    path = tmp_path / "CODEOWNERS"
+    path.write_text("* @org/team @individual\n")
+    rules = parse_codeowners(path)
+    owners_flat = [o for _, ows in rules for o in ows]
+    assert "individual" in owners_flat
+    assert all("/" not in o for o in owners_flat)
+
+
+def test_issue_numbers_from_text_extracts_issue_dump_urls():
+    text = "https://github.com/ebanerjeeTT/issue_dump/issues/123 and #456"
+    nums = issue_numbers_from_text(text)
+    assert 123 in nums
+
+
+def test_message_replies_handles_thread_replies_key():
+    msg = {"thread_replies": [{"ts": "1.0"}, {"ts": "2.0"}]}
+    assert len(message_replies(msg)) == 2
+
+
+def test_message_replies_falls_back_to_replies_key():
+    msg = {"replies": [{"ts": "3.0"}]}
+    assert len(message_replies(msg)) == 1
+
+
+def test_message_replies_returns_empty_for_missing():
+    assert message_replies({}) == []

--- a/tools/tests/ci/test_slice_07_issue_lifecycle.py
+++ b/tools/tests/ci/test_slice_07_issue_lifecycle.py
@@ -1,0 +1,72 @@
+"""Contract tests for Slice 7: issue lifecycle stage transitions.
+
+Validates state loading with issue_lifecycle schema, lifecycle
+decision parsing, and save_state round-trips.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from tools.ci.issue_lifecycle_stage import (
+    FINAL_MARKER,
+    RUN_JOB_URL_RE,
+    load_state,
+    save_state,
+)
+from tools.ci.common.markers import parse_json_after_marker
+from tools.ci.common.timestamps import now_iso, parse_iso_utc
+
+
+def test_load_state_creates_issue_lifecycle_key(tmp_path):
+    path = tmp_path / "state.json"
+    state = load_state(path)
+    assert "issue_lifecycle" in state
+    assert isinstance(state["issue_lifecycle"]["issues"], dict)
+
+
+def test_load_state_preserves_existing_issues(tmp_path):
+    path = tmp_path / "state.json"
+    data = {
+        "version": 1,
+        "items": [],
+        "issue_lifecycle": {"issues": {"42": {"status": "open"}}},
+    }
+    path.write_text(json.dumps(data))
+    state = load_state(path)
+    assert "42" in state["issue_lifecycle"]["issues"]
+
+
+def test_save_state_updates_timestamp(tmp_path):
+    path = tmp_path / "state.json"
+    state = {"version": 1, "items": [], "issue_lifecycle": {"issues": {}}}
+    save_state(path, state)
+    loaded = json.loads(path.read_text())
+    assert "updated_at_utc" in loaded
+    ts = parse_iso_utc(loaded["updated_at_utc"])
+    assert ts is not None
+
+
+def test_run_job_url_regex_captures_run_and_job():
+    url = "https://github.com/tenstorrent/tt-metal/actions/runs/12345/job/67890"
+    m = RUN_JOB_URL_RE.match(url)
+    assert m is not None
+    assert m.group(1) == "12345"
+    assert m.group(2) == "67890"
+
+
+def test_parse_lifecycle_decision_marker():
+    text = f"preamble\n{FINAL_MARKER}\n" + json.dumps({
+        "action": "close",
+        "reason": "issue resolved",
+    })
+    result = parse_json_after_marker(text, FINAL_MARKER)
+    assert result["action"] == "close"
+    assert result["reason"] == "issue resolved"
+
+
+def test_now_iso_format_matches_z_suffix():
+    ts = now_iso()
+    assert ts.endswith("Z")
+    assert parse_iso_utc(ts) is not None

--- a/tools/tests/ci/test_testing_thread_persona_session.py
+++ b/tools/tests/ci/test_testing_thread_persona_session.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from tools.ci.testing_thread_persona_session import build_summary
+
+
+def test_build_summary_contains_scenario_rows() -> None:
+    md = build_summary(
+        {
+            "anchor_ts": "123.45",
+            "scenarios": [
+                {
+                    "name": "active_plan",
+                    "progress_state": "fix_in_progress",
+                    "defer_disable": True,
+                    "fix_request_requested": False,
+                }
+            ],
+        }
+    )
+    assert "Thread Persona Simulation Session" in md
+    assert "active_plan" in md

--- a/tools/tests/ci/test_testing_triage_e2e_session.py
+++ b/tools/tests/ci/test_testing_triage_e2e_session.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from tools.ci.testing_triage_e2e_session import build_bot_response, parse_issue_number
+
+
+def test_parse_issue_number_from_text() -> None:
+    text = "Issue: https://github.com/ebanerjeeTT/issue_dump/issues/1234"
+    assert parse_issue_number(text) == 1234
+
+
+def test_build_bot_response_fix_request_contains_mock_pr() -> None:
+    text = build_bot_response(
+        issue_number=77,
+        progress={"defer_disable": False},
+        fix_request={"requested": True},
+        mock_github_owner="test-owner",
+    )
+    assert "Mock draft PR" in text
+    assert "mock-77" in text


### PR DESCRIPTION
## Summary

- Add `.github/workflows/triage-ci.yaml` -- the full reusable workflow (1261 lines) called by tt-metal
- Add `.github/actions/generate-slack-data-report/` composite action with Python helpers
- Add testing session scripts: `testing_triage_e2e_session.py`, `testing_thread_persona_session.py`, `testing_owner_resolution_session.py`
- Add project documentation: README, planning doc, roadmap, architecture diagrams
- 3 tests for testing harness scripts; **110 tests pass in aggregate** across all slices

## Context

This is **Slice 8 / Tier 4** -- the final slice of the CI triage autonomy port. It ties everything together with the workflow definition, testing infrastructure, and docs.

## Dependencies

- All prior slices (0-7). This PR merges slices 4, 5, 6, and 7 and adds the remaining files.

## Merge Order

Merge PRs in this order:
1. PR #1006 (Slice 0: Foundation)
2. PR #1007 (Slice 2: Slack ingestion) and PR #1008 (Slice 1: State + agent) -- in any order
3. PR #1009 (Slice 4: Draft PRs), PR #1010 (Slice 5: M4 issues), PR #1011 (Slice 6: M5 lifecycle), PR #1012 (Slice 7: Issue lifecycle) -- in any order within tier
4. This PR (Slice 8: Workflow + testing + docs) -- last

## Test plan

- [x] All 110 tests pass locally in aggregate
- [ ] Review workflow definition for correctness
- [ ] Review testing session scripts
- [ ] Verify documentation accuracy


Made with [Cursor](https://cursor.com)