### PR TITLE
docs: README summary-first, distinguish triage-issue creation from n8n lifecycle and Slack data-population issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,55 +2,17 @@
 
 A GitHub Actions-based system for CI triage and signal hygiene: identify likely culprit commits for failing jobs, create and maintain deterministic-failure issues, and sync recurring Slack errors into actionable GitHub issues.
 
-## Overview
-
-This repository provides the following capabilities:
-
-1. **Regression Analysis**: AI-powered analysis of failing GitHub Actions workflows that:
-   - Invoked via `.github/actions/regression-analysis/action.yml`
-   - Identifies the last successful run and first failing run
-   - Downloads commit metadata between those boundaries
-   - Uses GitHub Copilot CLI (LLM) to analyze code changes and determine root causes
-   - Categorizes failures into 5 distinct cases
-   - Identifies relevant developers (codeowners, commit authors)
-   - Optionally creates auto-fix PRs for simple fixes
-   - Sends formatted Slack notifications with triage results
-2. **Deterministic Failure Issue Lifecycle**: Workflow-driven issue management for persistent CI regressions:
-   - Invoked via `.github/workflows/triage-create-issues.yaml` (reusable workflow, runs `python3 -m tools.ci.create_issues`)
-   - Detects jobs that fail deterministically across consecutive runs, with an adaptive streak threshold: high-volume workflows (more main-branch runs per day than `high-volume-runs-per-day`) require more consecutive failures before an issue is filed than low-volume workflows, so noisy/frequent pipelines don't get flagged prematurely
-   - Re-checks each candidate against the latest run before spending time on it, in case it recovered since the last data snapshot
-   - Drafts issue title/body from failing logs using the GitHub Copilot CLI, and only files an issue when the drafted result is medium/high confidence
-   - Creates new issues (or runs in dry-run mode via `CREATE_ISSUES=false`)
-   - Avoids duplicate issues for already tracked workflow/job pairs (tracked via metadata markers in the issue body)
-   - Produces markdown summaries for review and an `issues.json` artifact
-
-3. **Slack Output Analysis**: Syncs error messages from Slack channels to GitHub issues:
-   - Invoked via `.github/actions/slack_output_analysis/action.yml`
-   - Fetches error messages from Slack channels
-   - Extracts errors and generates reports
-   - Groups similar errors for analysis/reporting in rebuild mode
-   - Creates, updates, and closes GitHub issues in sync flows
-   - Generates error reports and incremental reports
-
-4. **Bug-Escape Guidance (Separate Workstream)**:
-   - Invoked as guidance in `.github/actions/regression-analysis/regression_analysis/instructions/instructions_footer_for_llm.txt`
-   - Documents when failures indicate missing lower-level coverage
-   - Recommends shift-left test additions independently of issue grouping/maintenance logic
-
-## Documentation
+> **Not the same as the n8n "auto-triage" workflow.** There is a separate, n8n-based auto-triage workflow whose logic lives in [`tenstorrent/vulcan-orchestration`](https://github.com/tenstorrent/vulcan-orchestration/tree/main/workflows). This repo, `tt-auto-triage`, is a distinct GitHub Actions-native system — different runtime, different logic, no shared code. Don't look here for the n8n workflow's behavior, and don't look there for this repo's.
 
 For internal usage guides and runbooks, see the [Regression Analysis Confluence page](https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1794441312/How+to+Use+Regression+Handling).
 
-## Quickstart
+## What's Here
 
-### Regression Analysis (Minimal Setup)
+Three independent pieces, each usable on its own:
 
-**Prerequisites:**
-- GitHub Personal Access Token with `copilot` scope → Store as `COPILOT_PAT` secret
-- Slack Bot Token → Store as `SLACK_BOT_TOKEN` secret  
-- Slack Channel ID → Store as `SLACK_CHANNEL_ID` secret
+### 1. Regression Analysis
 
-**Minimal workflow:**
+`.github/actions/regression-analysis` — a composite action you attach to a failing CI job. It finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). It can optionally re-run the job on real hardware to confirm the failure is deterministic before reporting, draft an auto-fix PR for simple cases, and posts results to Slack.
 
 ```yaml
 - uses: actions/checkout@v4
@@ -64,173 +26,9 @@ For internal usage guides and runbooks, see the [Regression Analysis Confluence 
     SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
-That's it. The action will analyze the failure, classify it, and send results to Slack.
+### 2. Deterministic Failure Issue Lifecycle
 
-### Deterministic Failure Issue Lifecycle (Minimal Setup)
-
-**Prerequisites:**
-- Token with read access to workflow runs/artifacts → Store as `AGGREGATE_READ_TOKEN`
-- Token with write access to issue repo → Store as `ISSUE_WRITE_TOKEN`
-- GitHub PAT with `copilot` scope for issue drafting → Store as `COPILOT_PAT`
-
-**Minimal workflow (reusable workflow call):**
-
-```yaml
-jobs:
-  create-issues:
-    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-create-issues.yaml@main
-    with:
-      issue-repo: "your-org/ci-issues"
-      target-repo: "tenstorrent/tt-metal"
-      max-issues: 5
-    secrets:
-      AGGREGATE_READ_TOKEN: ${{ secrets.AGGREGATE_READ_TOKEN }}
-      ISSUE_WRITE_TOKEN: ${{ secrets.ISSUE_WRITE_TOKEN }}
-      COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
-```
-
-This stage finds deterministically-failing jobs (based on consecutive-failure streaks, see [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below), drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs.
-
-### Slack Output Analysis (Minimal Setup)
-
-**Prerequisites:**
-- GitHub Personal Access Token → Store as `GITHUB_TOKEN` secret
-- Slack Bot Token → Store as `SLACK_BOT_TOKEN` secret
-- Slack Channel ID → Store as `SLACK_CHANNEL_ID` secret
-
-**Minimal workflow:**
-
-```yaml
-- uses: actions/checkout@v4
-- uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-    channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
-```
-
-This will sync errors from Slack to GitHub issues using default settings.
-
----
-
-## Failure Case Categories
-
-The regression-analysis system categorizes failures into 5 cases:
-
-- **Case 1**: Deterministic failure with identified commit - A specific commit clearly explains the failure
-- **Case 2**: Deterministic failure but commit unknown - Failure is deterministic but the exact commit cannot be identified (expired logs, >100 commits, etc.)
-- **Case 3**: Failure likely outside tt-metal - Non-deterministic, infrastructure-related, or external issues
-- **Case 4**: Deterministic failure with multiple plausible commits - Multiple commits could plausibly cause the failure
-- **Case 5**: Deterministic failure with incomplete commit metadata - Failure is deterministic but some commit metadata couldn't be downloaded
-
-## Usage
-
-### Regression Analysis
-
-The `regression-analysis` action analyzes failing GitHub Actions workflows and produces triage reports.
-
-#### Basic Usage
-
-Add the action to your workflow file:
-
-```yaml
-jobs:
-  triage-failure:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-      issues: write
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Run regression-analysis
-        uses: tenstorrent/tt-auto-triage/.github/actions/regression-analysis@main
-        with:
-          workflow-name: "your-workflow"
-          job-name: "your-job-name"
-          copilot-pat: ${{ secrets.COPILOT_PAT }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-```
-
-#### Required Inputs
-
-- `workflow-name`: The workflow name to inspect, without file extension (e.g., `"ci"`)
-- `job-name`: The job/subjob name within the workflow (e.g., `"test-job"`)
-- `copilot-pat`: Personal Access Token for GitHub/Copilot authentication (requires `copilot` scope)
-
-#### Optional Inputs
-
-- `slack-test-only`: Skip analysis and only send a test Slack message (default: `"false"`)
-- `slack_ts`: Slack message timestamp for threading replies (default: `""`)
-- `allow-pings`: Whether to allow pinging users/groups in Slack messages (default: `"false"`)
-- `send-slack-message`: Whether to send a Slack message (default: `"true"`)
-- `enable-retry`: Automatically retry Case 1/4 failures on supported hardware to confirm determinism (default: `"true"`)
-- `cutoff-commit`: Optional commit SHA to ignore all runs on commits newer than this one
-
-#### Required Environment Variables
-
-- `SLACK_BOT_TOKEN`: Slack Bot Token for sending notifications (required if `send-slack-message` is `true`)
-- `SLACK_CHANNEL_ID`: Slack Channel ID to post messages to (required if `send-slack-message` is `true`)
-
-#### Required Permissions
-
-The workflow needs the following permissions:
-- `contents: read` - To read repository contents and commit history
-- `actions: read` - To read workflow run information
-- `actions: write` - To trigger retry runs (if `enable-retry` is `true`)
-- `issues: write` - To create/update issues (if auto-fix is enabled)
-
-#### Outputs
-
-The action produces:
-- `explanation.md`: Detailed markdown report in `.regression_analysis/output/explanation.md`
-- `slack_message.json`: Formatted Slack message payload in `.regression_analysis/output/slack_message.json`
-- Artifacts: Regression analysis data and output are uploaded as workflow artifacts
-
-#### Example: Triggering on Workflow Failure
-
-```yaml
-name: Regression Analysis on Failure
-
-on:
-  workflow_run:
-    workflows: ["CI Tests"]
-    types:
-      - completed
-
-jobs:
-  triage:
-    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      actions: read
-      issues: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.workflow_run.head_branch }}
-
-      - name: Run regression-analysis
-        uses: tenstorrent/tt-auto-triage/.github/actions/regression-analysis@main
-        with:
-          workflow-name: "ci"
-          job-name: ${{ github.event.workflow_run.jobs[0].name }}
-          copilot-pat: ${{ secrets.COPILOT_PAT }}
-        env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
-```
-
-### Deterministic Failure Issue Lifecycle
-
-The `triage-create-issues.yaml` reusable workflow scans recent CI runs for jobs that keep failing in the same way and opens a tracking issue in `issue-repo` once a job crosses its consecutive-failure threshold.
-
-#### Basic Usage
+`.github/workflows/triage-create-issues.yaml` — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs `consecutive-failures-high-volume` (default 4) failures in a row to qualify if its workflow runs more than `high-volume-runs-per-day` (default 5) times a day on main, or just `consecutive-failures-low-volume` (default 2) if it's a low-volume workflow — so a noisy, frequently-run pipeline isn't flagged on a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair.
 
 ```yaml
 jobs:
