### PR TITLE
Slice 0b: Guarded GitHub CLI wrapper

### DIFF
--- a/tools/ci/common/guarded.py
+++ b/tools/ci/common/guarded.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from .run_helper import run
 
+# parents[3]: common/ -> ci/ -> tools/ -> repo root
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _GUARDED_GH_DEFAULT: list[str] = [sys.executable, str(_REPO_ROOT / "tools" / "ci" / "guarded_gh.py")]
 

--- a/tools/ci/common/guarded.py
+++ b/tools/ci/common/guarded.py
@@ -1,0 +1,34 @@
+"""Wrapper around guarded_gh.py for programmatic use."""
+
+from __future__ import annotations
+
+import shlex
+import subprocess
+import sys
+from pathlib import Path
+
+from .run_helper import run
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_GUARDED_GH_DEFAULT: list[str] = [sys.executable, str(_REPO_ROOT / "tools" / "ci" / "guarded_gh.py")]
+
+
+def run_guarded_gh(
+    tokens: list[str],
+    *,
+    github_token: str | None = None,
+    check: bool = True,
+    capture: bool = True,
+    guarded_gh_cmd: list[str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Build a ``--command`` string and run it through ``guarded_gh.py``.
+
+    When *github_token* is supplied it is injected via the ``GITHUB_TOKEN``
+    environment variable (the pattern used by M4/M5/M6/issue_lifecycle).
+    When omitted the process inherits ambient ``gh`` auth (load_previous /
+    execute_disable pattern).
+    """
+    command = " ".join(shlex.quote(tok) for tok in tokens)
+    cmd = list(guarded_gh_cmd or _GUARDED_GH_DEFAULT) + ["--command", command]
+    env = {"GITHUB_TOKEN": github_token} if github_token else None
+    return run(cmd, env=env, check=check, capture=capture)

--- a/tools/ci/guarded_gh.py
+++ b/tools/ci/guarded_gh.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Execute a restricted subset of gh/git commands.
+
+This wrapper is designed for agent use where direct command access is blocked.
+It accepts a single command string, validates it against an allowlist, and
+executes only safe commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shlex
+import subprocess
+import sys
+from dataclasses import dataclass
+from typing import Sequence
+
+
+ISSUE_REPO_TEST = "ebanerjeeTT/issue_dump"
+PRIMARY_REPO = "tenstorrent/tt-metal"
+TEST_PR_REPO = "ebanerjeeTT/tt-metal"
+ALLOWED_WORKFLOW_IDS = {
+    "triage-ci",
+    "triage-ci.yaml",
+    "triage-ci.yml",
+    "all-static-checks",
+    "all-static-checks.yaml",
+    "all-static-checks.yml",
+    "pr-gate",
+    "pr-gate.yaml",
+    "pr-gate.yml",
+    "merge-gate",
+    "merge-gate.yaml",
+    "merge-gate.yml",
+}
+READ_REPOS = {PRIMARY_REPO, ISSUE_REPO_TEST}
+ALLOWED_PR_REPOS = {PRIMARY_REPO, TEST_PR_REPO}
+ALLOWED_WORKFLOW_REPOS = {PRIMARY_REPO, TEST_PR_REPO}
+ALLOWED_PUSH_REMOTE = "origin"
+ALLOWED_PUSH_REFSPECS = {
+    "ebanerjee/CI-maintenance",
+    "HEAD:ebanerjee/CI-maintenance",
+}
+ALLOWED_COMMIT_OPTS = {"-m", "--message"}
+
+DENY_CHARS = {";", "&&", "||", "|", "`", "$("}
+FREE_TEXT_OPTIONS = {"--body", "--title", "-m", "--message"}
+
+
+@dataclass(frozen=True)
+class Decision:
+    allowed: bool
+    reason: str
+
+
+def extract_option(tokens: Sequence[str], long_opt: str, short_opt: str | None = None) -> str | None:
+    for i, tok in enumerate(tokens):
+        if tok == long_opt or (short_opt and tok == short_opt):
+            if i + 1 < len(tokens):
+                return tokens[i + 1]
+            return None
+        if tok.startswith(f"{long_opt}="):
+            return tok.split("=", 1)[1]
+        if short_opt and tok.startswith(f"{short_opt}="):
+            return tok.split("=", 1)[1]
+    return None
+
+
+def first_positional_after(tokens: Sequence[str], start_idx: int) -> str | None:
+    for tok in tokens[start_idx:]:
+        if not tok.startswith("-"):
+            return tok
+    return None
+
+
+def has_option(tokens: Sequence[str], long_opt: str, short_opt: str | None = None) -> bool:
+    return extract_option(tokens, long_opt, short_opt) is not None
+
+
+def repo_for_command(tokens: Sequence[str]) -> str | None:
+    return extract_option(tokens, "--repo", "-R")
+
+
+def deny_for_suspicious_tokens(tokens: Sequence[str]) -> Decision | None:
+    skip_next = False
+    for tok in tokens:
+        if skip_next:
+            skip_next = False
+            continue
+        if tok in FREE_TEXT_OPTIONS:
+            skip_next = True
+            continue
+        if any(tok.startswith(f"{opt}=") for opt in FREE_TEXT_OPTIONS):
+            continue
+        for marker in DENY_CHARS:
+            if marker in tok:
+                return Decision(False, f"Denied: suspicious token detected: {tok!r}")
+    return None
+
+
+def ensure_repo(tokens: Sequence[str], allowed_repos: set[str], *, required: bool = True) -> Decision | None:
+    repo = repo_for_command(tokens)
+    if repo is None:
+        if required:
+            return Decision(False, "Denied: command must specify --repo/-R explicitly.")
+        return None
+    if repo not in allowed_repos:
+        return Decision(False, f"Denied: repo {repo!r} is not allowed.")
+    return None
+
+
+def validate(tokens: list[str]) -> Decision:
+    if not tokens:
+        return Decision(False, "Denied: empty command.")
+
+    suspicious = deny_for_suspicious_tokens(tokens)
+    if suspicious:
+        return suspicious
+
+    if tokens[0] == "git":
+        if len(tokens) < 2:
+            return Decision(False, "Denied: missing git subcommand.")
+        if tokens[1] == "push":
+            idx = 2
+            while idx < len(tokens) and tokens[idx].startswith("-"):
+                if tokens[idx] not in {"-u", "--set-upstream"}:
+                    return Decision(False, f"Denied: unsupported git push option {tokens[idx]!r}.")
+                idx += 1
+
+            if idx >= len(tokens):
+                return Decision(False, "Denied: git push requires remote.")
+            remote = tokens[idx]
+            idx += 1
+            if remote != ALLOWED_PUSH_REMOTE:
+                return Decision(False, f"Denied: git push remote must be {ALLOWED_PUSH_REMOTE!r}.")
+
+            if idx >= len(tokens):
+                return Decision(False, "Denied: git push requires explicit refspec.")
+            refspec = tokens[idx]
+            idx += 1
+            if refspec not in ALLOWED_PUSH_REFSPECS:
+                return Decision(False, f"Denied: refspec {refspec!r} is not allowed.")
+
+            if idx != len(tokens):
+                return Decision(False, "Denied: extra git push arguments are not allowed.")
+
+            return Decision(True, "Allowed: git push to ebanerjee/CI-maintenance only")
+
+        if tokens[1] == "commit":
+            idx = 2
+            has_message = False
+            while idx < len(tokens):
+                tok = tokens[idx]
+                if tok.startswith("-"):
+                    if tok in ALLOWED_COMMIT_OPTS:
+                        if idx + 1 >= len(tokens):
+                            return Decision(False, f"Denied: {tok} requires a value.")
+                        has_message = True
+                        idx += 2
+                        continue
+                    if any(tok.startswith(f"{opt}=") for opt in ALLOWED_COMMIT_OPTS):
+                        has_message = True
+                        idx += 1
+                        continue
+                    return Decision(False, f"Denied: unsupported git commit option {tok!r}.")
+                return Decision(False, "Denied: positional arguments are not allowed for git commit.")
+
+            if not has_message:
+                return Decision(False, "Denied: git commit requires -m/--message.")
+            return Decision(True, "Allowed: git commit with message only")
+
+        return Decision(False, "Denied: only git push/commit are allowlisted.")
+
+    if tokens[0] != "gh":
+        return Decision(False, "Denied: only commands starting with `gh` or allowlisted `git` are allowed.")
+    if len(tokens) < 2:
+        return Decision(False, "Denied: missing gh subcommand.")
+
+    root = tokens[1]
+    sub = tokens[2] if len(tokens) > 2 else ""
+
+    # Read-only auth status check is allowed.
+    if root == "auth" and sub == "status":
+        return Decision(True, "Allowed: gh auth status")
+
+    # Issue commands.
+    if root == "issue":
+        if sub in {"list", "view"}:
+            repo_check = ensure_repo(tokens, READ_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            return Decision(True, f"Allowed: gh issue {sub}")
+
+        if sub in {"create", "edit", "close", "reopen", "comment"}:
+            repo_check = ensure_repo(tokens, {ISSUE_REPO_TEST}, required=True)
+            if repo_check:
+                return repo_check
+            return Decision(True, f"Allowed: gh issue {sub} on test issue repo only")
+
+        return Decision(False, f"Denied: unsupported gh issue subcommand {sub!r}.")
+
+    # PR read-only commands in primary repo.
+    if root == "pr":
+        if sub in {"list", "view"}:
+            repo_check = ensure_repo(tokens, ALLOWED_PR_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            return Decision(True, f"Allowed: gh pr {sub}")
+        if sub == "comment":
+            repo_check = ensure_repo(tokens, ALLOWED_PR_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            if not has_option(tokens, "--body"):
+                return Decision(False, "Denied: gh pr comment must include --body.")
+            target = first_positional_after(tokens, 3)
+            if target is None:
+                return Decision(False, "Denied: gh pr comment requires PR number/url argument.")
+            return Decision(True, "Allowed: gh pr comment in primary repo")
+        if sub == "create":
+            repo_check = ensure_repo(tokens, ALLOWED_PR_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            if extract_option(tokens, "--base") != "main":
+                return Decision(False, "Denied: gh pr create must target --base main.")
+            if not has_option(tokens, "--head"):
+                return Decision(False, "Denied: gh pr create must include --head.")
+            if not has_option(tokens, "--title"):
+                return Decision(False, "Denied: gh pr create must include --title.")
+            if not has_option(tokens, "--body"):
+                return Decision(False, "Denied: gh pr create must include --body.")
+            if "--draft" not in tokens:
+                return Decision(False, "Denied: gh pr create must include --draft.")
+            return Decision(True, "Allowed: gh pr create (draft to main in primary repo)")
+        return Decision(False, f"Denied: unsupported gh pr subcommand {sub!r}.")
+
+    # Run read-only commands in primary repo.
+    if root == "run":
+        if sub in {"list", "view", "download"}:
+            repo_check = ensure_repo(tokens, {PRIMARY_REPO}, required=True)
+            if repo_check:
+                return repo_check
+            return Decision(True, f"Allowed: gh run {sub}")
+        return Decision(False, f"Denied: unsupported gh run subcommand {sub!r}.")
+
+    # Workflow commands. Dispatch is tightly constrained.
+    if root == "workflow":
+        if sub in {"list", "view"}:
+            repo_check = ensure_repo(tokens, ALLOWED_WORKFLOW_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            return Decision(True, f"Allowed: gh workflow {sub}")
+
+        if sub == "run":
+            repo_check = ensure_repo(tokens, ALLOWED_WORKFLOW_REPOS, required=True)
+            if repo_check:
+                return repo_check
+            workflow_id = first_positional_after(tokens, 3)
+            if workflow_id is None:
+                return Decision(False, "Denied: gh workflow run requires workflow id/name argument.")
+            if workflow_id not in ALLOWED_WORKFLOW_IDS:
+                return Decision(
+                    False,
+                    f"Denied: workflow {workflow_id!r} not in allowlist {sorted(ALLOWED_WORKFLOW_IDS)}.",
+                )
+            return Decision(True, "Allowed: gh workflow run in allowlist")
+
+        return Decision(False, f"Denied: unsupported gh workflow subcommand {sub!r}.")
+
+    # Disallow gh api to prevent bypassing restrictions.
+    if root == "api":
+        return Decision(False, "Denied: gh api is not allowed by this wrapper.")
+
+    return Decision(False, f"Denied: unsupported gh command group {root!r}.")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate and run an allowlisted gh command string.",
+    )
+    parser.add_argument(
+        "--command",
+        required=True,
+        help="Full gh command string to validate and execute.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate only; do not execute command.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        tokens = shlex.split(args.command, posix=True)
+    except ValueError as exc:
+        print(f"Denied: invalid command quoting: {exc}", file=sys.stderr)
+        return 2
+
+    decision = validate(tokens)
+    if not decision.allowed:
+        print(decision.reason, file=sys.stderr)
+        return 3
+
+    print(decision.reason, file=sys.stderr)
+    print("Command:", " ".join(shlex.quote(t) for t in tokens), file=sys.stderr)
+    if args.dry_run:
+        print("Dry-run mode: command not executed.", file=sys.stderr)
+        return 0
+
+    if len(tokens) >= 2 and tokens[0] == "git" and tokens[1] == "commit":
+        first = subprocess.run(tokens, check=False)
+        if first.returncode == 0:
+            return 0
+        print(
+            "git commit failed; retrying once after staging hook-modified tracked files.",
+            file=sys.stderr,
+        )
+        add = subprocess.run(["git", "add", "--update"], check=False)
+        if add.returncode != 0:
+            print("Retry aborted: git add --update failed.", file=sys.stderr)
+            return first.returncode
+        staged = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
+        if staged.returncode == 0:
+            print("Retry aborted: no staged changes after hook run.", file=sys.stderr)
+            return first.returncode
+        retry = subprocess.run(tokens, check=False)
+        return retry.returncode
+
+    proc = subprocess.run(tokens, check=False)
+    return proc.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/guarded_gh.py
+++ b/tools/ci/guarded_gh.py
@@ -74,7 +74,19 @@ def first_positional_after(tokens: Sequence[str], start_idx: int) -> str | None:
 
 
 def has_option(tokens: Sequence[str], long_opt: str, short_opt: str | None = None) -> bool:
-    return extract_option(tokens, long_opt, short_opt) is not None
+    """Check whether *long_opt* (or *short_opt*) appears in *tokens*.
+
+    Unlike ``extract_option``, this detects flags that are present but have no
+    following value (e.g. ``--body`` at end-of-list or ``--body=...`` form).
+    """
+    for tok in tokens:
+        if tok == long_opt or (short_opt and tok == short_opt):
+            return True
+        if tok.startswith(f"{long_opt}="):
+            return True
+        if short_opt and tok.startswith(f"{short_opt}="):
+            return True
+    return False
 
 
 def repo_for_command(tokens: Sequence[str]) -> str | None:
@@ -310,20 +322,28 @@ def main() -> int:
         return 0
 
     if len(tokens) >= 2 and tokens[0] == "git" and tokens[1] == "commit":
+        dirty_before = subprocess.run(
+            ["git", "diff", "--name-only"],
+            check=False, capture_output=True, text=True,
+        )
         first = subprocess.run(tokens, check=False)
         if first.returncode == 0:
             return 0
         print(
-            "git commit failed; retrying once after staging hook-modified tracked files.",
+            "git commit failed; retrying once after staging hook-modified files.",
             file=sys.stderr,
         )
-        add = subprocess.run(["git", "add", "--update"], check=False)
-        if add.returncode != 0:
-            print("Retry aborted: git add --update failed.", file=sys.stderr)
+        dirty_after = subprocess.run(
+            ["git", "diff", "--name-only"],
+            check=False, capture_output=True, text=True,
+        )
+        newly_dirty = set(dirty_after.stdout.splitlines()) - set(dirty_before.stdout.splitlines())
+        if not newly_dirty:
+            print("Retry aborted: no new dirty files after hook run.", file=sys.stderr)
             return first.returncode
-        staged = subprocess.run(["git", "diff", "--cached", "--quiet"], check=False)
-        if staged.returncode == 0:
-            print("Retry aborted: no staged changes after hook run.", file=sys.stderr)
+        add = subprocess.run(["git", "add", "--"] + sorted(newly_dirty), check=False)
+        if add.returncode != 0:
+            print("Retry aborted: git add failed.", file=sys.stderr)
             return first.returncode
         retry = subprocess.run(tokens, check=False)
         return retry.returncode

--- a/tools/tests/ci/test_common_guarded.py
+++ b/tools/tests/ci/test_common_guarded.py
@@ -1,10 +1,11 @@
-"""Tests for tools.ci.common.guarded."""
+"""Tests for tools.ci.common.guarded and guarded_gh.py helpers."""
 
 from __future__ import annotations
 
 from unittest.mock import patch
 
 from tools.ci.common.guarded import run_guarded_gh
+from tools.ci.guarded_gh import has_option, validate
 
 
 def test_run_guarded_gh_builds_command_string():
@@ -42,3 +43,26 @@ def test_run_guarded_gh_custom_cmd():
         cmd = args[0]
         assert cmd[0] == "python3"
         assert cmd[1] == "/custom/guard.py"
+
+
+def test_has_option_detects_flag_without_value():
+    """has_option must return True even when the flag has no following token."""
+    tokens = ["gh", "pr", "comment", "--repo", "org/repo", "--body"]
+    assert has_option(tokens, "--body") is True
+
+
+def test_has_option_detects_equals_form():
+    tokens = ["gh", "pr", "create", "--title=hello"]
+    assert has_option(tokens, "--title") is True
+
+
+def test_has_option_returns_false_when_absent():
+    tokens = ["gh", "pr", "create", "--title=hello"]
+    assert has_option(tokens, "--body") is False
+
+
+def test_validate_pr_comment_allows_body_at_end():
+    """Regression: --body at end of tokens (no value after) must still pass validation."""
+    tokens = ["gh", "pr", "comment", "--repo", "tenstorrent/tt-metal", "123", "--body", "msg"]
+    decision = validate(tokens)
+    assert decision.allowed, decision.reason

--- a/tools/tests/ci/test_common_guarded.py
+++ b/tools/tests/ci/test_common_guarded.py
@@ -1,0 +1,44 @@
+"""Tests for tools.ci.common.guarded."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from tools.ci.common.guarded import run_guarded_gh
+
+
+def test_run_guarded_gh_builds_command_string():
+    with patch("tools.ci.common.guarded.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        run_guarded_gh(["gh", "issue", "list", "--repo", "org/repo"])
+        args, kwargs = mock_run.call_args
+        cmd = args[0]
+        assert cmd[-2] == "--command"
+        assert "gh" in cmd[-1]
+        assert "issue" in cmd[-1]
+
+
+def test_run_guarded_gh_injects_token():
+    with patch("tools.ci.common.guarded.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        run_guarded_gh(["gh", "issue", "list"], github_token="tok_123")
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"] == {"GITHUB_TOKEN": "tok_123"}
+
+
+def test_run_guarded_gh_no_token_no_env():
+    with patch("tools.ci.common.guarded.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        run_guarded_gh(["gh", "issue", "list"])
+        _, kwargs = mock_run.call_args
+        assert kwargs["env"] is None
+
+
+def test_run_guarded_gh_custom_cmd():
+    with patch("tools.ci.common.guarded.run") as mock_run:
+        mock_run.return_value.returncode = 0
+        run_guarded_gh(["gh", "run", "list"], guarded_gh_cmd=["python3", "/custom/guard.py"])
+        args, _ = mock_run.call_args
+        cmd = args[0]
+        assert cmd[0] == "python3"
+        assert cmd[1] == "/custom/guard.py"


### PR DESCRIPTION
## Summary

- Add `tools/ci/guarded_gh.py` (336 lines) -- policy wrapper restricting gh/git to an approved command subset
- Add `tools/ci/common/guarded.py` -- programmatic Python interface with token injection
- 4 unit tests

## Context

Part 2 of 5 splitting the foundation layer. This is 414 lines total because `guarded_gh.py` is a single indivisible 336-line script.

## Test plan

- [x] All 4 tests pass locally


Made with [Cursor](https://cursor.com)