### PR TITLE
Slice 0c: JSON marker parsing utilities

### DIFF
--- a/tools/ci/common/markers.py
+++ b/tools/ci/common/markers.py
@@ -1,4 +1,17 @@
-"""JSON-after-marker parsing helpers for agent output."""
+"""JSON-after-marker parsing helpers for agent output.
+
+Three parsers with increasing flexibility:
+
+* ``parse_strict``  — exact marker match, JSON object only.
+                      Used by M5, issue_lifecycle, slack_thread_agent_analysis.
+* ``parse_with_fallbacks`` — marker + multiple fallback strategies (raw, fenced, brace scan).
+                      Used by M4 batch issue creation.
+* ``parse_with_regex``  — regex-tolerant marker match + fence stripping + brace fallback.
+                      Used by execute_disable_actions.
+
+Legacy aliases (``parse_json_after_marker``, ``parse_agent_json_payload``,
+``parse_agent_json_after_marker``) are kept for backward compatibility.
+"""
 
 from __future__ import annotations
 
@@ -7,8 +20,8 @@ import re
 from typing import Any
 
 
-def parse_json_after_marker(text: str, marker: str) -> dict[str, Any]:
-    """Simple ``str.find`` parser (M5 / issue_lifecycle / slack_thread pattern).
+def parse_strict(text: str, marker: str) -> dict[str, Any]:
+    """Exact marker match, returns a single JSON object.
 
     Raises on missing marker or non-object payload.
     """
@@ -34,11 +47,11 @@ def strip_json_fence(payload: str) -> str:
     return stripped
 
 
-def parse_agent_json_payload(text: str, *, marker: str) -> Any:
-    """Robust ``rfind``-based parser with multiple fallbacks (M4 pattern).
+def parse_with_fallbacks(text: str, *, marker: str) -> Any:
+    """Marker match with multiple fallback strategies.
 
     Tries, in order: marker extraction, raw JSON, last fenced block,
-    trailing ``{`` / ``[`` scan.
+    last ``{`` / ``[`` scan (scanning from end for robustness).
     """
     idx = text.rfind(marker)
     if idx >= 0:
@@ -64,7 +77,7 @@ def parse_agent_json_payload(text: str, *, marker: str) -> Any:
         except Exception:
             continue
 
-    for match in re.finditer(r"[\{\[]", stripped):
+    for match in reversed(list(re.finditer(r"[\{\[]", stripped))):
         candidate = stripped[match.start() :].strip()
         try:
             return json.loads(candidate)
@@ -75,10 +88,8 @@ def parse_agent_json_payload(text: str, *, marker: str) -> Any:
     raise ValueError(f"marker not found: {marker}. Could not parse fallback JSON. output excerpt: {excerpt}")
 
 
-def parse_agent_json_after_marker(text: str, marker: str) -> dict[str, Any]:
-    """``rfind``-based parser with regex marker matching and fence
-    stripping (execute_disable pattern).
-    """
+def parse_with_regex(text: str, marker: str) -> dict[str, Any]:
+    """Regex-tolerant marker match with fence stripping and brace fallback."""
     idx = text.rfind(marker)
     marker_end = idx + len(marker) if idx >= 0 else -1
     if idx < 0:
@@ -102,3 +113,9 @@ def parse_agent_json_after_marker(text: str, marker: str) -> dict[str, Any]:
         if brace_idx < 0:
             raise
         return json.loads(payload[brace_idx:])
+
+
+# Backward-compatible aliases
+parse_json_after_marker = parse_strict
+parse_agent_json_payload = parse_with_fallbacks
+parse_agent_json_after_marker = parse_with_regex

