### PR TITLE
Slice 0a: Common package skeleton + run_helper + timestamps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+pythonpath = ["."]

--- a/tools/__init__.py
+++ b/tools/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for ported CI triage modules.

--- a/tools/ci/__init__.py
+++ b/tools/ci/__init__.py
@@ -1,0 +1,1 @@
+# Package marker for CI triage helpers.

--- a/tools/ci/common/__init__.py
+++ b/tools/ci/common/__init__.py
@@ -1,0 +1,1 @@
+# Shared utilities for CI triage modules.

--- a/tools/ci/common/run_helper.py
+++ b/tools/ci/common/run_helper.py
@@ -1,0 +1,33 @@
+"""Shared subprocess runner with standard error formatting."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import subprocess
+
+
+def run(
+    cmd: list[str],
+    *,
+    env: dict[str, str] | None = None,
+    check: bool = True,
+    capture: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run *cmd* as a subprocess.
+
+    When *env* is given the entries are merged into the current environment.
+    On non-zero exit (and *check* is true) raise ``RuntimeError`` with
+    stdout/stderr.
+    """
+    proc_env = None
+    if env:
+        proc_env = os.environ.copy()
+        proc_env.update(env)
+    proc = subprocess.run(cmd, text=True, capture_output=capture, env=proc_env, check=False)
+    if check and proc.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({proc.returncode}): {' '.join(shlex.quote(x) for x in cmd)}\n"
+            f"stdout:\n{proc.stdout}\n\nstderr:\n{proc.stderr}"
+        )
+    return proc

--- a/tools/ci/common/timestamps.py
+++ b/tools/ci/common/timestamps.py
@@ -1,0 +1,42 @@
+"""Shared timestamp / datetime utilities."""
+
+from __future__ import annotations
+
+import datetime as dt
+from datetime import datetime, timezone
+
+
+def now_utc() -> str:
+    """ISO 8601 UTC timestamp with second precision (trailing ``Z``)."""
+    return dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def now_utc_dt() -> dt.datetime:
+    """Current UTC datetime (microsecond precision)."""
+    return dt.datetime.now(dt.UTC)
+
+
+now_iso = now_utc
+
+
+def parse_iso_utc(text: str | None) -> dt.datetime | None:
+    """Parse an ISO 8601 timestamp, returning ``None`` on failure."""
+    if not text:
+        return None
+    value = text.strip()
+    if not value:
+        return None
+    if value.endswith("Z"):
+        value = value[:-1] + "+00:00"
+    try:
+        parsed = dt.datetime.fromisoformat(value)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=dt.UTC)
+    return parsed.astimezone(dt.UTC)
+
+
+def iso_utc(ts: float) -> str:
+    """Convert a POSIX timestamp to an ISO 8601 UTC string."""
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()

--- a/tools/ci/common/timestamps.py
+++ b/tools/ci/common/timestamps.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import datetime as dt
-from datetime import datetime, timezone
 
 
 def now_utc() -> str:
@@ -39,4 +38,4 @@ def parse_iso_utc(text: str | None) -> dt.datetime | None:
 
 def iso_utc(ts: float) -> str:
     """Convert a POSIX timestamp to an ISO 8601 UTC string."""
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+    return dt.datetime.fromtimestamp(ts, tz=dt.UTC).isoformat()