@@ -245,194 +43,52 @@ jobs:
       COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
 ```
 
-#### Inputs
+### 3. Slack Output Analysis
 
-- `issue-repo`: Repository to create tracking issues in (default: `tenstorrent/tt-metal`)
-- `target-repo`: Repository to read workflow run data from (default: `tenstorrent/tt-metal`)
-- `max-issues`: Maximum number of issues to create in one run, `0` = unlimited (default: `0`)
-- `workflow-filter`: Comma-separated substrings to restrict which workflow names are considered; empty means all workflows (default: `""`)
-- `llm-backend`: LLM backend used to draft issue content — only `"copilot"` is currently supported (default: `"copilot"`)
-- `consecutive-failures-high-volume`: Consecutive failures required before filing an issue for a **high-volume** workflow (default: `4`)
-- `consecutive-failures-low-volume`: Consecutive failures required before filing an issue for a **low-volume** workflow (default: `2`)
-- `high-volume-runs-per-day`: Strict cutoff (`>`) on main-branch runs in the last 24h used to classify a workflow as high-volume vs. low-volume (default: `5`)
-
-The high/low-volume split exists so that "failing consistently" means something different depending on how often a workflow runs: a workflow that runs dozens of times a day needs a longer failure streak to rule out flakiness before an issue is opened, while a workflow that only runs a couple of times a day can be flagged after just a couple of failures in a row.
-
-#### Required Secrets
-
-- `AGGREGATE_READ_TOKEN`: Token with read access to workflow runs/artifacts in `target-repo`
-- `ISSUE_WRITE_TOKEN`: Token with write access to create issues in `issue-repo`
-- `COPILOT_PAT`: GitHub PAT with `copilot` scope, used to draft issue titles/bodies from failing logs
-
-#### How It Decides to File an Issue
-
-For each job whose recent-run streak meets the consecutive-failure threshold above:
-
-1. Re-checks the job's latest run on main to confirm it hasn't since recovered (the failure-streak data can be a stale snapshot)
-2. Downloads logs for that job and drafts an issue title/body with the Copilot CLI agent
-3. Skips the job if the agent determines the failure isn't deterministic, or returns low confidence — only `medium`/`high` confidence drafts result in an issue
-4. Skips the job if an issue is already open for that workflow/job pair (tracked via metadata markers embedded in the issue body)
-5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode)
-
-Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`).
-
-#### Outputs
-
-- `summary.md`: Markdown summary of created/skipped candidates, published to the job's step summary
-- `issues.json`: Artifact listing newly created and pre-existing tracked issue URLs
-
-### Slack Output Analysis
-
-The `slack_output_analysis` action syncs error messages from Slack channels to GitHub issues.
-
-#### Basic Usage
+`.github/actions/slack_output_analysis` — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many. Supports an `update` mode (sync new errors since last run) and a `rebuild` mode (recreate all issues from scratch).
 
 ```yaml
-jobs:
-  sync-slack-errors:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Sync Slack errors to GitHub issues
-        uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-          channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
-          update_mode: "update"
-          start_date: "January 1, 2026"
+- uses: actions/checkout@v4
+- uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+    channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
-#### Required Inputs
+### Bug-Escape Guidance (separate workstream)
 
-- `github_token`: GitHub Personal Access Token for creating/updating issues
-- `slack_token`: Slack Bot Token for fetching messages
-- `channel_id`: Slack channel ID to fetch messages from
+Guidance embedded in the regression-analysis LLM instructions (`regression_analysis/instructions/instructions_footer_for_llm.txt`) that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions. This is independent of the issue grouping/maintenance logic above.
 
-#### Optional Inputs
+## Failure Case Categories
 
-- `update_mode`: Mode to use - `"update"` to sync new errors (default) or `"rebuild"` to recreate all issues from scratch
-- `start_date`: Start date for fetching Slack messages (format: `"January 1, 2026"`, default: `"January 1, 2026"`)
-- `end_date`: End date cutoff for fetching messages (format: `"January 31, 2026"`, default: `""` for no cutoff)
-- `workflow_file`: Workflow file path for finding previous runs to create incremental report (e.g., `".github/workflows/analyze-ND-failures.yml"`, default: `""`)
+Regression Analysis classifies every failure into one of 5 cases:
 
-#### Outputs
-
-- `incremental_report_path`: Path to the incremental error report (new entries only)
-
-#### Example: Manual Workflow Dispatch
-
-```yaml
-name: Sync Slack Errors to GitHub
-
-on:
-  workflow_dispatch:
-    inputs:
-      github_token:
-        description: 'GitHub Personal Access Token'
-        required: true
-        type: string
-      slack_token:
-        description: 'Slack Bot Token'
-        required: true
-        type: string
-      channel_id:
-        description: 'Slack channel ID'
-        required: true
-        type: string
-      update_mode:
-        description: 'Mode: update or rebuild'
-        required: false
-        default: 'update'
-        type: choice
-        options:
-          - update
-          - rebuild
-      start_date:
-        description: 'Start date (format: January 1, 2026)'
-        required: false
-        default: 'January 1, 2026'
-        type: string
-
-jobs:
-  sync-slack-errors:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Sync Slack errors to GitHub issues
-        uses: ./.github/actions/slack_output_analysis
-        with:
-          github_token: ${{ inputs.github_token }}
-          slack_token: ${{ inputs.slack_token }}
-          channel_id: ${{ inputs.channel_id }}
-          update_mode: ${{ inputs.update_mode || 'update' }}
-          start_date: ${{ inputs.start_date || 'January 1, 2026' }}
-```
+- **Case 1**: Deterministic, culprit commit identified
+- **Case 2**: Deterministic, but the culprit commit couldn't be identified (expired logs, >100 commits, etc.)
+- **Case 3**: Likely outside tt-metal — non-deterministic, infra, or external
+- **Case 4**: Deterministic, multiple plausible culprit commits
+- **Case 5**: Deterministic, but some commit metadata couldn't be downloaded
 
 ## How It Works
 
-### Regression Analysis Pipeline
+**Regression Analysis pipeline:** find last-good/first-bad run boundaries → download the Slack directory (for developer lookups) → LLM filter stage (deterministic? gather commit metadata) → LLM analysis stage (assign confidence, categorize) → optional auto-fix PR (Case 1/2 only) → optional hardware retry to confirm determinism → post to Slack.
 
-1. **Find Boundaries**: Identifies the last successful run and first failing run for the specified workflow/job
-2. **Download Slack Directory**: Fetches Slack user/group directory for developer lookups
-3. **Filter Stage**: Uses LLM to determine deterministic failures and gather commit metadata
-4. **Analysis Stage**: Uses LLM to analyze commits, assign confidence scores, and categorize the failure
-5. **Auto-Fix (Optional)**: Attempts to create a draft PR for simple fixes (Case 1/2 only)
-6. **Retry Logic (Optional)**: Re-runs deterministic failures on supported hardware to confirm determinism
-7. **Slack Notification**: Formats and sends triage results to Slack
+**Issue Lifecycle pipeline:** download recent workflow run data → detect jobs on a qualifying consecutive-failure streak (adaptive threshold, see above) → drop pairs that already have an open tracked issue → re-confirm the job hasn't recovered → draft title/body via Copilot CLI, gated on confidence → create the issue (or dry-run) → write a markdown summary.
 
-### Deterministic Failure Issue Lifecycle Pipeline
-
-1. **Download Workflow Data**: Reads recent workflow runs and artifacts for the target repository
-2. **Detect Consistent Failures**: Finds jobs failing for N consecutive runs, where N adapts to the workflow's run volume (see [Inputs](#inputs) above)
-3. **Deduplicate Against Open Issues**: Skips workflow/job pairs that are already tracked
-4. **Confirm Freshness**: Re-checks each remaining candidate against the latest run before spending log-download/LLM cost on it, in case it already recovered
-5. **Draft Issue Content**: Uses the GitHub Copilot CLI agent plus run logs to generate issue title/body, and gate on medium/high confidence
-6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
-7. **Summarize Results**: Produces markdown summary output for auditing
-
-### Slack Output Analysis Pipeline
-
-1. **Fetch Messages**: Downloads error messages from the specified Slack channel
-2. **Extract Errors**: Extracts error messages from Slack messages (focuses on non-deterministic errors by default)
-3. **Group Similar Errors (Rebuild Mode)**: Uses ML-based similarity matching for grouped analysis/reporting
-4. **Issue Sync**: Creates/updates issues in update mode, recreates issues in rebuild mode, and applies close/cleanup logic during sync
-5. **Generate Reports**: Creates error reports and incremental reports comparing against previous runs
-
-### Bug-Escape Guidance (Separate Workstream)
-
-This is intentionally separate from issue grouping and issue maintenance workflows. It focuses on identifying likely bug escapes and proposing shift-left test coverage improvements in regression-analysis outputs.
+**Slack Output Analysis pipeline:** fetch channel messages → extract error text → (rebuild mode) group similar errors via similarity matching → create/update/close issues → generate a full and incremental error report.
 
 ## Requirements
 
 - GitHub Actions runner with Ubuntu Linux
-- GitHub Copilot CLI access (for regression-analysis)
+- GitHub Copilot CLI access (regression-analysis, create-issues)
 - Slack Bot Token with appropriate permissions
-- GitHub Personal Access Token with required scopes
-
-## Artifacts
-
-Both actions produce artifacts that can be downloaded from workflow runs:
-
-- **regression-analysis-data**: Contains commit metadata, boundary information, and intermediate analysis data
-- **regression-analysis-output**: Contains the final `explanation.md` and `slack_message.json` files
-- **error-report**: Contains the error report JSON (slack_output_analysis)
-- **incremental-error-report**: Contains incremental error report comparing against previous run
+- GitHub tokens with the scopes noted in each snippet above
 
 ## Contributing
 
-We welcome contributions to tt-auto-triage! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
-
-- Reporting bugs
-- Suggesting features
-- Submitting pull requests
-- Development guidelines
+See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting features, and submitting pull requests.
 
 ## License
 
-This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for the full license text.
-
-For clarification on how this license applies to hardware, models, and IP, please see [LICENSE_understanding.txt](LICENSE_understanding.txt).
+Apache License 2.0 — see [LICENSE](LICENSE). For how it applies to hardware, models, and IP, see [LICENSE_understanding.txt](LICENSE_understanding.txt).

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ jobs:
 - `target-repo`: Repository to read workflow run data from (default: `tenstorrent/tt-metal`)
 - `max-issues`: Maximum number of issues to create in one run, `0` = unlimited (default: `0`)
 - `workflow-filter`: Comma-separated substrings to restrict which workflow names are considered; empty means all workflows (default: `""`)
-- `llm-backend`: LLM backend used to draft issue content — only `"copilot"` is currently supported (default: `"copilot"`)
+- `llm-backend`: reserved for selecting the drafting backend — accepted by the workflow but currently a no-op; it isn't passed through to the job env or read by `tools.ci.create_issues`, so Copilot is used regardless of this value (default: `"copilot"`)
 - `consecutive-failures-high-volume`: Consecutive failures required before filing an issue for a **high-volume** workflow (default: `4`)
 - `consecutive-failures-low-volume`: Consecutive failures required before filing an issue for a **low-volume** workflow (default: `2`)
 - `high-volume-runs-per-day`: Strict cutoff (`>`) on main-branch runs in the last 24h used to classify a workflow as high-volume vs. low-volume (default: `5`)
@@ -251,7 +251,9 @@ For each job whose recent-run streak meets the consecutive-failure threshold abo
 2. Downloads logs for that job and drafts an issue title/body with the Copilot CLI agent
 3. Skips the job if the agent determines the failure isn't deterministic, or returns low confidence — only `medium`/`high` confidence drafts result in an issue
 4. Skips the job if an issue is already open for that workflow/job pair (tracked via metadata markers embedded in the issue body)
-5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode), and stops there
+5. Creates the issue, and stops there
+
+The underlying script (`tools.ci.create_issues`) supports a dry-run mode — set `CREATE_ISSUES=false` and it only records what *would* have been created — but the reusable workflow (`triage-create-issues.yaml`) always hard-codes `CREATE_ISSUES: "true"` in its step env with no input to override it, so dry-run isn't reachable by calling the workflow. To dry-run, invoke `python3 -m tools.ci.create_issues` directly with `CREATE_ISSUES` unset.
 
 Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`). There is no update or close step in this repo — once filed, the issue is picked up and lifecycled by a separate n8n workflow outside this repo.
 
