### PR TITLE
scripts/resolve_group_pings: skip recursing into person dict's own values after resolution

### DIFF
--- a/.github/actions/slack-report-auto-triage/scripts/resolve_group_pings.py
+++ b/.github/actions/slack-report-auto-triage/scripts/resolve_group_pings.py
@@ -106,6 +106,7 @@ def walk_person_fields(obj: Any, group_index: Dict, user_index: Dict) -> int:
         if "slack_id" in obj and "name" in obj:
             if resolve_person(obj, group_index, user_index):
                 resolved += 1
+            return resolved  # person fields are scalars, not sub-documents
         for value in obj.values():
             resolved += walk_person_fields(value, group_index, user_index)
     elif isinstance(obj, list):


### PR DESCRIPTION
walk_person_fields treated person dicts and container dicts as
mutually exclusive in intent, but not in code. After identifying
a dict as a person object (has both `slack_id` and `name`) and
calling resolve_person on it, the function fell through to the
`for value in obj.values()` loop unconditionally, recursing into
the already-handled person's own fields.

This caused two problems:

1. If a person dict contained a nested sub-dict that also matched
   the person schema (e.g. a `metadata` field with `slack_id` +
   `name`), that inner dict would be resolved twice — once via the
   outer person's value iteration, and once when the walker reached
   it independently.

2. The `resolved` count returned to process_file was inflated by
   any such redundant recursion, producing incorrect log output and
   potentially triggering a file write when no real resolution
   occurred.

Fix: add `return resolved` immediately after the person-object
branch so that once a dict is handled as a person, we stop. Its
fields are scalar properties, not sub-documents to walk. Non-person
dicts continue to be walked via the else-path as before.

One line added, no existing test fixtures affected.