### PR TITLE
Slice 0d: Triage state management

### DIFF
--- a/tools/ci/common/state.py
+++ b/tools/ci/common/state.py
@@ -1,0 +1,110 @@
+"""Triage state persistence helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .timestamps import now_utc
+
+ALLOWED_STATUS = {
+    "new",
+    "planned",
+    "pr_open",
+    "kickoff_running",
+    "kickoff_failed_new_failure",
+    "completed",
+    "needs_human",
+    "paused",
+}
+
+
+def empty_state() -> dict[str, Any]:
+    return {"version": 1, "updated_at_utc": now_utc(), "items": []}
+
+
+def save_state(path: Path, state: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    state["updated_at_utc"] = now_utc()
+    path.write_text(json.dumps(state, indent=2), encoding="utf-8")
+
+
+def load_state(path: Path, *, schema: str = "base") -> dict[str, Any]:
+    """Load triage state from *path*.
+
+    *schema* controls validation strictness:
+
+    - ``"base"`` -- minimal (M5 pattern): missing file returns ``empty_state()``.
+    - ``"issue_lifecycle"`` -- ensures nested ``issue_lifecycle.issues`` dict.
+    - ``"disable"`` -- strict validation of keys, statuses, and attempts.
+    """
+    if schema == "base":
+        return _load_base(path)
+    if schema == "issue_lifecycle":
+        return _load_issue_lifecycle(path)
+    if schema == "disable":
+        return _load_disable(path)
+    raise ValueError(f"unknown state schema: {schema}")
+
+
+def _load_base(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return empty_state()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return empty_state()
+    return payload
+
+
+def _load_issue_lifecycle(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {"version": 1, "updated_at_utc": now_utc(), "items": [], "issue_lifecycle": {"issues": {}}}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        payload = {"version": 1, "updated_at_utc": now_utc(), "items": []}
+    issue_lifecycle = payload.get("issue_lifecycle")
+    if not isinstance(issue_lifecycle, dict):
+        issue_lifecycle = {}
+    issues = issue_lifecycle.get("issues")
+    if not isinstance(issues, dict):
+        issues = {}
+    issue_lifecycle["issues"] = issues
+    payload["issue_lifecycle"] = issue_lifecycle
+    return payload
+
+
+def _load_disable(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return empty_state()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("state must be a JSON object")
+    if not isinstance(data.get("items"), list):
+        raise ValueError("state.items must be a list")
+    seen: set[str] = set()
+    for item in data["items"]:
+        if not isinstance(item, dict):
+            raise ValueError("state items must be objects")
+        key = str(item.get("key", ""))
+        if not key:
+            raise ValueError("state item missing key")
+        if key in seen:
+            raise ValueError(f"duplicate state key: {key}")
+        seen.add(key)
+        status = str(item.get("status", ""))
+        if status not in ALLOWED_STATUS:
+            raise ValueError(f"invalid state status for {key}: {status}")
+        attempts = item.get("attempts", 0)
+        if not isinstance(attempts, int) or attempts < 0:
+            raise ValueError(f"invalid attempts for {key}")
+    return data
+
+
+def append_history(item: dict[str, Any], event: str, details: str) -> None:
+    """Append a timestamped event to an item's history list."""
+    history = item.setdefault("history", [])
+    if not isinstance(history, list):
+        item["history"] = []
+        history = item["history"]
+    history.append({"ts_utc": now_utc(), "event": event, "details": details})

