### PR TITLE
Slice 0e: Slack, GitHub, and CODEOWNERS API helpers

### DIFF
--- a/tools/ci/common/codeowners.py
+++ b/tools/ci/common/codeowners.py
@@ -1,0 +1,75 @@
+"""CODEOWNERS parsing helpers."""
+
+from __future__ import annotations
+
+import fnmatch
+from pathlib import Path
+
+
+def parse_codeowners(
+    path: Path, *, keep_teams: bool = True,
+) -> list[tuple[str, list[str]]]:
+    """Parse a CODEOWNERS file into ``(pattern, owners)`` tuples.
+
+    When *keep_teams* is ``False``, ``@org/team`` handles are excluded (only
+    individual ``@user`` handles are kept).
+    """
+    if not path.exists():
+        return []
+    rules: list[tuple[str, list[str]]] = []
+    for raw in path.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        pattern = parts[0].lstrip("/")
+        owners: list[str] = []
+        for tok in parts[1:]:
+            if not tok.startswith("@"):
+                continue
+            handle = tok[1:]
+            if not keep_teams and "/" in handle:
+                continue
+            if handle:
+                owners.append(handle)
+        if owners:
+            rules.append((pattern, owners))
+    return rules
+
+
+def codeowners_match(path: str, pattern: str) -> bool:
+    """Return whether *path* matches a CODEOWNERS *pattern*."""
+    p = path.lstrip("/")
+    pat = pattern.lstrip("/")
+    if fnmatch.fnmatch(p, pat):
+        return True
+    if pat.endswith("/") and p.startswith(pat):
+        return True
+    if "/" not in pat and fnmatch.fnmatch(Path(p).name, pat):
+        return True
+    return False
+
+
+def parse_codeowners_logins(path: Path) -> list[str]:
+    """Return a flat, deduplicated list of individual logins (no teams)."""
+    out: list[str] = []
+    seen: set[str] = set()
+    lines = path.read_text(encoding="utf-8", errors="ignore").splitlines() if path.exists() else []
+    for raw in lines:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        for tok in line.split()[1:]:
+            if not tok.startswith("@"):
+                continue
+            login = tok[1:].strip()
+            if not login or "/" in login:
+                continue
+            low = login.lower()
+            if low in seen:
+                continue
+            seen.add(low)
+            out.append(login)
+    return out