--- a/tools/ci/common/markers.py
+++ b/tools/ci/common/markers.py
@@ -1,0 +1,104 @@
+"""JSON-after-marker parsing helpers for agent output."""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+
+def parse_json_after_marker(text: str, marker: str) -> dict[str, Any]:
+    """Simple ``str.find`` parser (M5 / issue_lifecycle / slack_thread pattern).
+
+    Raises on missing marker or non-object payload.
+    """
+    idx = text.find(marker)
+    if idx < 0:
+        raise ValueError(f"marker not found: {marker}")
+    payload = text[idx + len(marker) :].strip()
+    if not payload:
+        raise ValueError("empty json payload after marker")
+    obj = json.loads(payload)
+    if not isinstance(obj, dict):
+        raise ValueError("payload after marker is not a JSON object")
+    return obj
+
+
+def strip_json_fence(payload: str) -> str:
+    """Remove optional triple-backtick JSON fencing."""
+    stripped = payload.strip()
+    if stripped.startswith("```"):
+        stripped = re.sub(r"^```(?:json)?\s*", "", stripped, flags=re.IGNORECASE)
+        stripped = re.sub(r"\s*```$", "", stripped)
+        stripped = stripped.strip()
+    return stripped
+
+
+def parse_agent_json_payload(text: str, *, marker: str) -> Any:
+    """Robust ``rfind``-based parser with multiple fallbacks (M4 pattern).
+
+    Tries, in order: marker extraction, raw JSON, last fenced block,
+    trailing ``{`` / ``[`` scan.
+    """
+    idx = text.rfind(marker)
+    if idx >= 0:
+        payload = strip_json_fence(text[idx + len(marker) :])
+        return json.loads(payload)
+
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError(f"marker not found: {marker}. output excerpt: <empty>")
+
+    try:
+        return json.loads(strip_json_fence(stripped))
+    except Exception:
+        pass
+
+    fenced = re.findall(r"```(?:json)?\s*(.*?)```", stripped, flags=re.IGNORECASE | re.DOTALL)
+    for block in reversed(fenced):
+        candidate = block.strip()
+        if not candidate:
+            continue
+        try:
+            return json.loads(candidate)
+        except Exception:
+            continue
+
+    for match in re.finditer(r"[\{\[]", stripped):
+        candidate = stripped[match.start() :].strip()
+        try:
+            return json.loads(candidate)
+        except Exception:
+            continue
+
+    excerpt = stripped[-600:].replace("\n", "\\n")
+    raise ValueError(f"marker not found: {marker}. Could not parse fallback JSON. output excerpt: {excerpt}")
+
+
+def parse_agent_json_after_marker(text: str, marker: str) -> dict[str, Any]:
+    """``rfind``-based parser with regex marker matching and fence
+    stripping (execute_disable pattern).
+    """
+    idx = text.rfind(marker)
+    marker_end = idx + len(marker) if idx >= 0 else -1
+    if idx < 0:
+        marker_re = re.compile(rf"`?\s*{re.escape(marker)}\s*`?")
+        matches = list(marker_re.finditer(text))
+        if matches:
+            marker_end = matches[-1].end()
+    if marker_end < 0:
+        raise ValueError(f"marker not found: {marker}")
+
+    payload = text[marker_end:].strip()
+    if payload.startswith("```"):
+        payload = re.sub(r"^```(?:json)?\s*", "", payload)
+        payload = re.sub(r"\s*```$", "", payload)
+        payload = payload.strip()
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        brace_idx = payload.find("{")
+        if brace_idx < 0:
+            raise
+        return json.loads(payload[brace_idx:])