@@ -372,7 +374,7 @@ The LLM instructions used in the Analysis Stage (`instructions_footer_for_llm.tx
 3. **Deduplicate Against Open Issues**: Skips workflow/job pairs that are already tracked
 4. **Confirm Freshness**: Re-checks each remaining candidate against the latest run before spending log-download/LLM cost on it, in case it already recovered
 5. **Draft Issue Content**: Uses the GitHub Copilot CLI agent plus run logs to generate issue title/body, and gate on medium/high confidence
-6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
+6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` — the reusable workflow always sets this, so calling it via `triage-create-issues.yaml` always creates for real; `CREATE_ISSUES=false` (dry-run, recording what would have been created) is only reachable by running `python3 -m tools.ci.create_issues` directly
 7. **Summarize Results**: Produces markdown summary output for auditing
 
 This pipeline never updates or closes an issue it created — that's out of scope for this repo. Once filed, a separate n8n workflow outside this repo takes over updating and lifecycling it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tt-auto-triage
 
-A GitHub Actions-based system for CI triage and signal hygiene: identify likely culprit commits for failing jobs, create and maintain deterministic-failure issues, and sync recurring Slack errors into actionable GitHub issues.
+A GitHub Actions-based system for CI triage and signal hygiene: identify likely culprit commits for failing jobs, file triage issues for jobs that fail consistently, and track recurring Slack errors as issues for data population.
 
 > **Not the same as the n8n "auto-triage" workflow.** There is a separate, n8n-based auto-triage workflow whose logic lives in [`tenstorrent/vulcan-orchestration`](https://github.com/tenstorrent/vulcan-orchestration/tree/main/workflows). This repo, `tt-auto-triage`, is a distinct GitHub Actions-native system — different runtime, different logic, no shared code. Don't look here for the n8n workflow's behavior, and don't look there for this repo's.
 
@@ -10,9 +10,9 @@ Three independent pieces, each usable on its own:
 
 1. **Regression Analysis** (`.github/actions/regression-analysis`) — a composite action attached to a failing CI job. Finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). Can optionally re-run the job on real hardware to confirm determinism, draft an auto-fix PR for simple cases, and posts results to Slack. Its LLM instructions also include bug-escape guidance — prompt text that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions in the triage output. This is just guidance surfaced in regression-analysis's own output, not a bug-escape detection system — the actual bug-escape finding logic runs as a separate workflow outside this repo.
 
-2. **Deterministic Failure Issue Lifecycle** (`.github/workflows/triage-create-issues.yaml`) — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs a longer consecutive-failure streak to qualify if its workflow runs frequently on main, and a shorter streak if it's low-volume — so a noisy, frequently-run pipeline isn't flagged over a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair. See [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below for the exact thresholds.
+2. **Deterministic Failure Issue Creation** (`.github/workflows/triage-create-issues.yaml`) — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**, so someone actually triages/fixes them. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs a longer consecutive-failure streak to qualify if its workflow runs frequently on main, and a shorter streak if it's low-volume — so a noisy, frequently-run pipeline isn't flagged over a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair. **This repo's job stops at filing the issue** — updating, tracking, and closing it out is handled entirely by a separate n8n workflow outside this repo. See [Deterministic Failure Issue Creation](#deterministic-failure-issue-creation) below for the exact thresholds.
 
-3. **Slack Output Analysis** (`.github/actions/slack_output_analysis`) — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many.
+3. **Slack Output Analysis** (`.github/actions/slack_output_analysis`) — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many. These issues exist purely for **data population** — tracking recurring error signal that regression-analysis posts to Slack — not to prompt someone to triage them. They are unrelated to, and created independently of, the triage issues from Deterministic Failure Issue Creation above.
 
 Everything below this point is detailed reference material — full setup, all inputs/outputs, and pipeline internals for each piece.
 
@@ -45,7 +45,7 @@ For internal usage guides and runbooks, see the [Regression Analysis Confluence 
 
 That's it. The action will analyze the failure, classify it, and send results to Slack.
 
-### Deterministic Failure Issue Lifecycle (Minimal Setup)
+### Deterministic Failure Issue Creation (Minimal Setup)
 
 **Prerequisites:**
 - Token with read access to workflow runs/artifacts → Store as `AGGREGATE_READ_TOKEN`
@@ -68,7 +68,7 @@ jobs:
       COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
 ```
 
-This stage finds deterministically-failing jobs (based on consecutive-failure streaks, see [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below), drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs.
+This stage finds deterministically-failing jobs (based on consecutive-failure streaks, see [Deterministic Failure Issue Creation](#deterministic-failure-issue-creation) below), drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs. It only creates the issue — updating/closing it afterward is handled by a separate n8n workflow outside this repo.
 
 ### Slack Output Analysis (Minimal Setup)
 
@@ -88,7 +88,7 @@ This stage finds deterministically-failing jobs (based on consecutive-failure st
     channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
-This will sync errors from Slack to GitHub issues using default settings.
+This will sync errors from Slack to GitHub issues using default settings. These are data-population issues for tracking recurring Slack error signal, unrelated to the triage issues created by Deterministic Failure Issue Creation above.
 
 ---
 
@@ -205,9 +205,9 @@ jobs:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
-### Deterministic Failure Issue Lifecycle
+### Deterministic Failure Issue Creation
 
-The `triage-create-issues.yaml` reusable workflow scans recent CI runs for jobs that keep failing in the same way and opens a tracking issue in `issue-repo` once a job crosses its consecutive-failure threshold.
+The `triage-create-issues.yaml` reusable workflow scans recent CI runs for jobs that keep failing in the same way and opens a triage issue in `issue-repo` once a job crosses its consecutive-failure threshold. This repo's involvement ends once the issue is created — there is no update/close logic here; a separate n8n workflow outside this repo owns updating and lifecycling these issues afterward.
 
 #### Basic Usage
 
@@ -251,9 +251,9 @@ For each job whose recent-run streak meets the consecutive-failure threshold abo
 2. Downloads logs for that job and drafts an issue title/body with the Copilot CLI agent
 3. Skips the job if the agent determines the failure isn't deterministic, or returns low confidence — only `medium`/`high` confidence drafts result in an issue
 4. Skips the job if an issue is already open for that workflow/job pair (tracked via metadata markers embedded in the issue body)
-5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode)
+5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode), and stops there
 
-Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`).
+Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`). There is no update or close step in this repo — once filed, the issue is picked up and lifecycled by a separate n8n workflow outside this repo.
 
 #### Outputs
 
@@ -262,7 +262,7 @@ Set `max-issues` to cap how many issues a single run can create, and `workflow-f
 
 ### Slack Output Analysis
 
-The `slack_output_analysis` action syncs error messages from Slack channels to GitHub issues.
+The `slack_output_analysis` action syncs error messages from Slack channels to GitHub issues. It creates, updates, and closes issues on its own (unlike Deterministic Failure Issue Creation, which only creates) — but these issues exist purely for **data population**, tracking recurring error signal that regression-analysis posts to Slack. They're a separate, unrelated bucket of issues from the triage issues created by [Deterministic Failure Issue Creation](#deterministic-failure-issue-creation) above, and aren't meant to drive anyone's triage queue.
 
 #### Basic Usage
 
@@ -365,7 +365,7 @@ jobs:
 
 The LLM instructions used in the Analysis Stage (`instructions_footer_for_llm.txt`) also carry bug-escape guidance: prompt text that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions in the triage output. This only shapes what regression-analysis writes about a given failure — the actual bug-escape detection/finding logic is a separate workflow that lives outside this repo.
 
-### Deterministic Failure Issue Lifecycle Pipeline
+### Deterministic Failure Issue Creation Pipeline
 
 1. **Download Workflow Data**: Reads recent workflow runs and artifacts for the target repository
 2. **Detect Consistent Failures**: Finds jobs failing for N consecutive runs, where N adapts to the workflow's run volume (see [Inputs](#inputs) above)
@@ -375,6 +375,8 @@ The LLM instructions used in the Analysis Stage (`instructions_footer_for_llm.tx
 6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
 7. **Summarize Results**: Produces markdown summary output for auditing
 
+This pipeline never updates or closes an issue it created — that's out of scope for this repo. Once filed, a separate n8n workflow outside this repo takes over updating and lifecycling it.
+
 ### Slack Output Analysis Pipeline
 
 1. **Fetch Messages**: Downloads error messages from the specified Slack channel
@@ -382,6 +384,8 @@ The LLM instructions used in the Analysis Stage (`instructions_footer_for_llm.tx
 3. **Group Similar Errors (Rebuild Mode)**: Uses ML-based similarity matching for grouped analysis/reporting
 4. **Issue Sync**: Creates/updates issues in update mode, recreates issues in rebuild mode, and applies close/cleanup logic during sync
 5. **Generate Reports**: Creates error reports and incremental reports comparing against previous runs
+
+Unlike the pipeline above, this one does manage its own issues end-to-end (create/update/close) — but again, those issues are a separate, data-population-only bucket unrelated to the triage issues from Deterministic Failure Issue Creation.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -16,12 +16,13 @@ This repository provides the following capabilities:
    - Optionally creates auto-fix PRs for simple fixes
    - Sends formatted Slack notifications with triage results
 2. **Deterministic Failure Issue Lifecycle**: Workflow-driven issue management for persistent CI regressions:
-   - Invoked via `.github/workflows/triage-create-issues.yaml` (or orchestrated through `.github/workflows/triage-ci.yaml`)
-   - Detects jobs that fail deterministically across consecutive runs
-   - Drafts issue content from failing logs
-   - Creates new issues (or runs in dry-run mode)
-   - Avoids duplicate issues for already tracked workflow/job pairs
-   - Produces markdown summaries for review
+   - Invoked via `.github/workflows/triage-create-issues.yaml` (reusable workflow, runs `python3 -m tools.ci.create_issues`)
+   - Detects jobs that fail deterministically across consecutive runs, with an adaptive streak threshold: high-volume workflows (more main-branch runs per day than `high-volume-runs-per-day`) require more consecutive failures before an issue is filed than low-volume workflows, so noisy/frequent pipelines don't get flagged prematurely
+   - Re-checks each candidate against the latest run before spending time on it, in case it recovered since the last data snapshot
+   - Drafts issue title/body from failing logs using the GitHub Copilot CLI, and only files an issue when the drafted result is medium/high confidence
+   - Creates new issues (or runs in dry-run mode via `CREATE_ISSUES=false`)
+   - Avoids duplicate issues for already tracked workflow/job pairs (tracked via metadata markers in the issue body)
+   - Produces markdown summaries for review and an `issues.json` artifact
 
 3. **Slack Output Analysis**: Syncs error messages from Slack channels to GitHub issues:
    - Invoked via `.github/actions/slack_output_analysis/action.yml`
@@ -70,7 +71,7 @@ That's it. The action will analyze the failure, classify it, and send results to
 **Prerequisites:**
 - Token with read access to workflow runs/artifacts → Store as `AGGREGATE_READ_TOKEN`
 - Token with write access to issue repo → Store as `ISSUE_WRITE_TOKEN`
-- Cursor API key for issue drafting → Store as `CURSOR_API_KEY`
+- GitHub PAT with `copilot` scope for issue drafting → Store as `COPILOT_PAT`
 
 **Minimal workflow (reusable workflow call):**
 
@@ -85,10 +86,10 @@ jobs:
     secrets:
       AGGREGATE_READ_TOKEN: ${{ secrets.AGGREGATE_READ_TOKEN }}
       ISSUE_WRITE_TOKEN: ${{ secrets.ISSUE_WRITE_TOKEN }}
-      CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+      COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
 ```
 
-This stage finds deterministic failures, drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs.
+This stage finds deterministically-failing jobs (based on consecutive-failure streaks, see [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below), drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs.
 
 ### Slack Output Analysis (Minimal Setup)
 
@@ -225,6 +226,61 @@ jobs:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
+### Deterministic Failure Issue Lifecycle
+
+The `triage-create-issues.yaml` reusable workflow scans recent CI runs for jobs that keep failing in the same way and opens a tracking issue in `issue-repo` once a job crosses its consecutive-failure threshold.
+
+#### Basic Usage
+
+```yaml
+jobs:
+  create-issues:
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-create-issues.yaml@main
+    with:
+      issue-repo: "tenstorrent/tt-metal"
+      target-repo: "tenstorrent/tt-metal"
+    secrets:
+      AGGREGATE_READ_TOKEN: ${{ secrets.AGGREGATE_READ_TOKEN }}
+      ISSUE_WRITE_TOKEN: ${{ secrets.ISSUE_WRITE_TOKEN }}
+      COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+```
+
+#### Inputs
+
+- `issue-repo`: Repository to create tracking issues in (default: `tenstorrent/tt-metal`)
+- `target-repo`: Repository to read workflow run data from (default: `tenstorrent/tt-metal`)
+- `max-issues`: Maximum number of issues to create in one run, `0` = unlimited (default: `0`)
+- `workflow-filter`: Comma-separated substrings to restrict which workflow names are considered; empty means all workflows (default: `""`)
+- `llm-backend`: LLM backend used to draft issue content — only `"copilot"` is currently supported (default: `"copilot"`)
+- `consecutive-failures-high-volume`: Consecutive failures required before filing an issue for a **high-volume** workflow (default: `4`)
+- `consecutive-failures-low-volume`: Consecutive failures required before filing an issue for a **low-volume** workflow (default: `2`)
+- `high-volume-runs-per-day`: Strict cutoff (`>`) on main-branch runs in the last 24h used to classify a workflow as high-volume vs. low-volume (default: `5`)
+
+The high/low-volume split exists so that "failing consistently" means something different depending on how often a workflow runs: a workflow that runs dozens of times a day needs a longer failure streak to rule out flakiness before an issue is opened, while a workflow that only runs a couple of times a day can be flagged after just a couple of failures in a row.
+
+#### Required Secrets
+
+- `AGGREGATE_READ_TOKEN`: Token with read access to workflow runs/artifacts in `target-repo`
+- `ISSUE_WRITE_TOKEN`: Token with write access to create issues in `issue-repo`
+- `COPILOT_PAT`: GitHub PAT with `copilot` scope, used to draft issue titles/bodies from failing logs
+
+#### How It Decides to File an Issue
+
+For each job whose recent-run streak meets the consecutive-failure threshold above:
+
+1. Re-checks the job's latest run on main to confirm it hasn't since recovered (the failure-streak data can be a stale snapshot)
+2. Downloads logs for that job and drafts an issue title/body with the Copilot CLI agent
+3. Skips the job if the agent determines the failure isn't deterministic, or returns low confidence — only `medium`/`high` confidence drafts result in an issue
+4. Skips the job if an issue is already open for that workflow/job pair (tracked via metadata markers embedded in the issue body)
+5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode)
+
+Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`).
+
+#### Outputs
+
+- `summary.md`: Markdown summary of created/skipped candidates, published to the job's step summary
+- `issues.json`: Artifact listing newly created and pre-existing tracked issue URLs
+
 ### Slack Output Analysis
 
 The `slack_output_analysis` action syncs error messages from Slack channels to GitHub issues.
@@ -331,11 +387,12 @@ jobs:
 ### Deterministic Failure Issue Lifecycle Pipeline
 
 1. **Download Workflow Data**: Reads recent workflow runs and artifacts for the target repository
-2. **Detect Deterministic Failures**: Finds jobs failing for N consecutive runs
+2. **Detect Consistent Failures**: Finds jobs failing for N consecutive runs, where N adapts to the workflow's run volume (see [Inputs](#inputs) above)
 3. **Deduplicate Against Open Issues**: Skips workflow/job pairs that are already tracked
-4. **Draft Issue Content**: Uses Cursor agent output plus run logs to generate issue title/body
-5. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
-6. **Summarize Results**: Produces markdown summary output for auditing
+4. **Confirm Freshness**: Re-checks each remaining candidate against the latest run before spending log-download/LLM cost on it, in case it already recovered
+5. **Draft Issue Content**: Uses the GitHub Copilot CLI agent plus run logs to generate issue title/body, and gate on medium/high confidence
+6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
+7. **Summarize Results**: Produces markdown summary output for auditing
 
 ### Slack Output Analysis Pipeline
 

--- a/README.md
+++ b/README.md
@@ -4,15 +4,34 @@ A GitHub Actions-based system for CI triage and signal hygiene: identify likely 
 
 > **Not the same as the n8n "auto-triage" workflow.** There is a separate, n8n-based auto-triage workflow whose logic lives in [`tenstorrent/vulcan-orchestration`](https://github.com/tenstorrent/vulcan-orchestration/tree/main/workflows). This repo, `tt-auto-triage`, is a distinct GitHub Actions-native system — different runtime, different logic, no shared code. Don't look here for the n8n workflow's behavior, and don't look there for this repo's.
 
+## Summary
+
+Three independent pieces, each usable on its own, plus a documentation-only workstream:
+
+1. **Regression Analysis** (`.github/actions/regression-analysis`) — a composite action attached to a failing CI job. Finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). Can optionally re-run the job on real hardware to confirm determinism, draft an auto-fix PR for simple cases, and posts results to Slack.
+
+2. **Deterministic Failure Issue Lifecycle** (`.github/workflows/triage-create-issues.yaml`) — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs a longer consecutive-failure streak to qualify if its workflow runs frequently on main, and a shorter streak if it's low-volume — so a noisy, frequently-run pipeline isn't flagged over a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair. See [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below for the exact thresholds.
+
+3. **Slack Output Analysis** (`.github/actions/slack_output_analysis`) — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many.
+
+4. **Bug-Escape Guidance** (separate workstream) — guidance embedded in the regression-analysis LLM instructions that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions. Independent of the issue grouping/maintenance logic above.
+
+Everything below this point is detailed reference material — full setup, all inputs/outputs, and pipeline internals for each piece.
+
+## Documentation
+
 For internal usage guides and runbooks, see the [Regression Analysis Confluence page](https://tenstorrent.atlassian.net/wiki/spaces/MI6/pages/1794441312/How+to+Use+Regression+Handling).
 
-## What's Here
+## Quickstart
 
-Three independent pieces, each usable on its own:
+### Regression Analysis (Minimal Setup)
 
-### 1. Regression Analysis
+**Prerequisites:**
+- GitHub Personal Access Token with `copilot` scope → Store as `COPILOT_PAT` secret
+- Slack Bot Token → Store as `SLACK_BOT_TOKEN` secret  
+- Slack Channel ID → Store as `SLACK_CHANNEL_ID` secret
 
-`.github/actions/regression-analysis` — a composite action you attach to a failing CI job. It finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). It can optionally re-run the job on real hardware to confirm the failure is deterministic before reporting, draft an auto-fix PR for simple cases, and posts results to Slack.
+**Minimal workflow:**
 
 ```yaml
 - uses: actions/checkout@v4
@@ -26,9 +45,173 @@ Three independent pieces, each usable on its own:
     SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
 ```
 
-### 2. Deterministic Failure Issue Lifecycle
+That's it. The action will analyze the failure, classify it, and send results to Slack.
 
-`.github/workflows/triage-create-issues.yaml` — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs `consecutive-failures-high-volume` (default 4) failures in a row to qualify if its workflow runs more than `high-volume-runs-per-day` (default 5) times a day on main, or just `consecutive-failures-low-volume` (default 2) if it's a low-volume workflow — so a noisy, frequently-run pipeline isn't flagged on a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair.
+### Deterministic Failure Issue Lifecycle (Minimal Setup)
+
+**Prerequisites:**
+- Token with read access to workflow runs/artifacts → Store as `AGGREGATE_READ_TOKEN`
+- Token with write access to issue repo → Store as `ISSUE_WRITE_TOKEN`
+- GitHub PAT with `copilot` scope for issue drafting → Store as `COPILOT_PAT`
+
+**Minimal workflow (reusable workflow call):**
+
+```yaml
+jobs:
+  create-issues:
+    uses: tenstorrent/tt-auto-triage/.github/workflows/triage-create-issues.yaml@main
+    with:
+      issue-repo: "your-org/ci-issues"
+      target-repo: "tenstorrent/tt-metal"
+      max-issues: 5
+    secrets:
+      AGGREGATE_READ_TOKEN: ${{ secrets.AGGREGATE_READ_TOKEN }}
+      ISSUE_WRITE_TOKEN: ${{ secrets.ISSUE_WRITE_TOKEN }}
+      COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
+```
+
+This stage finds deterministically-failing jobs (based on consecutive-failure streaks, see [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below), drafts issue content from logs, and creates issues while preventing duplicates for already tracked workflow/job pairs.
+
+### Slack Output Analysis (Minimal Setup)
+
+**Prerequisites:**
+- GitHub Personal Access Token → Store as `GITHUB_TOKEN` secret
+- Slack Bot Token → Store as `SLACK_BOT_TOKEN` secret
+- Slack Channel ID → Store as `SLACK_CHANNEL_ID` secret
+
+**Minimal workflow:**
+
+```yaml
+- uses: actions/checkout@v4
+- uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
+  with:
+    github_token: ${{ secrets.GITHUB_TOKEN }}
+    slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+    channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+```
+
+This will sync errors from Slack to GitHub issues using default settings.
+
+---
+
+## Failure Case Categories
+
+The regression-analysis system categorizes failures into 5 cases:
+
+- **Case 1**: Deterministic failure with identified commit - A specific commit clearly explains the failure
+- **Case 2**: Deterministic failure but commit unknown - Failure is deterministic but the exact commit cannot be identified (expired logs, >100 commits, etc.)
+- **Case 3**: Failure likely outside tt-metal - Non-deterministic, infrastructure-related, or external issues
+- **Case 4**: Deterministic failure with multiple plausible commits - Multiple commits could plausibly cause the failure
+- **Case 5**: Deterministic failure with incomplete commit metadata - Failure is deterministic but some commit metadata couldn't be downloaded
+
+## Usage
+
+### Regression Analysis
+
+The `regression-analysis` action analyzes failing GitHub Actions workflows and produces triage reports.
+
+#### Basic Usage
+
+Add the action to your workflow file:
+
+```yaml
+jobs:
+  triage-failure:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run regression-analysis
+        uses: tenstorrent/tt-auto-triage/.github/actions/regression-analysis@main
+        with:
+          workflow-name: "your-workflow"
+          job-name: "your-job-name"
+          copilot-pat: ${{ secrets.COPILOT_PAT }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+```
+
+#### Required Inputs
+
+- `workflow-name`: The workflow name to inspect, without file extension (e.g., `"ci"`)
+- `job-name`: The job/subjob name within the workflow (e.g., `"test-job"`)
+- `copilot-pat`: Personal Access Token for GitHub/Copilot authentication (requires `copilot` scope)
+
+#### Optional Inputs
+
+- `slack-test-only`: Skip analysis and only send a test Slack message (default: `"false"`)
+- `slack_ts`: Slack message timestamp for threading replies (default: `""`)
+- `allow-pings`: Whether to allow pinging users/groups in Slack messages (default: `"false"`)
+- `send-slack-message`: Whether to send a Slack message (default: `"true"`)
+- `enable-retry`: Automatically retry Case 1/4 failures on supported hardware to confirm determinism (default: `"true"`)
+- `cutoff-commit`: Optional commit SHA to ignore all runs on commits newer than this one
+
+#### Required Environment Variables
+
+- `SLACK_BOT_TOKEN`: Slack Bot Token for sending notifications (required if `send-slack-message` is `true`)
+- `SLACK_CHANNEL_ID`: Slack Channel ID to post messages to (required if `send-slack-message` is `true`)
+
+#### Required Permissions
+
+The workflow needs the following permissions:
+- `contents: read` - To read repository contents and commit history
+- `actions: read` - To read workflow run information
+- `actions: write` - To trigger retry runs (if `enable-retry` is `true`)
+- `issues: write` - To create/update issues (if auto-fix is enabled)
+
+#### Outputs
+
+The action produces:
+- `explanation.md`: Detailed markdown report in `.regression_analysis/output/explanation.md`
+- `slack_message.json`: Formatted Slack message payload in `.regression_analysis/output/slack_message.json`
+- Artifacts: Regression analysis data and output are uploaded as workflow artifacts
+
+#### Example: Triggering on Workflow Failure
+
+```yaml
+name: Regression Analysis on Failure
+
+on:
+  workflow_run:
+    workflows: ["CI Tests"]
+    types:
+      - completed
+
+jobs:
+  triage:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      issues: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_branch }}
+
+      - name: Run regression-analysis
+        uses: tenstorrent/tt-auto-triage/.github/actions/regression-analysis@main
+        with:
+          workflow-name: "ci"
+          job-name: ${{ github.event.workflow_run.jobs[0].name }}
+          copilot-pat: ${{ secrets.COPILOT_PAT }}
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
+```
+
+### Deterministic Failure Issue Lifecycle
+
+The `triage-create-issues.yaml` reusable workflow scans recent CI runs for jobs that keep failing in the same way and opens a tracking issue in `issue-repo` once a job crosses its consecutive-failure threshold.
+
+#### Basic Usage
 
 ```yaml
 jobs:
@@ -43,52 +226,194 @@ jobs:
       COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
 ```
 
-### 3. Slack Output Analysis
+#### Inputs
 
-`.github/actions/slack_output_analysis` — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many. Supports an `update` mode (sync new errors since last run) and a `rebuild` mode (recreate all issues from scratch).
+- `issue-repo`: Repository to create tracking issues in (default: `tenstorrent/tt-metal`)
+- `target-repo`: Repository to read workflow run data from (default: `tenstorrent/tt-metal`)
+- `max-issues`: Maximum number of issues to create in one run, `0` = unlimited (default: `0`)
+- `workflow-filter`: Comma-separated substrings to restrict which workflow names are considered; empty means all workflows (default: `""`)
+- `llm-backend`: LLM backend used to draft issue content — only `"copilot"` is currently supported (default: `"copilot"`)
+- `consecutive-failures-high-volume`: Consecutive failures required before filing an issue for a **high-volume** workflow (default: `4`)
+- `consecutive-failures-low-volume`: Consecutive failures required before filing an issue for a **low-volume** workflow (default: `2`)
+- `high-volume-runs-per-day`: Strict cutoff (`>`) on main-branch runs in the last 24h used to classify a workflow as high-volume vs. low-volume (default: `5`)
+
+The high/low-volume split exists so that "failing consistently" means something different depending on how often a workflow runs: a workflow that runs dozens of times a day needs a longer failure streak to rule out flakiness before an issue is opened, while a workflow that only runs a couple of times a day can be flagged after just a couple of failures in a row.
+
+#### Required Secrets
+
+- `AGGREGATE_READ_TOKEN`: Token with read access to workflow runs/artifacts in `target-repo`
+- `ISSUE_WRITE_TOKEN`: Token with write access to create issues in `issue-repo`
+- `COPILOT_PAT`: GitHub PAT with `copilot` scope, used to draft issue titles/bodies from failing logs
+
+#### How It Decides to File an Issue
+
+For each job whose recent-run streak meets the consecutive-failure threshold above:
+
+1. Re-checks the job's latest run on main to confirm it hasn't since recovered (the failure-streak data can be a stale snapshot)
+2. Downloads logs for that job and drafts an issue title/body with the Copilot CLI agent
+3. Skips the job if the agent determines the failure isn't deterministic, or returns low confidence — only `medium`/`high` confidence drafts result in an issue
+4. Skips the job if an issue is already open for that workflow/job pair (tracked via metadata markers embedded in the issue body)
+5. Creates the issue (or, with `CREATE_ISSUES=false`, just records what *would* have been created — this is the workflow's dry-run mode)
+
+Set `max-issues` to cap how many issues a single run can create, and `workflow-filter` to scope the scan to specific workflows (e.g. `"Blackhole,ops-unit-tests"`).
+
+#### Outputs
+
+- `summary.md`: Markdown summary of created/skipped candidates, published to the job's step summary
+- `issues.json`: Artifact listing newly created and pre-existing tracked issue URLs
+
+### Slack Output Analysis
+
+The `slack_output_analysis` action syncs error messages from Slack channels to GitHub issues.
+
+#### Basic Usage
 
 ```yaml
-- uses: actions/checkout@v4
-- uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
-  with:
-    github_token: ${{ secrets.GITHUB_TOKEN }}
-    slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
-    channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+jobs:
+  sync-slack-errors:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Sync Slack errors to GitHub issues
+        uses: tenstorrent/tt-auto-triage/.github/actions/slack_output_analysis@main
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          slack_token: ${{ secrets.SLACK_BOT_TOKEN }}
+          channel_id: ${{ secrets.SLACK_CHANNEL_ID }}
+          update_mode: "update"
+          start_date: "January 1, 2026"
 ```
 
-### Bug-Escape Guidance (separate workstream)
+#### Required Inputs
 
-Guidance embedded in the regression-analysis LLM instructions (`regression_analysis/instructions/instructions_footer_for_llm.txt`) that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions. This is independent of the issue grouping/maintenance logic above.
+- `github_token`: GitHub Personal Access Token for creating/updating issues
+- `slack_token`: Slack Bot Token for fetching messages
+- `channel_id`: Slack channel ID to fetch messages from
 
-## Failure Case Categories
+#### Optional Inputs
 
-Regression Analysis classifies every failure into one of 5 cases:
+- `update_mode`: Mode to use - `"update"` to sync new errors (default) or `"rebuild"` to recreate all issues from scratch
+- `start_date`: Start date for fetching Slack messages (format: `"January 1, 2026"`, default: `"January 1, 2026"`)
+- `end_date`: End date cutoff for fetching messages (format: `"January 31, 2026"`, default: `""` for no cutoff)
+- `workflow_file`: Workflow file path for finding previous runs to create incremental report (e.g., `".github/workflows/analyze-ND-failures.yml"`, default: `""`)
 
-- **Case 1**: Deterministic, culprit commit identified
-- **Case 2**: Deterministic, but the culprit commit couldn't be identified (expired logs, >100 commits, etc.)
-- **Case 3**: Likely outside tt-metal — non-deterministic, infra, or external
-- **Case 4**: Deterministic, multiple plausible culprit commits
-- **Case 5**: Deterministic, but some commit metadata couldn't be downloaded
+#### Outputs
+
+- `incremental_report_path`: Path to the incremental error report (new entries only)
+
+#### Example: Manual Workflow Dispatch
+
+```yaml
+name: Sync Slack Errors to GitHub
+
+on:
+  workflow_dispatch:
+    inputs:
+      github_token:
+        description: 'GitHub Personal Access Token'
+        required: true
+        type: string
+      slack_token:
+        description: 'Slack Bot Token'
+        required: true
+        type: string
+      channel_id:
+        description: 'Slack channel ID'
+        required: true
+        type: string
+      update_mode:
+        description: 'Mode: update or rebuild'
+        required: false
+        default: 'update'
+        type: choice
+        options:
+          - update
+          - rebuild
+      start_date:
+        description: 'Start date (format: January 1, 2026)'
+        required: false
+        default: 'January 1, 2026'
+        type: string
+
+jobs:
+  sync-slack-errors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Sync Slack errors to GitHub issues
+        uses: ./.github/actions/slack_output_analysis
+        with:
+          github_token: ${{ inputs.github_token }}
+          slack_token: ${{ inputs.slack_token }}
+          channel_id: ${{ inputs.channel_id }}
+          update_mode: ${{ inputs.update_mode || 'update' }}
+          start_date: ${{ inputs.start_date || 'January 1, 2026' }}
+```
 
 ## How It Works
 
-**Regression Analysis pipeline:** find last-good/first-bad run boundaries → download the Slack directory (for developer lookups) → LLM filter stage (deterministic? gather commit metadata) → LLM analysis stage (assign confidence, categorize) → optional auto-fix PR (Case 1/2 only) → optional hardware retry to confirm determinism → post to Slack.
+### Regression Analysis Pipeline
 
-**Issue Lifecycle pipeline:** download recent workflow run data → detect jobs on a qualifying consecutive-failure streak (adaptive threshold, see above) → drop pairs that already have an open tracked issue → re-confirm the job hasn't recovered → draft title/body via Copilot CLI, gated on confidence → create the issue (or dry-run) → write a markdown summary.
+1. **Find Boundaries**: Identifies the last successful run and first failing run for the specified workflow/job
+2. **Download Slack Directory**: Fetches Slack user/group directory for developer lookups
+3. **Filter Stage**: Uses LLM to determine deterministic failures and gather commit metadata
+4. **Analysis Stage**: Uses LLM to analyze commits, assign confidence scores, and categorize the failure
+5. **Auto-Fix (Optional)**: Attempts to create a draft PR for simple fixes (Case 1/2 only)
+6. **Retry Logic (Optional)**: Re-runs deterministic failures on supported hardware to confirm determinism
+7. **Slack Notification**: Formats and sends triage results to Slack
 
-**Slack Output Analysis pipeline:** fetch channel messages → extract error text → (rebuild mode) group similar errors via similarity matching → create/update/close issues → generate a full and incremental error report.
+### Deterministic Failure Issue Lifecycle Pipeline
+
+1. **Download Workflow Data**: Reads recent workflow runs and artifacts for the target repository
+2. **Detect Consistent Failures**: Finds jobs failing for N consecutive runs, where N adapts to the workflow's run volume (see [Inputs](#inputs) above)
+3. **Deduplicate Against Open Issues**: Skips workflow/job pairs that are already tracked
+4. **Confirm Freshness**: Re-checks each remaining candidate against the latest run before spending log-download/LLM cost on it, in case it already recovered
+5. **Draft Issue Content**: Uses the GitHub Copilot CLI agent plus run logs to generate issue title/body, and gate on medium/high confidence
+6. **Create Issues**: Opens GitHub issues when `CREATE_ISSUES=true` (or records dry-run results)
+7. **Summarize Results**: Produces markdown summary output for auditing
+
+### Slack Output Analysis Pipeline
+
+1. **Fetch Messages**: Downloads error messages from the specified Slack channel
+2. **Extract Errors**: Extracts error messages from Slack messages (focuses on non-deterministic errors by default)
+3. **Group Similar Errors (Rebuild Mode)**: Uses ML-based similarity matching for grouped analysis/reporting
+4. **Issue Sync**: Creates/updates issues in update mode, recreates issues in rebuild mode, and applies close/cleanup logic during sync
+5. **Generate Reports**: Creates error reports and incremental reports comparing against previous runs
+
+### Bug-Escape Guidance (Separate Workstream)
+
+This is intentionally separate from issue grouping and issue maintenance workflows. It focuses on identifying likely bug escapes and proposing shift-left test coverage improvements in regression-analysis outputs.
 
 ## Requirements
 
 - GitHub Actions runner with Ubuntu Linux
-- GitHub Copilot CLI access (regression-analysis, create-issues)
+- GitHub Copilot CLI access (for regression-analysis)
 - Slack Bot Token with appropriate permissions
-- GitHub tokens with the scopes noted in each snippet above
+- GitHub Personal Access Token with required scopes
+
+## Artifacts
+
+Both actions produce artifacts that can be downloaded from workflow runs:
+
+- **regression-analysis-data**: Contains commit metadata, boundary information, and intermediate analysis data
+- **regression-analysis-output**: Contains the final `explanation.md` and `slack_message.json` files
+- **error-report**: Contains the error report JSON (slack_output_analysis)
+- **incremental-error-report**: Contains incremental error report comparing against previous run
 
 ## Contributing
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on reporting bugs, suggesting features, and submitting pull requests.
+We welcome contributions to tt-auto-triage! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guidelines on:
+
+- Reporting bugs
+- Suggesting features
+- Submitting pull requests
+- Development guidelines
 
 ## License
 
-Apache License 2.0 — see [LICENSE](LICENSE). For how it applies to hardware, models, and IP, see [LICENSE_understanding.txt](LICENSE_understanding.txt).
+This project is licensed under the Apache License 2.0. See the [LICENSE](LICENSE) file for the full license text.
+
+For clarification on how this license applies to hardware, models, and IP, please see [LICENSE_understanding.txt](LICENSE_understanding.txt).

--- a/README.md
+++ b/README.md
@@ -6,15 +6,13 @@ A GitHub Actions-based system for CI triage and signal hygiene: identify likely 
 
 ## Summary
 
-Three independent pieces, each usable on its own, plus a documentation-only workstream:
+Three independent pieces, each usable on its own:
 
-1. **Regression Analysis** (`.github/actions/regression-analysis`) — a composite action attached to a failing CI job. Finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). Can optionally re-run the job on real hardware to confirm determinism, draft an auto-fix PR for simple cases, and posts results to Slack.
+1. **Regression Analysis** (`.github/actions/regression-analysis`) — a composite action attached to a failing CI job. Finds the last successful run and the first failing run, downloads the commits in between, and uses the GitHub Copilot CLI to identify the likely culprit commit and classify the failure into one of [5 cases](#failure-case-categories). Can optionally re-run the job on real hardware to confirm determinism, draft an auto-fix PR for simple cases, and posts results to Slack. Its LLM instructions also include bug-escape guidance — prompt text that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions in the triage output. This is just guidance surfaced in regression-analysis's own output, not a bug-escape detection system — the actual bug-escape finding logic runs as a separate workflow outside this repo.
 
 2. **Deterministic Failure Issue Lifecycle** (`.github/workflows/triage-create-issues.yaml`) — a reusable workflow, typically run on a schedule, that scans recent runs across a target repo and files a tt-metal issue for jobs that are **failing consistently**. "Consistently" is threshold-based and adapts to how often a workflow runs: a job needs a longer consecutive-failure streak to qualify if its workflow runs frequently on main, and a shorter streak if it's low-volume — so a noisy, frequently-run pipeline isn't flagged over a couple of flaky runs. Before drafting anything it re-checks that the job hasn't since recovered, then uses the Copilot CLI to draft an issue from the logs and only files it if the draft comes back medium/high confidence and no issue is already tracked for that workflow/job pair. See [Deterministic Failure Issue Lifecycle](#deterministic-failure-issue-lifecycle) below for the exact thresholds.
 
 3. **Slack Output Analysis** (`.github/actions/slack_output_analysis`) — syncs recurring error messages posted to a Slack channel into GitHub issues, grouping similar errors via text-similarity matching so repeat instances of the same error land on one issue instead of many.
-
-4. **Bug-Escape Guidance** (separate workstream) — guidance embedded in the regression-analysis LLM instructions that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions. Independent of the issue grouping/maintenance logic above.
 
 Everything below this point is detailed reference material — full setup, all inputs/outputs, and pipeline internals for each piece.
 
@@ -365,6 +363,8 @@ jobs:
 6. **Retry Logic (Optional)**: Re-runs deterministic failures on supported hardware to confirm determinism
 7. **Slack Notification**: Formats and sends triage results to Slack
 
+The LLM instructions used in the Analysis Stage (`instructions_footer_for_llm.txt`) also carry bug-escape guidance: prompt text that flags when a failure indicates missing lower-level test coverage and recommends shift-left additions in the triage output. This only shapes what regression-analysis writes about a given failure — the actual bug-escape detection/finding logic is a separate workflow that lives outside this repo.
+
 ### Deterministic Failure Issue Lifecycle Pipeline
 
 1. **Download Workflow Data**: Reads recent workflow runs and artifacts for the target repository
@@ -382,10 +382,6 @@ jobs:
 3. **Group Similar Errors (Rebuild Mode)**: Uses ML-based similarity matching for grouped analysis/reporting
 4. **Issue Sync**: Creates/updates issues in update mode, recreates issues in rebuild mode, and applies close/cleanup logic during sync
 5. **Generate Reports**: Creates error reports and incremental reports comparing against previous runs
-
-### Bug-Escape Guidance (Separate Workstream)
-
-This is intentionally separate from issue grouping and issue maintenance workflows. It focuses on identifying likely bug escapes and proposing shift-left test coverage improvements in regression-analysis outputs.
 
 ## Requirements
 


### PR DESCRIPTION
## Summary
- Adds a short **Summary** section right at the top of the README covering the high-level logic of all three pipelines — this is what you see immediately when opening the repo. Full detailed reference material (Quickstart, per-action inputs/outputs, examples, pipeline breakdowns) stays below it, unchanged in depth.
- Calls out clearly, right after the intro line, that this repo (`tt-auto-triage`, GitHub Actions-based) is a completely separate system from the n8n-based "auto-triage" workflow whose logic lives in [`tenstorrent/vulcan-orchestration`](https://github.com/tenstorrent/vulcan-orchestration/tree/main/workflows).
- Renames "Deterministic Failure Issue Lifecycle" → **"Deterministic Failure Issue Creation"** throughout, since this repo verifiably only calls `gh issue create` for these (confirmed via code inspection — no update/close logic in `tools/ci/create_issues`). Makes explicit that updating/closing/lifecycling those triage issues is owned entirely by a separate n8n workflow outside this repo.
- Clarifies that `slack_output_analysis`'s issues are a completely separate, unrelated bucket: they exist for **data population** (tracking recurring Slack error signal sourced from regression-analysis), not to drive human triage — even though that pipeline does manage its own issues end-to-end (create/update/close), confirmed live via `tenstorrent/tt-metal`'s `grouping-ci-failures.yaml`, which runs it hourly in update mode.
- Folds "Bug-Escape Guidance" into the Regression Analysis description instead of presenting it as its own workstream/section — it's just prompt guidance embedded in regression-analysis's LLM instructions; the real bug-escape detection logic is a different workflow outside this repo.
- Fixes stale references to a since-removed Cursor-based drafting flow (`CURSOR_API_KEY`, "Cursor agent", a nonexistent `triage-ci.yaml`).

## Test plan
- [x] Verified `tools/ci/create_issues` contains no `gh issue edit`/`close` calls (create-only)
- [x] Verified `slack_output_analysis`'s update/close logic is live via `gh search code` against `tenstorrent/tt-metal`
- [x] Verified all input/secret names mentioned match `.github/workflows/triage-create-issues.yaml`, `tools/ci/create_issues/__main__.py`, and the two action.yml files
- [ ] Docs-only change; no functional testing required