--- a/tools/ci/common/github.py
+++ b/tools/ci/common/github.py
@@ -13,8 +13,11 @@ _DEFAULT_UA = "tt-metal-ci-triage"
 
 def github_api_get(
     token: str, endpoint: str, *, user_agent: str = _DEFAULT_UA,
-) -> dict[str, Any]:
-    """GET a GitHub REST API endpoint.  *endpoint* should start with ``/``."""
+) -> Any:
+    """GET a GitHub REST API endpoint.  *endpoint* should start with ``/``.
+
+    Returns a dict for object endpoints or a list for collection endpoints.
+    """
     req = urllib.request.Request(
         f"https://api.github.com{endpoint}",
         headers={

--- a/tools/ci/common/github.py
+++ b/tools/ci/common/github.py
@@ -1,0 +1,39 @@
+"""Shared GitHub REST API helpers."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+_DEFAULT_UA = "tt-metal-ci-triage"
+
+
+def github_api_get(
+    token: str, endpoint: str, *, user_agent: str = _DEFAULT_UA,
+) -> dict[str, Any]:
+    """GET a GitHub REST API endpoint.  *endpoint* should start with ``/``."""
+    req = urllib.request.Request(
+        f"https://api.github.com{endpoint}",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "User-Agent": user_agent,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=20) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def github_user_info(
+    token: str, username: str, *, user_agent: str = _DEFAULT_UA,
+) -> dict[str, Any]:
+    """Return the public profile for *username*, or ``{}`` on any error."""
+    try:
+        return github_api_get(
+            token, f"/users/{urllib.parse.quote(username)}", user_agent=user_agent,
+        )
+    except Exception:
+        return {}

--- a/tools/ci/common/slack.py
+++ b/tools/ci/common/slack.py
@@ -40,22 +40,25 @@ def slack_api_get_simple(token: str, endpoint: str, params: dict[str, str]) -> d
         return json.loads(resp.read().decode("utf-8"))
 
 
+_MAX_RETRY_AFTER = 120
+
+
 def slack_api_get(
     token: str, endpoint: str, params: dict[str, Any], *, max_retries: int = 5,
 ) -> dict[str, Any]:
     """GET with automatic retry on HTTP 429 and Slack-level rate limiting."""
     url = f"{API_BASE}/{endpoint}?{urllib.parse.urlencode(params)}"
-    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
 
     attempt = 0
     while True:
         attempt += 1
+        req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
         try:
             with urllib.request.urlopen(req, timeout=60) as resp:
                 payload = json.loads(resp.read().decode("utf-8"))
         except urllib.error.HTTPError as exc:
             if exc.code == 429 and attempt <= max_retries:
-                retry_after = int(exc.headers.get("Retry-After", "1"))
+                retry_after = min(int(exc.headers.get("Retry-After", "1")), _MAX_RETRY_AFTER)
                 time.sleep(retry_after)
                 continue
             raise RuntimeError(f"HTTP error from Slack API ({endpoint}): {exc}") from exc

--- a/tools/ci/common/slack.py
+++ b/tools/ci/common/slack.py
@@ -1,0 +1,85 @@
+"""Shared Slack Web API helpers."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+API_BASE = "https://slack.com/api"
+
+
+def slack_api_form(token: str, endpoint: str, fields: dict[str, str]) -> dict[str, Any]:
+    """POST an ``application/x-www-form-urlencoded`` request to the Slack Web API."""
+    data = urllib.parse.urlencode(fields).encode("utf-8")
+    req = urllib.request.Request(
+        f"{API_BASE}/{endpoint}",
+        data=data,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def slack_api_get_simple(token: str, endpoint: str, params: dict[str, str]) -> dict[str, Any]:
+    """Simple GET against the Slack Web API (no retry / rate-limit handling)."""
+    query = urllib.parse.urlencode(params)
+    req = urllib.request.Request(
+        f"{API_BASE}/{endpoint}?{query}",
+        headers={"Authorization": f"Bearer {token}"},
+        method="GET",
+    )
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return json.loads(resp.read().decode("utf-8"))
+
+
+def slack_api_get(
+    token: str, endpoint: str, params: dict[str, Any], *, max_retries: int = 5,
+) -> dict[str, Any]:
+    """GET with automatic retry on HTTP 429 and Slack-level rate limiting."""
+    url = f"{API_BASE}/{endpoint}?{urllib.parse.urlencode(params)}"
+    req = urllib.request.Request(url, headers={"Authorization": f"Bearer {token}"})
+
+    attempt = 0
+    while True:
+        attempt += 1
+        try:
+            with urllib.request.urlopen(req, timeout=60) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except urllib.error.HTTPError as exc:
+            if exc.code == 429 and attempt <= max_retries:
+                retry_after = int(exc.headers.get("Retry-After", "1"))
+                time.sleep(retry_after)
+                continue
+            raise RuntimeError(f"HTTP error from Slack API ({endpoint}): {exc}") from exc
+        except urllib.error.URLError as exc:
+            raise RuntimeError(f"Network error calling Slack API ({endpoint}): {exc}") from exc
+
+        if payload.get("ok", False):
+            return payload
+
+        error = payload.get("error", "unknown_error")
+        if error == "ratelimited" and attempt <= max_retries:
+            time.sleep(min(2**attempt, 30))
+            continue
+        raise RuntimeError(f"Slack API error from {endpoint}: {error}")
+
+
+def post_slack_message(
+    *, slack_token: str, channel_id: str, text: str, thread_ts: str | None = None,
+) -> str:
+    """Post a message (optionally in a thread) and return the message ``ts``."""
+    fields: dict[str, str] = {"channel": channel_id, "text": text}
+    if thread_ts:
+        fields["thread_ts"] = thread_ts
+    payload = slack_api_form(slack_token, "chat.postMessage", fields)
+    if not payload.get("ok"):
+        raise RuntimeError(f"chat.postMessage failed: {payload.get('error', 'unknown_error')}")
+    return str(payload.get("ts", "")).strip()

--- a/tools/tests/ci/test_common_codeowners.py
+++ b/tools/tests/ci/test_common_codeowners.py
@@ -1,0 +1,70 @@
+"""Tests for tools.ci.common.codeowners."""
+
+from __future__ import annotations
+
+from tools.ci.common.codeowners import codeowners_match, parse_codeowners, parse_codeowners_logins
+
+
+SAMPLE_CODEOWNERS = """\
+# Top-level
+* @org/default-team @alice
+
+# Tests
+tests/ @bob @org/qa-team
+
+# Models
+models/*.py @carol
+"""
+
+
+def test_parse_codeowners_keep_teams(tmp_path):
+    path = tmp_path / "CODEOWNERS"
+    path.write_text(SAMPLE_CODEOWNERS)
+    rules = parse_codeowners(path, keep_teams=True)
+    assert len(rules) == 3
+    assert rules[0] == ("*", ["org/default-team", "alice"])
+    assert rules[1] == ("tests/", ["bob", "org/qa-team"])
+
+
+def test_parse_codeowners_drop_teams(tmp_path):
+    path = tmp_path / "CODEOWNERS"
+    path.write_text(SAMPLE_CODEOWNERS)
+    rules = parse_codeowners(path, keep_teams=False)
+    assert len(rules) == 3
+    assert rules[0] == ("*", ["alice"])
+    assert rules[1] == ("tests/", ["bob"])
+    assert rules[2] == ("models/*.py", ["carol"])
+
+
+def test_parse_codeowners_missing_file(tmp_path):
+    assert parse_codeowners(tmp_path / "nope") == []
+
+
+def test_codeowners_match_glob():
+    assert codeowners_match("tests/foo.py", "tests/")
+    assert codeowners_match("models/bar.py", "models/*.py")
+
+
+def test_codeowners_match_basename():
+    assert codeowners_match("deeply/nested/Makefile", "Makefile")
+
+
+def test_codeowners_match_no_match():
+    assert not codeowners_match("src/main.py", "tests/")
+
+
+def test_parse_codeowners_logins(tmp_path):
+    path = tmp_path / "CODEOWNERS"
+    path.write_text(SAMPLE_CODEOWNERS)
+    logins = parse_codeowners_logins(path)
+    assert "alice" in logins
+    assert "bob" in logins
+    assert "carol" in logins
+    assert all("/" not in l for l in logins)
+
+
+def test_parse_codeowners_logins_deduplicates(tmp_path):
+    path = tmp_path / "CODEOWNERS"
+    path.write_text("* @Alice\ntests/ @alice\n")
+    logins = parse_codeowners_logins(path)
+    assert len(logins) == 1

--- a/tools/tests/ci/test_common_slack_github.py
+++ b/tools/tests/ci/test_common_slack_github.py
@@ -1,0 +1,113 @@
+"""Tests for tools.ci.common.slack and tools.ci.common.github retry logic."""
+
+from __future__ import annotations
+
+import io
+import json
+from http.client import HTTPResponse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.ci.common import slack, github
+
+
+class TestSlackApiGetRetry:
+    def _make_http_error(self, code: int, retry_after: str = "0"):
+        import urllib.error
+        headers = MagicMock()
+        headers.get.return_value = retry_after
+        return urllib.error.HTTPError(
+            url="https://slack.com/api/test",
+            code=code,
+            msg="rate limited",
+            hdrs=headers,
+            fp=io.BytesIO(b""),
+        )
+
+    @patch("tools.ci.common.slack.urllib.request.urlopen")
+    def test_retries_on_429(self, mock_urlopen):
+        err = self._make_http_error(429, "0")
+        ok_body = json.dumps({"ok": True, "data": 1}).encode()
+        ok_resp = MagicMock()
+        ok_resp.read.return_value = ok_body
+        ok_resp.__enter__ = lambda s: s
+        ok_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [err, ok_resp]
+
+        result = slack.slack_api_get("tok", "conversations.history", {"channel": "C1"})
+        assert result == {"ok": True, "data": 1}
+        assert mock_urlopen.call_count == 2
+
+    @patch("tools.ci.common.slack.urllib.request.urlopen")
+    def test_caps_retry_after_at_max(self, mock_urlopen):
+        err = self._make_http_error(429, "9999")
+        ok_body = json.dumps({"ok": True}).encode()
+        ok_resp = MagicMock()
+        ok_resp.read.return_value = ok_body
+        ok_resp.__enter__ = lambda s: s
+        ok_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [err, ok_resp]
+
+        with patch("tools.ci.common.slack.time.sleep") as mock_sleep:
+            slack.slack_api_get("tok", "test", {})
+            mock_sleep.assert_called_once_with(slack._MAX_RETRY_AFTER)
+
+    @patch("tools.ci.common.slack.urllib.request.urlopen")
+    def test_retries_on_ratelimited_error(self, mock_urlopen):
+        limited_body = json.dumps({"ok": False, "error": "ratelimited"}).encode()
+        limited_resp = MagicMock()
+        limited_resp.read.return_value = limited_body
+        limited_resp.__enter__ = lambda s: s
+        limited_resp.__exit__ = MagicMock(return_value=False)
+
+        ok_body = json.dumps({"ok": True}).encode()
+        ok_resp = MagicMock()
+        ok_resp.read.return_value = ok_body
+        ok_resp.__enter__ = lambda s: s
+        ok_resp.__exit__ = MagicMock(return_value=False)
+
+        mock_urlopen.side_effect = [limited_resp, ok_resp]
+
+        with patch("tools.ci.common.slack.time.sleep"):
+            result = slack.slack_api_get("tok", "test", {})
+        assert result["ok"] is True
+
+    @patch("tools.ci.common.slack.urllib.request.urlopen")
+    def test_raises_after_max_retries(self, mock_urlopen):
+        err = self._make_http_error(429, "0")
+        mock_urlopen.side_effect = [err] * 6
+
+        with patch("tools.ci.common.slack.time.sleep"):
+            with pytest.raises(RuntimeError, match="HTTP error"):
+                slack.slack_api_get("tok", "test", {}, max_retries=5)
+
+
+class TestGithubApiGet:
+    @patch("tools.ci.common.github.urllib.request.urlopen")
+    def test_returns_list_for_collection(self, mock_urlopen):
+        body = json.dumps([{"id": 1}, {"id": 2}]).encode()
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp
+
+        result = github.github_api_get("tok", "/repos/org/repo/issues")
+        assert isinstance(result, list)
+        assert len(result) == 2
+
+    @patch("tools.ci.common.github.urllib.request.urlopen")
+    def test_returns_dict_for_object(self, mock_urlopen):
+        body = json.dumps({"login": "user1"}).encode()
+        resp = MagicMock()
+        resp.read.return_value = body
+        resp.__enter__ = lambda s: s
+        resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = resp
+
+        result = github.github_api_get("tok", "/users/user1")
+        assert isinstance(result, dict)
+        assert result["login"] == "user1"


### PR DESCRIPTION
## Summary

- Add `tools/ci/common/slack.py` -- Slack Web API POST/GET with retry logic and message posting
- Add `tools/ci/common/github.py` -- GitHub REST API GET helper and user info retrieval
- Add `tools/ci/common/codeowners.py` -- CODEOWNERS file parsing with glob path matching
- 8 unit tests for CODEOWNERS parsing and matching

## Context

Part 5 of 5 splitting the foundation layer. 269 lines. This completes the `common/` package.

## Test plan

- [x] All 8 tests pass locally
- [x] All 51 foundation tests pass cumulatively


Made with [Cursor](https://cursor.com)