--- a/tools/ci/common/state.py
+++ b/tools/ci/common/state.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from .timestamps import now_utc
+
+log = logging.getLogger(__name__)
+
+SUPPORTED_VERSIONS = {1}
 
 ALLOWED_STATUS = {
     "new",
@@ -54,6 +59,7 @@ def _load_base(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         return empty_state()
+    _warn_unsupported_version(payload)
     return payload
 
 
@@ -63,6 +69,7 @@ def _load_issue_lifecycle(path: Path) -> dict[str, Any]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
         payload = {"version": 1, "updated_at_utc": now_utc(), "items": []}
+    _warn_unsupported_version(payload)
     issue_lifecycle = payload.get("issue_lifecycle")
     if not isinstance(issue_lifecycle, dict):
         issue_lifecycle = {}
@@ -82,19 +89,20 @@ def _load_disable(path: Path) -> dict[str, Any]:
         raise ValueError("state must be a JSON object")
     if not isinstance(data.get("items"), list):
         raise ValueError("state.items must be a list")
+    _warn_unsupported_version(data)
     seen: set[str] = set()
     for item in data["items"]:
         if not isinstance(item, dict):
             raise ValueError("state items must be objects")
-        key = str(item.get("key", ""))
-        if not key:
-            raise ValueError("state item missing key")
+        key = item.get("key")
+        if not isinstance(key, str) or not key:
+            raise ValueError(f"state item has missing or non-string key: {key!r}")
         if key in seen:
             raise ValueError(f"duplicate state key: {key}")
         seen.add(key)
-        status = str(item.get("status", ""))
-        if status not in ALLOWED_STATUS:
-            raise ValueError(f"invalid state status for {key}: {status}")
+        status = item.get("status")
+        if not isinstance(status, str) or status not in ALLOWED_STATUS:
+            raise ValueError(f"invalid state status for {key}: {status!r}")
         attempts = item.get("attempts", 0)
         if not isinstance(attempts, int) or attempts < 0:
             raise ValueError(f"invalid attempts for {key}")
@@ -105,6 +113,13 @@ def append_history(item: dict[str, Any], event: str, details: str) -> None:
     """Append a timestamped event to an item's history list."""
     history = item.setdefault("history", [])
     if not isinstance(history, list):
+        log.warning("item['history'] was %s, resetting to list", type(history).__name__)
         item["history"] = []
         history = item["history"]
     history.append({"ts_utc": now_utc(), "event": event, "details": details})
+
+
+def _warn_unsupported_version(data: dict[str, Any]) -> None:
+    version = data.get("version")
+    if version not in SUPPORTED_VERSIONS:
+        log.warning("state file version %r not in %s -- loading anyway", version, SUPPORTED_VERSIONS)

--- a/tools/tests/ci/test_common_state.py
+++ b/tools/tests/ci/test_common_state.py
@@ -1,0 +1,101 @@
+"""Tests for tools.ci.common.state."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tools.ci.common.state import (
+    ALLOWED_STATUS,
+    append_history,
+    empty_state,
+    load_state,
+    save_state,
+)
+
+
+def test_empty_state_schema():
+    s = empty_state()
+    assert s["version"] == 1
+    assert isinstance(s["items"], list)
+    assert "updated_at_utc" in s
+
+
+def test_save_and_load_base(tmp_path):
+    path = tmp_path / "state.json"
+    state = empty_state()
+    state["items"].append({"key": "test", "status": "new"})
+    save_state(path, state)
+    loaded = load_state(path, schema="base")
+    assert loaded["items"][0]["key"] == "test"
+
+
+def test_load_base_missing_file(tmp_path):
+    s = load_state(tmp_path / "missing.json", schema="base")
+    assert s == empty_state() or s["version"] == 1
+
+
+def test_load_issue_lifecycle_creates_nested(tmp_path):
+    path = tmp_path / "state.json"
+    path.write_text(json.dumps({"version": 1, "items": []}))
+    s = load_state(path, schema="issue_lifecycle")
+    assert isinstance(s["issue_lifecycle"]["issues"], dict)
+
+
+def test_load_issue_lifecycle_missing_file(tmp_path):
+    s = load_state(tmp_path / "nope.json", schema="issue_lifecycle")
+    assert "issue_lifecycle" in s
+    assert isinstance(s["issue_lifecycle"]["issues"], dict)
+
+
+def test_load_disable_valid(tmp_path):
+    path = tmp_path / "state.json"
+    data = {
+        "version": 1,
+        "updated_at_utc": "2024-01-01T00:00:00Z",
+        "items": [{"key": "a", "status": "new", "attempts": 0}],
+    }
+    path.write_text(json.dumps(data))
+    loaded = load_state(path, schema="disable")
+    assert loaded["items"][0]["key"] == "a"
+
+
+def test_load_disable_duplicate_key_raises(tmp_path):
+    path = tmp_path / "state.json"
+    data = {
+        "version": 1,
+        "items": [
+            {"key": "a", "status": "new", "attempts": 0},
+            {"key": "a", "status": "planned", "attempts": 0},
+        ],
+    }
+    path.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="duplicate state key"):
+        load_state(path, schema="disable")
+
+
+def test_load_disable_bad_status_raises(tmp_path):
+    path = tmp_path / "state.json"
+    data = {"version": 1, "items": [{"key": "a", "status": "bogus", "attempts": 0}]}
+    path.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="invalid state status"):
+        load_state(path, schema="disable")
+
+
+def test_load_unknown_schema_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown state schema"):
+        load_state(tmp_path / "x.json", schema="bogus")
+
+
+def test_append_history():
+    item: dict = {"key": "test"}
+    append_history(item, "created", "initial")
+    assert len(item["history"]) == 1
+    assert item["history"][0]["event"] == "created"
+    assert "ts_utc" in item["history"][0]
+
+
+def test_allowed_status_has_expected_values():
+    for s in ("new", "planned", "completed", "needs_human"):
+        assert s in ALLOWED_STATUS

--- a/tools/tests/ci/test_common_state.py
+++ b/tools/tests/ci/test_common_state.py
@@ -99,3 +99,32 @@ def test_append_history():
 def test_allowed_status_has_expected_values():
     for s in ("new", "planned", "completed", "needs_human"):
         assert s in ALLOWED_STATUS
+
+
+def test_load_disable_non_string_key_raises(tmp_path):
+    path = tmp_path / "state.json"
+    data = {"version": 1, "items": [{"key": 42, "status": "new", "attempts": 0}]}
+    path.write_text(json.dumps(data))
+    with pytest.raises(ValueError, match="non-string key"):
+        load_state(path, schema="disable")
+
+
+def test_unsupported_version_logs_warning(tmp_path, caplog):
+    path = tmp_path / "state.json"
+    data = {"version": 99, "items": []}
+    path.write_text(json.dumps(data))
+    import logging
+    with caplog.at_level(logging.WARNING, logger="tools.ci.common.state"):
+        loaded = load_state(path, schema="base")
+    assert loaded["version"] == 99
+    assert "version 99" in caplog.text
+
+
+def test_append_history_resets_non_list(caplog):
+    import logging
+    item: dict = {"key": "test", "history": "not-a-list"}
+    with caplog.at_level(logging.WARNING, logger="tools.ci.common.state"):
+        append_history(item, "created", "initial")
+    assert isinstance(item["history"], list)
+    assert len(item["history"]) == 1
+    assert "resetting to list" in caplog.text


### PR DESCRIPTION
## Summary

- Add `tools/ci/common/state.py` -- load, save, and validate triage state across schemas
- Supports base, issue_lifecycle, and disable schemas with strict validation
- 11 unit tests

## Context

Part 4 of 5 splitting the foundation layer. 211 lines.

## Test plan

- [x] All 11 tests pass locally


Made with [Cursor](https://cursor.com)