--- a/tools/tests/ci/test_common_markers.py
+++ b/tools/tests/ci/test_common_markers.py
@@ -1,0 +1,90 @@
+"""Tests for tools.ci.common.markers."""
+
+from __future__ import annotations
+
+import pytest
+
+from tools.ci.common.markers import (
+    parse_agent_json_after_marker,
+    parse_agent_json_payload,
+    parse_json_after_marker,
+    strip_json_fence,
+)
+
+
+class TestParseJsonAfterMarker:
+    def test_simple_success(self):
+        text = "preamble ===MARKER=== {\"key\": \"value\"}"
+        result = parse_json_after_marker(text, "===MARKER===")
+        assert result == {"key": "value"}
+
+    def test_missing_marker_raises(self):
+        with pytest.raises(ValueError, match="marker not found"):
+            parse_json_after_marker("no marker here", "===MISSING===")
+
+    def test_empty_payload_raises(self):
+        with pytest.raises(ValueError, match="empty json payload"):
+            parse_json_after_marker("prefix ===M===  ", "===M===")
+
+    def test_non_object_raises(self):
+        with pytest.raises(ValueError, match="not a JSON object"):
+            parse_json_after_marker('===M=== ["array"]', "===M===")
+
+
+class TestStripJsonFence:
+    def test_removes_backtick_fence(self):
+        assert strip_json_fence('```json\n{"a":1}\n```') == '{"a":1}'
+
+    def test_no_fence_passes_through(self):
+        assert strip_json_fence('{"a":1}') == '{"a":1}'
+
+
+class TestParseAgentJsonPayload:
+    def test_with_marker(self):
+        text = "stuff ===M=== {\"ok\": true}"
+        result = parse_agent_json_payload(text, marker="===M===")
+        assert result == {"ok": True}
+
+    def test_fallback_raw_json(self):
+        text = '{"fallback": true}'
+        result = parse_agent_json_payload(text, marker="===MISSING===")
+        assert result == {"fallback": True}
+
+    def test_fallback_fenced_block(self):
+        text = 'some text\n```json\n{"fenced": true}\n```'
+        result = parse_agent_json_payload(text, marker="===MISSING===")
+        assert result == {"fenced": True}
+
+    def test_empty_raises(self):
+        with pytest.raises(ValueError, match="output excerpt: <empty>"):
+            parse_agent_json_payload("", marker="===M===")
+
+    def test_unparseable_raises(self):
+        with pytest.raises(ValueError, match="Could not parse fallback"):
+            parse_agent_json_payload("just plain text here", marker="===M===")
+
+
+class TestParseAgentJsonAfterMarker:
+    def test_with_marker(self):
+        text = "output ===M=== {\"status\": \"ok\"}"
+        result = parse_agent_json_after_marker(text, "===M===")
+        assert result == {"status": "ok"}
+
+    def test_fenced_payload(self):
+        text = "output ===M===\n```json\n{\"fenced\": true}\n```"
+        result = parse_agent_json_after_marker(text, "===M===")
+        assert result == {"fenced": True}
+
+    def test_backtick_wrapped_marker(self):
+        text = "output `===M===` {\"wrapped\": true}"
+        result = parse_agent_json_after_marker(text, "===M===")
+        assert result == {"wrapped": True}
+
+    def test_missing_marker_raises(self):
+        with pytest.raises(ValueError, match="marker not found"):
+            parse_agent_json_after_marker("no marker", "===MISSING===")
+
+    def test_brace_fallback(self):
+        text = "output ===M=== some junk {\"found\": true}"
+        result = parse_agent_json_after_marker(text, "===M===")
+        assert result == {"found": True}

--- a/tools/tests/ci/test_common_markers.py
+++ b/tools/tests/ci/test_common_markers.py
@@ -5,30 +5,33 @@ from __future__ import annotations
 import pytest
 
 from tools.ci.common.markers import (
-    parse_agent_json_after_marker,
-    parse_agent_json_payload,
+    parse_strict,
+    parse_with_fallbacks,
+    parse_with_regex,
     parse_json_after_marker,
+    parse_agent_json_payload,
+    parse_agent_json_after_marker,
     strip_json_fence,
 )
 
 
-class TestParseJsonAfterMarker:
+class TestParseStrict:
     def test_simple_success(self):
         text = "preamble ===MARKER=== {\"key\": \"value\"}"
-        result = parse_json_after_marker(text, "===MARKER===")
+        result = parse_strict(text, "===MARKER===")
         assert result == {"key": "value"}
 
     def test_missing_marker_raises(self):
         with pytest.raises(ValueError, match="marker not found"):
-            parse_json_after_marker("no marker here", "===MISSING===")
+            parse_strict("no marker here", "===MISSING===")
 
     def test_empty_payload_raises(self):
         with pytest.raises(ValueError, match="empty json payload"):
-            parse_json_after_marker("prefix ===M===  ", "===M===")
+            parse_strict("prefix ===M===  ", "===M===")
 
     def test_non_object_raises(self):
         with pytest.raises(ValueError, match="not a JSON object"):
