### PR TITLE
 #1117: Export the artifact with the auto triage mapping

### DIFF
--- a/.github/actions/slack_output_analysis/extract_errors.py
+++ b/.github/actions/slack_output_analysis/extract_errors.py
@@ -13,9 +13,10 @@ When EXTRACT_ALL_ERRORS is True:
 All errors are extracted from the "FAILURE MESSAGE:" field as-is, without any truncation or cleanup.
 Entries without "FAILURE MESSAGE:" are skipped.
 
-Output format: [error_message, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd]
+Output format: [error_message, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd, full_report_link]
 All fields except error_message can be None if not available.
 is_nd is a boolean indicating if the error is marked as non-deterministic (ND).
+full_report_link is the URL to the auto-triage workflow run that analyzed this failure.
 """
 
 import json
@@ -225,9 +226,11 @@ def main():
                     job_name = parsed_job
             # Determine if this is an ND error
             is_nd = is_non_deterministic(entry)
-            # Save as list: [error_message, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd]
+            # Extract full_report_link (URL to the auto-triage workflow run)
+            full_report_link = entry.get("full_report_link", "") or None
+            # Save as list: [error_message, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd, full_report_link]
             # Use None if URL, timestamp, job, or workflow not found
-            errors.append([error_msg, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd])
+            errors.append([error_msg, failing_run_url, formatted_timestamp, job_name, workflow_name, is_nd, full_report_link])
         else:
             skipped += 1
 

--- a/.github/actions/slack_output_analysis/generate_error_report.py
+++ b/.github/actions/slack_output_analysis/generate_error_report.py
@@ -143,6 +143,29 @@ def extract_job_id_from_url(job_url: str) -> Optional[int]:
     
     return None
 
+
+def extract_run_id_from_url(run_url: str) -> Optional[int]:
+    """Extract workflow run ID from GitHub Actions run URL.
+
+    Args:
+        run_url: GitHub Actions run URL (e.g., https://github.com/owner/repo/actions/runs/RUN_ID)
+
+    Returns:
+        Run ID as integer, or None if not found
+    """
+    if not run_url:
+        return None
+
+    try:
+        match = re.search(r'/actions/runs/(\d+)', run_url)
+        if match:
+            return int(match.group(1))
+    except (ValueError, AttributeError):
+        pass
+
+    return None
+
+
 # Job name fetching is now handled by github_api_utils.get_job_name_from_github
 # with persistent caching - this local function is no longer needed
 
@@ -577,6 +600,7 @@ def generate_error_report() -> tuple[List[Dict[str, Any]], str]:
         job_url = error_entry[1] if len(error_entry) > 1 else None
         timestamp_str = error_entry[2] if len(error_entry) > 2 else ""
         is_nd = error_entry[5] if len(error_entry) > 5 else False
+        full_report_link = error_entry[6] if len(error_entry) > 6 else None
         
         if not error_message or not job_url:
             if not job_url:
@@ -874,6 +898,9 @@ def generate_error_report() -> tuple[List[Dict[str, Any]], str]:
             "oldest_job_error_message": oldest_run_error_message,
             "oldest_job_slack_ts": oldest_run_timestamp_utc,
             "oldest_job_commit_hash": oldest_run_commit_hash,
+            # Auto-triage run mapping
+            "auto_triage_run_id": extract_run_id_from_url(full_report_link) if full_report_link else None,
+            "auto_triage_run_link": full_report_link,
         }
         report_entries.append(report_entry)
     


### PR DESCRIPTION
Add the new field auto_triage_id to the JobClusterFailure
Checks if auto_triage/output/slack_message.json exists (skips gracefully if not)
Extracts github_job_id from the failing_run_url field
Writes auto_triage_result.json to auto_triage/output/, where it gets picked up by the existing upload step