--- a/tools/tests/ci/conftest.py
+++ b/tools/tests/ci/conftest.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+@pytest.fixture()
+def fake_slack_api(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``common.slack`` POST and GET helpers to return configurable responses."""
+    mock_form = MagicMock(return_value={"ok": True, "ts": "1234567890.123456"})
+    mock_get_simple = MagicMock(return_value={"ok": True, "messages": []})
+    mock_get = MagicMock(return_value={"ok": True, "messages": []})
+
+    monkeypatch.setattr("tools.ci.common.slack.slack_api_form", mock_form)
+    monkeypatch.setattr("tools.ci.common.slack.slack_api_get_simple", mock_get_simple)
+    monkeypatch.setattr("tools.ci.common.slack.slack_api_get", mock_get)
+
+    return {"form": mock_form, "get_simple": mock_get_simple, "get": mock_get}
+
+
+@pytest.fixture()
+def fake_github_api(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``common.github`` helpers to return empty/configurable responses."""
+    mock_get = MagicMock(return_value={})
+    mock_user = MagicMock(return_value={"login": "testuser", "name": "Test User", "email": ""})
+
+    monkeypatch.setattr("tools.ci.common.github.github_api_get", mock_get)
+    monkeypatch.setattr("tools.ci.common.github.github_user_info", mock_user)
+
+    return {"get": mock_get, "user_info": mock_user}
+
+
+@pytest.fixture()
+def fake_guarded_gh(monkeypatch: pytest.MonkeyPatch):
+    """Patch ``common.guarded.run_guarded_gh`` to return a successful no-op."""
+    import subprocess
+
+    proc = subprocess.CompletedProcess(args=[], returncode=0, stdout="", stderr="")
+    mock = MagicMock(return_value=proc)
+    monkeypatch.setattr("tools.ci.common.guarded.run_guarded_gh", mock)
+    return mock
+
+
+@pytest.fixture()
+def fake_state_dir(tmp_path: Path):
+    """Create a ``tmp_path`` containing a valid minimal ``ci_triage_state.json``."""
+    state_path = tmp_path / "ci_triage_state.json"
+    state_path.write_text(
+        json.dumps({"version": 1, "updated_at_utc": "2024-01-01T00:00:00Z", "items": []}),
+        encoding="utf-8",
+    )
+    return {"dir": tmp_path, "state_path": state_path}

--- a/tools/tests/ci/conftest.py
+++ b/tools/tests/ci/conftest.py
@@ -1,15 +1,10 @@
 from __future__ import annotations
 
 import json
-import sys
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
-
-REPO_ROOT = Path(__file__).resolve().parents[3]
-if str(REPO_ROOT) not in sys.path:
-    sys.path.insert(0, str(REPO_ROOT))
 
 
 @pytest.fixture()

--- a/tools/tests/ci/test_common_run_helper.py
+++ b/tools/tests/ci/test_common_run_helper.py
@@ -1,0 +1,28 @@
+"""Tests for tools.ci.common.run_helper."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ci.common.run_helper import run
+
+
+def test_run_success():
+    proc = run(["echo", "hello"])
+    assert proc.returncode == 0
+    assert "hello" in proc.stdout
+
+
+def test_run_failure_raises():
+    with pytest.raises(RuntimeError, match="Command failed"):
+        run(["false"])
+
+
+def test_run_no_check():
+    proc = run(["false"], check=False)
+    assert proc.returncode != 0
+
+
+def test_run_env_injection():
+    proc = run(["env"], env={"TEST_MARKER_XYZ": "42"})
+    assert "TEST_MARKER_XYZ=42" in proc.stdout

--- a/tools/tests/ci/test_common_timestamps.py
+++ b/tools/tests/ci/test_common_timestamps.py
@@ -1,0 +1,55 @@
+"""Tests for tools.ci.common.timestamps."""
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+
+from tools.ci.common.timestamps import iso_utc, now_iso, now_utc, now_utc_dt, parse_iso_utc
+
+ISO_Z_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$")
+
+
+def test_now_utc_format():
+    result = now_utc()
+    assert ISO_Z_RE.match(result), f"unexpected format: {result}"
+
+
+def test_now_utc_dt_returns_aware_datetime():
+    result = now_utc_dt()
+    assert isinstance(result, dt.datetime)
+    assert result.tzinfo is not None
+
+
+def test_now_iso_is_alias_for_now_utc():
+    assert now_iso is now_utc
+
+
+def test_parse_iso_utc_z_suffix():
+    result = parse_iso_utc("2024-06-15T12:30:00Z")
+    assert result is not None
+    assert result.year == 2024
+    assert result.month == 6
+    assert result.hour == 12
+    assert result.tzinfo is not None
+
+
+def test_parse_iso_utc_offset():
+    result = parse_iso_utc("2024-06-15T12:30:00+00:00")
+    assert result is not None
+    assert result.hour == 12
+
+
+def test_parse_iso_utc_none_returns_none():
+    assert parse_iso_utc(None) is None
+    assert parse_iso_utc("") is None
+    assert parse_iso_utc("   ") is None
+
+
+def test_parse_iso_utc_invalid_returns_none():
+    assert parse_iso_utc("not-a-date") is None
+
+
+def test_iso_utc_epoch_zero():
+    result = iso_utc(0.0)
+    assert "1970-01-01" in result


### PR DESCRIPTION
## Summary

- Add `tools/ci/common/` package with `__init__`, `run_helper`, and `timestamps` modules
- Add shared `conftest.py` with pytest fixtures for mocking Slack, GitHub, guarded_gh, and state
- 12 unit tests

## Context

Part 1 of 5 splitting the foundation layer. This establishes the package skeleton and the two leaf utility modules that have no internal dependencies.

## Test plan

- [x] All 12 tests pass locally


Made with [Cursor](https://cursor.com)