### PR TITLE
create-issues: include Nightly tt-metal L2 failures

### DIFF
--- a/.github/workflows/triage-create-issues.yaml
+++ b/.github/workflows/triage-create-issues.yaml
@@ -60,7 +60,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tenstorrent/tt-auto-triage
-          ref: main
+          # TODO: revert to main before merge
+          ref: ebanerjee/making-auto-triage-look-at-l2
           persist-credentials: false
 
       - name: Set up Node.js 24 (required for Copilot CLI)

--- a/.github/workflows/triage-create-issues.yaml
+++ b/.github/workflows/triage-create-issues.yaml
@@ -60,8 +60,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tenstorrent/tt-auto-triage
-          # TODO: revert to main before merge
-          ref: ebanerjee/making-auto-triage-look-at-l2
+          ref: main
           persist-credentials: false
 
       - name: Set up Node.js 24 (required for Copilot CLI)

--- a/tools/ci/create_issues/detect_failures.py
+++ b/tools/ci/create_issues/detect_failures.py
@@ -9,7 +9,7 @@ from typing import Any, Iterator
 
 from .helpers import api_get, gh, log, paginate_api, sanitize_text
 
-SKIP_KEYWORDS: tuple[str, ...] = ("Nightly tt-metal L2 tests",)
+SKIP_KEYWORDS: tuple[str, ...] = ()
 
 
 def _run_timestamp(run: dict[str, Any]) -> float:


### PR DESCRIPTION
## Summary
- Stop skipping `Nightly tt-metal L2 tests` in create-issues failure detection so consecutive L2 nightly failures can be filed as triage issues.
- Aggregate workflow data already includes L2; this only removes the detector-side skip.

## Test plan
- [x] Run `(triage) Create CI Triage Issues` with `workflow-filter: Nightly tt-metal L2` and a small `max-issues`
- [x] Confirm L2 jobs are no longer logged as skipped by keyword
- [x] Confirm issues are only filed when the low-volume consecutive-failure threshold is met


Made with [Cursor](https://cursor.com)