-            parse_json_after_marker('===M=== ["array"]', "===M===")
+            parse_strict('===M=== ["array"]', "===M===")
 
 
 class TestStripJsonFence:
@@ -39,52 +42,69 @@ class TestStripJsonFence:
         assert strip_json_fence('{"a":1}') == '{"a":1}'
 
 
-class TestParseAgentJsonPayload:
+class TestParseWithFallbacks:
     def test_with_marker(self):
         text = "stuff ===M=== {\"ok\": true}"
-        result = parse_agent_json_payload(text, marker="===M===")
+        result = parse_with_fallbacks(text, marker="===M===")
         assert result == {"ok": True}
 
     def test_fallback_raw_json(self):
         text = '{"fallback": true}'
-        result = parse_agent_json_payload(text, marker="===MISSING===")
+        result = parse_with_fallbacks(text, marker="===MISSING===")
         assert result == {"fallback": True}
 
     def test_fallback_fenced_block(self):
         text = 'some text\n```json\n{"fenced": true}\n```'
-        result = parse_agent_json_payload(text, marker="===MISSING===")
+        result = parse_with_fallbacks(text, marker="===MISSING===")
         assert result == {"fenced": True}
 
     def test_empty_raises(self):
         with pytest.raises(ValueError, match="output excerpt: <empty>"):
-            parse_agent_json_payload("", marker="===M===")
+            parse_with_fallbacks("", marker="===M===")
 
     def test_unparseable_raises(self):
         with pytest.raises(ValueError, match="Could not parse fallback"):
-            parse_agent_json_payload("just plain text here", marker="===M===")
+            parse_with_fallbacks("just plain text here", marker="===M===")
+
+    def test_brace_scan_prefers_last_match(self):
+        """The brace fallback should try the last '{' first for robustness."""
+        text = 'garbage {bad json} more stuff {"real": true}'
+        result = parse_with_fallbacks(text, marker="===MISSING===")
+        assert result == {"real": True}
 
 
-class TestParseAgentJsonAfterMarker:
+class TestParseWithRegex:
     def test_with_marker(self):
         text = "output ===M=== {\"status\": \"ok\"}"
-        result = parse_agent_json_after_marker(text, "===M===")
+        result = parse_with_regex(text, "===M===")
         assert result == {"status": "ok"}
 
     def test_fenced_payload(self):
         text = "output ===M===\n```json\n{\"fenced\": true}\n```"
-        result = parse_agent_json_after_marker(text, "===M===")
+        result = parse_with_regex(text, "===M===")
         assert result == {"fenced": True}
 
     def test_backtick_wrapped_marker(self):
         text = "output `===M===` {\"wrapped\": true}"
-        result = parse_agent_json_after_marker(text, "===M===")
+        result = parse_with_regex(text, "===M===")
         assert result == {"wrapped": True}
 
     def test_missing_marker_raises(self):
         with pytest.raises(ValueError, match="marker not found"):
-            parse_agent_json_after_marker("no marker", "===MISSING===")
+            parse_with_regex("no marker", "===MISSING===")
 
     def test_brace_fallback(self):
         text = "output ===M=== some junk {\"found\": true}"
-        result = parse_agent_json_after_marker(text, "===M===")
+        result = parse_with_regex(text, "===M===")
         assert result == {"found": True}
+
+
+class TestLegacyAliases:
+    def test_parse_json_after_marker_is_parse_strict(self):
+        assert parse_json_after_marker is parse_strict
+
+    def test_parse_agent_json_payload_is_parse_with_fallbacks(self):
+        assert parse_agent_json_payload is parse_with_fallbacks
+
+    def test_parse_agent_json_after_marker_is_parse_with_regex(self):
+        assert parse_agent_json_after_marker is parse_with_regex


### PR DESCRIPTION
## Summary

- Add `tools/ci/common/markers.py` -- strategies for extracting agent JSON output after markers
- Handles fenced code blocks, raw JSON, and robust fallbacks
- 16 unit tests

## Context

Part 3 of 5 splitting the foundation layer. 194 lines.

## Test plan

- [x] All 16 tests pass locally


Made with [Cursor](https://cursor.com)