### PR TITLE
create-issues: resolve last passing commit per job, not per workflow

### DIFF
--- a/.github/workflows/triage-create-issues.yaml
+++ b/.github/workflows/triage-create-issues.yaml
@@ -35,6 +35,14 @@ on:
         description: "Strict cutoff (>) for classifying a workflow as high-volume based on main runs in the last 24h."
         type: number
         default: 5
+      dry-run:
+        description: "Evaluate candidates and draft issue bodies without creating any issues. Use to validate changes before they run for real."
+        type: boolean
+        default: false
+      auto-triage-ref:
+        description: "tt-auto-triage ref to check out. Point at a branch to test unmerged changes."
+        type: string
+        default: "main"
     secrets:
       AGGREGATE_READ_TOKEN:
         description: "Token with read access to workflow runs and artifacts"
@@ -60,7 +68,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: tenstorrent/tt-auto-triage
-          ref: main
+          ref: ${{ inputs.auto-triage-ref }}
           persist-credentials: false
 
       - name: Set up Node.js 24 (required for Copilot CLI)
@@ -87,7 +95,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.AGGREGATE_READ_TOKEN }}
           ISSUE_WRITE_TOKEN: ${{ secrets.ISSUE_WRITE_TOKEN }}
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
-          CREATE_ISSUES: "true"
+          CREATE_ISSUES: ${{ !inputs.dry-run }}
           ISSUE_REPO: ${{ inputs.issue-repo }}
           TARGET_REPO: ${{ inputs.target-repo }}
           MAX_ISSUES: ${{ inputs.max-issues }}

--- a/.github/workflows/triage-create-issues.yaml
+++ b/.github/workflows/triage-create-issues.yaml
@@ -62,7 +62,10 @@ permissions:
 jobs:
   create-issues:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # Real runs sit at 12-17min. The per-candidate last-passing search adds up
+    # to MAX_SEARCH_SECONDS each, and jobs that never passed run that budget to
+    # exhaustion, so leave room rather than truncating a run mid-draft.
+    timeout-minutes: 45
     steps:
       - name: Checkout tt-auto-triage
         uses: actions/checkout@v4

--- a/tests/create_issues/test_detect_failures.py
+++ b/tests/create_issues/test_detect_failures.py
@@ -1,26 +1,61 @@
 import unittest
+from contextlib import ExitStack
 from unittest.mock import patch
 
 from tools.ci.create_issues.detect_failures import (
+    MAX_CONSECUTIVE_MISSING,
+    MAX_RUNS_SCANNED,
+    MAX_SEARCH_SECONDS,
+    _clear_run_jobs_cache,
     _parse_job_url,
     iter_failing_jobs,
+    resolve_last_passing_boundary,
     streak_still_failing,
 )
 
 
-def _run(run_id, ts, conclusion, sha):
+def _run(run_id, ts, conclusion, sha, **extra):
     return {
         "id": run_id,
         "created_at": ts,
         "conclusion": conclusion,
         "head_sha": sha,
         "html_url": f"https://github.com/o/r/actions/runs/{run_id}",
+        "workflow_id": 555,
+        **extra,
     }
+
+
+def _job(name, conclusion, run_id):
+    return {
+        "name": name,
+        "conclusion": conclusion,
+        "html_url": f"https://github.com/o/r/actions/runs/{run_id}/job/{run_id}9",
+    }
+
+
+def _jobs_fake(jobs_by_run, counter=None):
+    """Build a paginate_api fake serving per-run job lists.
+
+    ``jobs_by_run`` maps run_id -> list of (job_name, conclusion). Runs absent
+    from the mapping return no jobs at all.
+    """
+
+    def fake(url, key, token=None):
+        run_id = int(url.split("/runs/")[1].split("/")[0])
+        if counter is not None:
+            counter.append(run_id)
+        return [_job(name, concl, run_id) for name, concl in jobs_by_run.get(run_id, [])]
+
+    return fake
 
 
 class BoundaryLinkTests(unittest.TestCase):
     """First/last failing boundaries must reference the oldest/newest analyzed
     failing JOBs, not runs or an inferred streak start."""
+
+    def setUp(self) -> None:
+        _clear_run_jobs_cache()
 
     def test_first_and_last_failing_link_to_jobs(self) -> None:
         # Newest -> oldest. Two consecutive failures trigger the low-volume
@@ -33,19 +68,9 @@ class BoundaryLinkTests(unittest.TestCase):
             _run(50, "2026-06-15T00:00:00Z", "success", "sha_pass"),
         ]
 
-        def fake_paginate(url, key, token):
-            run_id = int(url.split("/runs/")[1].split("/")[0])
-            return [
-                {
-                    "name": "build",
-                    "conclusion": "failure",
-                    "html_url": f"https://github.com/o/r/actions/runs/{run_id}/job/{run_id}9",
-                }
-            ]
-
         with patch(
             "tools.ci.create_issues.detect_failures.paginate_api",
-            side_effect=fake_paginate,
+            side_effect=_jobs_fake({rid: [("build", "failure")] for rid in (300, 200, 100)}),
         ), patch("tools.ci.create_issues.detect_failures.time.sleep"):
             jobs = list(
                 iter_failing_jobs(
@@ -71,11 +96,200 @@ class BoundaryLinkTests(unittest.TestCase):
             job["last_failing_url"],
             "https://github.com/o/r/actions/runs/300/job/3009",
         )
-        # Last passing remains a run URL.
-        self.assertEqual(job["last_passing_url"], "https://github.com/o/r/actions/runs/50")
         # Neither failing boundary points at a bare run URL.
         self.assertIn("/job/", job["first_failing_url"])
         self.assertIn("/job/", job["last_failing_url"])
+        # Last passing is resolved separately by the caller, so the generator
+        # must not spend API calls guessing at it.
+        self.assertNotIn("last_passing_sha", job)
+        self.assertNotIn("last_passing_url", job)
+
+
+class LastPassingBoundaryTests(unittest.TestCase):
+    """Last passing must be the most recent run where THIS job succeeded —
+    workflow-level success is a different (and usually wrong) question."""
+
+    def setUp(self) -> None:
+        _clear_run_jobs_cache()
+
+    def _resolve(self, runs, jobs_by_run, counter=None, api_get=None):
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "tools.ci.create_issues.detect_failures.paginate_api",
+                    side_effect=_jobs_fake(jobs_by_run, counter),
+                )
+            )
+            stack.enter_context(patch("tools.ci.create_issues.detect_failures.time.sleep"))
+            if api_get is not None:
+                stack.enter_context(
+                    patch("tools.ci.create_issues.detect_failures.api_get", side_effect=api_get)
+                )
+            return resolve_last_passing_boundary("build", runs, "o/r", token="t")
+
+    def test_uses_job_success_when_workflow_run_failed(self) -> None:
+        # The #52401 case: run 100 failed overall because a sibling job failed,
+        # but the job we care about passed in it.
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(200, "2026-06-15T02:00:00Z", "failure", "sha_old"),
+            _run(100, "2026-06-15T01:00:00Z", "failure", "sha_pass"),
+        ]
+        jobs_by_run = {
+            300: [("build", "failure")],
+            200: [("build", "failure")],
+            100: [("build", "success"), ("sibling", "failure")],
+        }
+
+        found = self._resolve(runs, jobs_by_run)
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found["head_sha"], "sha_pass")
+        self.assertEqual(found["created_at"], "2026-06-15T01:00:00Z")
+        self.assertEqual(found["job_url"], "https://github.com/o/r/actions/runs/100/job/1009")
+
+    def test_returns_none_when_job_never_passed(self) -> None:
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(200, "2026-06-15T02:00:00Z", "failure", "sha_old"),
+        ]
+        jobs_by_run = {300: [("build", "failure")], 200: [("build", "failure")]}
+
+        found = self._resolve(
+            runs, jobs_by_run, api_get=lambda url, token=None: {"workflow_runs": []}
+        )
+
+        self.assertIsNone(found)
+
+    def test_skips_runs_where_job_absent(self) -> None:
+        # A run that never scheduled this job must not end the search.
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(200, "2026-06-15T02:00:00Z", "failure", "sha_skip"),
+            _run(100, "2026-06-15T01:00:00Z", "failure", "sha_pass"),
+        ]
+        jobs_by_run = {
+            300: [("build", "failure")],
+            200: [("other", "failure")],
+            100: [("build", "success")],
+        }
+
+        found = self._resolve(runs, jobs_by_run)
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found["head_sha"], "sha_pass")
+
+    def test_ignores_manual_runs(self) -> None:
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(250, "2026-06-15T02:30:00Z", "success", "sha_manual", event="workflow_dispatch"),
+            _run(100, "2026-06-15T01:00:00Z", "failure", "sha_pass"),
+        ]
+        jobs_by_run = {
+            300: [("build", "failure")],
+            250: [("build", "success")],
+            100: [("build", "success")],
+        }
+
+        found = self._resolve(runs, jobs_by_run)
+
+        self.assertEqual(found["head_sha"], "sha_pass")
+
+    def test_dedupes_repeated_run_attempts(self) -> None:
+        # The snapshot stores one entry per attempt; the same run must only be
+        # fetched (and charged against the budget) once.
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(100, "2026-06-15T01:00:00Z", "failure", "sha_pass"),
+        ]
+        jobs_by_run = {300: [("build", "failure")], 100: [("build", "success")]}
+        fetched: list[int] = []
+
+        found = self._resolve(runs, jobs_by_run, counter=fetched)
+
+        self.assertEqual(found["head_sha"], "sha_pass")
+        self.assertEqual(fetched, [300, 100])
+
+    def test_respects_missing_job_budget(self) -> None:
+        # A renamed job would otherwise drag the walk across all of history.
+        total = MAX_CONSECUTIVE_MISSING + 10
+        runs = [
+            _run(1000 + i, f"2026-06-15T00:{i:02d}:00Z", "failure", f"sha{i}")
+            for i in range(total, 0, -1)
+        ]
+        jobs_by_run = {run["id"]: [("renamed", "failure")] for run in runs}
+        fetched: list[int] = []
+
+        found = self._resolve(runs, jobs_by_run, counter=fetched)
+
+        self.assertIsNone(found)
+        self.assertEqual(len(fetched), MAX_CONSECUTIVE_MISSING)
+
+    def test_respects_run_scan_budget(self) -> None:
+        total = MAX_RUNS_SCANNED + 15
+        runs = [
+            _run(1000 + i, f"2026-06-15T00:{i:02d}:00Z", "failure", f"sha{i}")
+            for i in range(total, 0, -1)
+        ]
+        jobs_by_run = {run["id"]: [("build", "failure")] for run in runs}
+        fetched: list[int] = []
+
+        found = self._resolve(runs, jobs_by_run, counter=fetched)
+
+        self.assertIsNone(found)
+        self.assertEqual(len(fetched), MAX_RUNS_SCANNED)
+
+    def test_falls_back_to_older_history(self) -> None:
+        # The job last passed before the snapshot's rolling window.
+        runs = [
+            _run(300, "2026-06-15T03:00:00Z", "failure", "sha_new"),
+            _run(200, "2026-06-15T02:00:00Z", "failure", "sha_old"),
+        ]
+        older = _run(50, "2026-05-01T00:00:00Z", "failure", "sha_ancient")
+        jobs_by_run = {
+            300: [("build", "failure")],
+            200: [("build", "failure")],
+            50: [("build", "success")],
+        }
+
+        def fake_api_get(url, token=None):
+            self.assertIn("/actions/workflows/555/runs", url)
+            return {"workflow_runs": [older]}
+
+        found = self._resolve(runs, jobs_by_run, api_get=fake_api_get)
+
+        self.assertIsNotNone(found)
+        self.assertEqual(found["head_sha"], "sha_ancient")
+        self.assertEqual(found["job_url"], "https://github.com/o/r/actions/runs/50/job/509")
+
+    def test_respects_time_budget(self) -> None:
+        # Big pipelines make each run's job list slow to fetch, so the run
+        # count alone does not bound the search; the clock has to.
+        runs = [
+            _run(1000 + i, f"2026-06-15T00:{i:02d}:00Z", "failure", f"sha{i}")
+            for i in range(MAX_RUNS_SCANNED, 0, -1)
+        ]
+        jobs_by_run = {run["id"]: [("build", "failure")] for run in runs}
+        fetched: list[int] = []
+
+        # Time stands still long enough to seed the deadline and scan a couple
+        # of runs, then jumps past it.
+        ticks = {"n": 0}
+
+        def fake_clock():
+            ticks["n"] += 1
+            return 0.0 if ticks["n"] <= 3 else MAX_SEARCH_SECONDS + 1.0
+
+        with patch("tools.ci.create_issues.detect_failures.time.time", fake_clock):
+            found = self._resolve(runs, jobs_by_run, counter=fetched)
+
+        self.assertIsNone(found)
+        # Stopped on the clock, well before the run-count cap.
+        self.assertLess(len(fetched), MAX_RUNS_SCANNED)
+
+    def test_returns_none_for_empty_runs(self) -> None:
+        self.assertIsNone(resolve_last_passing_boundary("build", [], "o/r", token="t"))
 
 
 class StreakStillFailingTests(unittest.TestCase):

--- a/tools/ci/create_issues/__main__.py
+++ b/tools/ci/create_issues/__main__.py
@@ -11,6 +11,7 @@ from typing import Any
 from .detect_failures import (
     download_job_logs,
     iter_failing_jobs,
+    resolve_last_passing_boundary,
     streak_still_failing,
 )
 from .download_data import download_workflow_data
@@ -99,6 +100,8 @@ def main() -> int:
     tracked_pairs = tracked_pairs_from_issues(open_issues)
     logs_dir = Path("build_ci/create_issues/logs")
 
+    runs_by_workflow = {name: runs for name, runs in workflow_data}
+
     summary: list[dict[str, Any]] = []
     created_so_far = 0
     candidates = list(
@@ -145,7 +148,23 @@ def main() -> int:
             continue
         enriched_job = enriched[0]
 
-        # ── Step 3: Draft issue body via LLM ────────────────────────
+        # ── Step 3: Resolve the last-passing boundary ───────────────
+        # Deferred until here because it costs API calls: only candidates that
+        # survived the gates above will actually reach the issue body.
+        last_passing = resolve_last_passing_boundary(
+            enriched_job["job_name"],
+            runs_by_workflow.get(enriched_job["workflow_name"], []),
+            TARGET_REPO,
+        )
+        if last_passing:
+            enriched_job["last_passing_sha"] = last_passing["head_sha"]
+            enriched_job["last_passing_date"] = last_passing["created_at"]
+            enriched_job["last_passing_url"] = last_passing["job_url"]
+            log(f"  Last passing: {last_passing['head_sha'][:12]} ({last_passing['created_at']})")
+        else:
+            log("  Last passing: not found within search budget")
+
+        # ── Step 4: Draft issue body via LLM ────────────────────────
         log_paths = enriched_job.get("log_paths", [])
         log("  Drafting issue via Copilot agent...")
         per_workflow_consecutive = enriched_job.get("consecutive", CONSECUTIVE_LOW_VOLUME)
@@ -176,13 +195,13 @@ def main() -> int:
             summary.append(_entry(job, "agent_skipped", reason=reason))
             continue
 
-        # ── Step 4: Dry-run gate ────────────────────────────────────
+        # ── Step 5: Dry-run gate ────────────────────────────────────
         if not CREATE_ISSUES:
             log(f"  Eligible but CREATE_ISSUES=false (dry run): {job['workflow_name']} / {job['job_name']}")
             summary.append(_entry(job, "dry_run"))
             continue
 
-        # ── Step 5: Create the issue ────────────────────────────────
+        # ── Step 6: Create the issue ────────────────────────────────
         issue_url, issue_title, issue_body = create_issue(
             enriched_job, agent_result,
         )

--- a/tools/ci/create_issues/__main__.py
+++ b/tools/ci/create_issues/__main__.py
@@ -104,6 +104,9 @@ def main() -> int:
 
     summary: list[dict[str, Any]] = []
     created_so_far = 0
+    # Issues created, plus those a dry run would have created. MAX_ISSUES gates
+    # on this so a dry run costs the same bounded amount of work as a real one.
+    budget_used = 0
     candidates = list(
         iter_failing_jobs(
             workflow_data,
@@ -123,7 +126,7 @@ def main() -> int:
         )
 
         # ── Early exit: MAX_ISSUES reached ──────────────────────────
-        if MAX_ISSUES and created_so_far >= MAX_ISSUES:
+        if MAX_ISSUES and budget_used >= MAX_ISSUES:
             reason = "max issues reached; remaining candidates not evaluated"
             _log_rejection(job, "global-limit", reason)
             summary.append(_entry(job, "limit_reached", reason=reason))
@@ -199,6 +202,7 @@ def main() -> int:
         if not CREATE_ISSUES:
             log(f"  Eligible but CREATE_ISSUES=false (dry run): {job['workflow_name']} / {job['job_name']}")
             summary.append(_entry(job, "dry_run"))
+            budget_used += 1
             continue
 
         # ── Step 6: Create the issue ────────────────────────────────
@@ -206,6 +210,7 @@ def main() -> int:
             enriched_job, agent_result,
         )
         created_so_far += 1
+        budget_used += 1
         open_issues.append({
             "number": issue_url.rsplit("/", 1)[-1],
             "title": issue_title,

--- a/tools/ci/create_issues/detect_failures.py
+++ b/tools/ci/create_issues/detect_failures.py
@@ -11,6 +11,65 @@ from .helpers import api_get, gh, log, paginate_api, sanitize_text
 
 SKIP_KEYWORDS: tuple[str, ...] = ()
 
+# Boundary search budgets. A workflow's snapshot can hold hundreds of runs
+# (merge-gate/sanity-tests average >500 on main per 15-day window, each with
+# 100+ jobs), so an unbounded walk would blow the workflow's time budget for a
+# single long-broken job. The wall-clock cap is the backstop: a run's job list
+# can take seconds to fetch on big pipelines, so a run count alone does not
+# bound the search well enough.
+MAX_RUNS_SCANNED = 40
+MAX_CONSECUTIVE_MISSING = 15
+MAX_FALLBACK_PAGES = 3
+MAX_SEARCH_SECONDS = 45.0
+
+# run_id -> {job_name: {"conclusion": str, "html_url": str}}
+# Completed runs never change their job conclusions, and this is a single-shot
+# CLI, so caching for the process lifetime is safe. Tests must clear it.
+_RUN_JOBS_CACHE: dict[int, dict[str, dict[str, str]]] = {}
+
+
+def _clear_run_jobs_cache() -> None:
+    """Reset the per-run job cache (used by tests)."""
+    _RUN_JOBS_CACHE.clear()
+
+
+def _fetch_run_jobs(
+    owner: str,
+    repo: str,
+    run_id: int,
+    token: str | None,
+) -> dict[str, dict[str, str]]:
+    """Return {job_name: {conclusion, html_url}} for a run, cached by run id.
+
+    Returns an empty mapping when the API call fails so callers can treat the
+    run as "no data" rather than crashing the whole detection pass.
+    """
+    cached = _RUN_JOBS_CACHE.get(run_id)
+    if cached is not None:
+        return cached
+
+    try:
+        all_jobs = paginate_api(
+            f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?per_page=100",
+            "jobs",
+            token,
+        )
+    except Exception as exc:
+        log(f"  Warning: could not fetch jobs for run {run_id} ({type(exc).__name__}): {exc}")
+        return {}
+
+    jobs = {
+        job["name"]: {
+            "conclusion": job.get("conclusion") or "",
+            "html_url": job.get("html_url", ""),
+        }
+        for job in all_jobs
+        if job.get("name")
+    }
+    _RUN_JOBS_CACHE[run_id] = jobs
+    time.sleep(0.3)
+    return jobs
+
 
 def _run_timestamp(run: dict[str, Any]) -> float:
     """Parse a run's GitHub timestamp into epoch seconds; 0 if unparseable."""
@@ -29,7 +88,7 @@ def _run_date_iso(run: dict[str, Any]) -> str:
 def _build_boundary_info(
     oldest_failing_run: dict[str, Any] | None,
     newest_failing_run: dict[str, Any] | None,
-    last_passing_run: dict[str, Any] | None,
+    last_passing: dict[str, str] | None,
     oldest_failing_job_url: str = "",
     newest_failing_job_url: str = "",
 ) -> dict[str, Any]:
@@ -41,10 +100,15 @@ def _build_boundary_info(
     may have failed for a different reason. Their URLs point to the specific
     failing JOB, not the run.
 
+    ``last_passing`` comes from :func:`resolve_last_passing_boundary` and refers
+    to the most recent run where THIS job succeeded, which is not the same as
+    the most recent run where the whole workflow succeeded: in multi-job
+    pipelines a job routinely passes inside a run that fails overall.
+
     Fields produced (all optional — missing when data is unavailable):
       - first_failing_sha / first_failing_date / first_failing_url (job URL)
       - last_failing_sha  / last_failing_date  / last_failing_url  (job URL)
-      - last_passing_sha  / last_passing_date  / last_passing_url   (run URL)
+      - last_passing_sha  / last_passing_date  / last_passing_url  (job URL)
     """
     info: dict[str, Any] = {}
 
@@ -58,12 +122,154 @@ def _build_boundary_info(
         info["last_failing_date"] = _run_date_iso(newest_failing_run)
         info["last_failing_url"] = newest_failing_job_url
 
-    if last_passing_run:
-        info["last_passing_sha"] = last_passing_run.get("head_sha", "")
-        info["last_passing_date"] = _run_date_iso(last_passing_run)
-        info["last_passing_url"] = last_passing_run.get("html_url", "")
+    if last_passing:
+        info["last_passing_sha"] = last_passing.get("head_sha", "")
+        info["last_passing_date"] = last_passing.get("created_at", "")
+        info["last_passing_url"] = last_passing.get("job_url", "")
 
     return info
+
+
+def _is_manual(run: dict[str, Any]) -> bool:
+    """Manually dispatched runs are excluded upstream; mirror that filter."""
+    return run.get("event") == "workflow_dispatch"
+
+
+def _budget_spent(job_name: str, budget: dict[str, float]) -> bool:
+    """Report (and log) whether the last-passing search must stop."""
+    if budget["runs_left"] <= 0:
+        log(f"  Last-passing search for '{job_name}': run scan budget exhausted")
+        return True
+    if budget["missing_streak"] >= MAX_CONSECUTIVE_MISSING:
+        log(
+            f"  Last-passing search for '{job_name}': job absent from "
+            f"{MAX_CONSECUTIVE_MISSING} consecutive runs (renamed or removed?), giving up"
+        )
+        return True
+    if time.time() >= budget["deadline"]:
+        log(f"  Last-passing search for '{job_name}': {MAX_SEARCH_SECONDS:.0f}s time budget reached")
+        return True
+    return False
+
+
+def _scan_runs_for_passing_job(
+    job_name: str,
+    runs: list[dict[str, Any]],
+    owner: str,
+    repo: str,
+    token: str | None,
+    seen_run_ids: set[int],
+    budget: dict[str, float],
+) -> dict[str, str] | None:
+    """Walk runs newest→oldest looking for one where ``job_name`` succeeded.
+
+    ``seen_run_ids`` and ``budget`` are mutated so a caller can run this over
+    several run sources (snapshot, then live API pages) under one shared cap.
+    Returns None when the budget runs out or the runs are exhausted.
+    """
+    for run in runs:
+        if _budget_spent(job_name, budget):
+            return None
+
+        run_id = run.get("id")
+        if not run_id or _is_manual(run):
+            continue
+        # The snapshot keeps one entry per run attempt, so the same run id can
+        # appear more than once.
+        if run_id in seen_run_ids:
+            continue
+        seen_run_ids.add(run_id)
+        budget["runs_left"] -= 1
+
+        job = _fetch_run_jobs(owner, repo, run_id, token).get(job_name)
+        if job is None:
+            budget["missing_streak"] += 1
+            continue
+        budget["missing_streak"] = 0
+
+        if job.get("conclusion") == "success":
+            return {
+                "head_sha": run.get("head_sha", ""),
+                "created_at": _run_date_iso(run),
+                "job_url": job.get("html_url", ""),
+            }
+
+    return None
+
+
+def resolve_last_passing_boundary(
+    job_name: str,
+    runs: list[dict[str, Any]],
+    target_repo: str,
+    token: str | None = None,
+) -> dict[str, str] | None:
+    """Find the most recent run in which ``job_name`` itself succeeded.
+
+    This is deliberately JOB-level. A workflow-level check ("when did this
+    pipeline last pass?") answers a different question and is almost always
+    useless for multi-job pipelines, where a job can pass in a run that fails
+    overall and the pipeline may never be fully green.
+
+    Searches the snapshot runs first, then falls back to paginating live
+    workflow history, since a job can have last passed before the snapshot's
+    rolling window. Returns None if no passing run is found within budget, in
+    which case the issue renders "N/A".
+    """
+    if not runs:
+        return None
+    if token is None:
+        token = os.environ.get("GITHUB_TOKEN")
+    owner, repo = target_repo.split("/")
+
+    seen_run_ids: set[int] = set()
+    budget: dict[str, float] = {
+        "runs_left": MAX_RUNS_SCANNED,
+        "missing_streak": 0,
+        "deadline": time.time() + MAX_SEARCH_SECONDS,
+    }
+
+    ordered = sorted(runs, key=_run_timestamp, reverse=True)
+    found = _scan_runs_for_passing_job(
+        job_name, ordered, owner, repo, token, seen_run_ids, budget
+    )
+    if found:
+        return found
+    if _budget_spent(job_name, budget):
+        return None
+
+    # ── Fallback: the job may have last passed before the snapshot window ──
+    workflow_id = next((r.get("workflow_id") for r in ordered if r.get("workflow_id")), None)
+    if not workflow_id:
+        return None
+
+    log(f"  Last-passing search for '{job_name}': no pass in snapshot, checking older history")
+    for page in range(1, MAX_FALLBACK_PAGES + 1):
+        try:
+            data = api_get(
+                f"https://api.github.com/repos/{owner}/{repo}/actions/workflows/"
+                f"{workflow_id}/runs?branch=main&status=completed&per_page=100&page={page}",
+                token,
+            )
+        except Exception as exc:
+            log(f"  Warning: last-passing history lookup failed ({type(exc).__name__}): {exc}")
+            return None
+
+        page_runs = data.get("workflow_runs", [])
+        if not page_runs:
+            return None
+
+        found = _scan_runs_for_passing_job(
+            job_name, page_runs, owner, repo, token, seen_run_ids, budget
+        )
+        if found:
+            return found
+        if _budget_spent(job_name, budget):
+            return None
+        if len(page_runs) < 100:
+            return None
+
+    log(f"  Last-passing search for '{job_name}': page limit reached without finding a pass")
+    return None
 
 
 def iter_failing_jobs(
@@ -128,19 +334,14 @@ def iter_failing_jobs(
             run_id = run.get("id")
             if not run_id:
                 continue
-            try:
-                all_jobs = paginate_api(
-                    f"https://api.github.com/repos/{owner}/{repo}/actions/runs/{run_id}/jobs?per_page=100",
-                    "jobs",
-                    token,
-                )
-            except Exception as exc:
-                log(f"  Warning: skipping run {run_id} for '{workflow_name}' due to API error ({type(exc).__name__}): {exc}")
+            all_jobs = _fetch_run_jobs(owner, repo, run_id, token)
+            if not all_jobs:
                 continue
             run_failed_jobs[run_id] = {
-                job["name"]: job.get("html_url", "") for job in all_jobs if job.get("conclusion") == "failure"
+                name: job.get("html_url", "")
+                for name, job in all_jobs.items()
+                if job.get("conclusion") == "failure"
             }
-            time.sleep(0.3)
 
         if len(run_failed_jobs) < consecutive:
             log(
@@ -157,26 +358,6 @@ def iter_failing_jobs(
             log(f"  '{workflow_name}': skipped before candidate creation (no common failing jobs across runs)")
             continue
 
-        # ── Temporal boundary: most-recent passing run ────────────────
-        # Walk full history (newest→oldest) to find the most-recent success
-        # before the current contiguous failure streak. The first/last failing
-        # boundaries are taken from the analyzed runs below, not from the
-        # streak start (which may have failed for a different reason).
-        all_sorted = sorted(runs, key=_run_timestamp, reverse=True)
-        in_streak = False
-        last_passing_run: dict[str, Any] | None = None
-        for run in all_sorted:
-            conclusion = run.get("conclusion")
-            if conclusion == "failure":
-                in_streak = True  # we are inside the current failure streak
-            elif conclusion == "success":
-                if in_streak:
-                    # First success after the failure streak — the boundary
-                    # between the current streak and older history.
-                    last_passing_run = run
-                # Most-recent run is a success (or boundary found) — stop.
-                break
-
         # run_ids preserves sorted_runs order (newest→oldest), so index 0 is
         # the newest analyzed failing run and index -1 the oldest.
         oldest_failing_run = sorted_runs[-1]
@@ -187,10 +368,12 @@ def iter_failing_jobs(
                 log(f"  Skipping already-tracked job: {workflow_name} / {job_name}")
                 continue
             job_urls = [run_failed_jobs[run_id].get(job_name, "") for run_id in run_ids]
+            # The last-passing boundary is resolved lazily by the caller, after
+            # the freshness and max-issues gates, because it costs API calls.
             boundary_info = _build_boundary_info(
                 oldest_failing_run,
                 newest_failing_run,
-                last_passing_run,
+                None,
                 oldest_failing_job_url=job_urls[-1] if job_urls else "",
                 newest_failing_job_url=job_urls[0] if job_urls else "",
             )

--- a/tools/ci/create_issues/draft_issues.py
+++ b/tools/ci/create_issues/draft_issues.py
@@ -92,17 +92,17 @@ def draft_issue_body(
         sha = job["last_passing_sha"][:12]
         date = job.get("last_passing_date", "N/A")
         url = job.get("last_passing_url", "")
-        timeline_lines.append(f"- Last passing job: commit `{sha}` on {date}" + (f" — {url}" if url else ""))
+        timeline_lines.append(f"- Last passing commit: `{sha}` on {date}" + (f" — {url}" if url else ""))
     if job.get("first_failing_sha"):
         sha = job["first_failing_sha"][:12]
         date = job.get("first_failing_date", "N/A")
         url = job.get("first_failing_url", "")
-        timeline_lines.append(f"- First failing run: commit `{sha}` on {date}" + (f" — {url}" if url else ""))
+        timeline_lines.append(f"- First failing commit: `{sha}` on {date}" + (f" — {url}" if url else ""))
     if job.get("last_failing_sha"):
         sha = job["last_failing_sha"][:12]
         date = job.get("last_failing_date", "N/A")
         url = job.get("last_failing_url", "")
-        timeline_lines.append(f"- Most recent failing run: commit `{sha}` on {date}" + (f" — {url}" if url else ""))
+        timeline_lines.append(f"- Most recent failing commit: `{sha}` on {date}" + (f" — {url}" if url else ""))
 
     regression_timeline = "\n".join(timeline_lines) if timeline_lines else "No temporal boundary data available."
 

--- a/tools/ci/create_issues/draft_issues.py
+++ b/tools/ci/create_issues/draft_issues.py
@@ -92,7 +92,7 @@ def draft_issue_body(
         sha = job["last_passing_sha"][:12]
         date = job.get("last_passing_date", "N/A")
         url = job.get("last_passing_url", "")
-        timeline_lines.append(f"- Last passing run: commit `{sha}` on {date}" + (f" — {url}" if url else ""))
+        timeline_lines.append(f"- Last passing job: commit `{sha}` on {date}" + (f" — {url}" if url else ""))
     if job.get("first_failing_sha"):
         sha = job["first_failing_sha"][:12]
         date = job.get("first_failing_date", "N/A")

--- a/tools/ci/create_issues/prompts/draft_issue.txt
+++ b/tools/ci/create_issues/prompts/draft_issue.txt
@@ -27,7 +27,7 @@ INSTRUCTIONS:
    - there are no contradictory terminal errors across runs (for example: timeout in one run, assertion in another),
    - your error_excerpt quotes those terminal lines directly from the provided logs (no paraphrased or inferred error text),
    - you can explicitly point to at least one terminal error line from each run supporting the same root cause,
-   - if both last passing and first failing boundaries are present, they must refer to different commits/runs (same SHA or same run URL means deterministic=false — do not file an issue and do not compensate with a warning in the issue body).
+   - if both last passing and first failing boundaries are present, they must refer to different commits/runs (same SHA, or both URLs pointing into the same run, means deterministic=false — do not file an issue and do not compensate with a warning in the issue body).
 6. Additional strictness rules:
    - If a run has multiple plausible terminal failures and you cannot confidently identify one shared root cause across all runs, set deterministic=false.
    - If failures look related but not clearly identical (same subsystem but different terminal exception class), set deterministic=false.
@@ -40,10 +40,10 @@ INSTRUCTIONS:
      **Job:** ...
      ### Regression timeline
      Include the regression timeline data provided above. Show:
-     - Last passing commit (SHA + date + run URL) — or "N/A" if unknown
+     - Last passing commit (SHA + date + job URL) — the most recent run in which THIS job succeeded, or "N/A" if unknown
      - First failing commit (SHA + date + job URL) — the oldest analyzed run confirmed failing with this error
      - Most recent failing commit (SHA + date + job URL)
-     The first/most-recent failing links point to the specific failing job, not the run.
+     All three links point to the specific job, not the run. A last passing commit whose run failed overall is expected and correct: other jobs in that pipeline can fail while this one passes.
      This helps readers immediately gauge when the regression started and how long it has persisted.
      ### Failing job URLs (last $consecutive runs)
      - (list each job URL)


### PR DESCRIPTION
## Problem

CI failure report issues from `tenstorrent-github-bot` almost always render **`Last passing commit: N/A`**, even when the GitHub Actions history clearly shows the test passing. Reported in Slack against [tenstorrent/tt-metal#52401](https://github.com/tenstorrent/tt-metal/issues/52401).

Two things were wrong, and they compounded:

**1. Wrong granularity.** Issues are filed **per job**, but the boundary was computed by scanning the `workflow-data.json` snapshot for runs where the whole **workflow** succeeded:

```python
elif conclusion == "success":
    if in_streak:
        last_passing_run = run
    break
```

In a multi-job pipeline a job routinely passes inside a run that fails overall because a *sibling* job failed. For the Flux.1-dev job in #52401, run [30850750750](https://github.com/tenstorrent/tt-metal/actions/runs/30850750750/job/91819645253) has `job.conclusion == success` but `run.conclusion == failure`, so it was never counted.

**2. No workflow-level success to find anyway.** `(Tier 1) Models Unit` had only **2** workflow-level successes in its last 100 runs, both from late June — nothing inside the 15-day snapshot window. So even the run-level walk came up empty and the field fell back to `N/A`.

A third, smaller bug: the boundary was computed **once per workflow** and reused for every failing job in it, so all jobs shared one answer.

## Fix

New `resolve_last_passing_boundary()` in `detect_failures.py` answers "when did *this job* last succeed?":

- Walks runs newest to oldest checking the **job's own** conclusion
- Skips runs where the job wasn't scheduled, rather than ending the search
- Skips `workflow_dispatch` runs and dedupes repeated run attempts
- Falls back to paginating live workflow history when the job last passed before the snapshot window
- Returns the **job** URL, consistent with the first/most-recent failing links

`last_passing_url` changes from a run URL to a job URL. The prompt now also tells the drafting model that a last-passing commit whose run failed overall is expected and correct, so it doesn't read that as contradictory and set `deterministic=false`.

### Cost control

The lookup runs **lazily** from `__main__.py`, after the freshness re-check and the max-issues cutoff. `iter_failing_jobs` is materialized with `list(...)` before any gating, so anything computed inside it gets paid for on candidates that are later discarded.

It's bounded four ways: a 40-run scan cap, a 15-run consecutive-missing abort (renamed or matrix-parameterized jobs), a 3-page fallback cap, and a 45s wall clock. The clock is the backstop that actually matters — a `merge-gate` run has **122 jobs**, so a single run's job page takes seconds to fetch and a run count alone doesn't bound the search.

Per-run job conclusions are now cached module-level, so consecutive-failure detection and the boundary walk share fetches instead of each paying for them.

## Verification

Against live tt-metal data for the #52401 job, the resolver returns commit `056c4c410df4`, run [30977114206](https://github.com/tenstorrent/tt-metal/actions/runs/30977114206/job/92218081501), in **6.3s**.

That's a *tighter* boundary than the run cited in the Slack report. Tracing the job's own conclusions shows why:

| Run created | Job conclusion |
|---|---|
| Aug 3 20:33 | success (the run cited in Slack) |
| Aug 4 05:07 | success |
| Aug 4 20:33 | success |
| **Aug 5 05:06** | **success — last pass** |
| Aug 5 18:26 | absent |
| Aug 5 20:32 | failure — first failing, matches the issue |
| Aug 6 05:06 | failure |

It also correctly walked past the two runs where the job wasn't scheduled.

Worst case (a job name that never appears, on `merge-gate`) is capped at **48.6s**, down from 84s before the wall clock was added.

## Test plan

- [x] `python3 -m unittest discover -s tests` — 25 tests pass
- [x] New coverage: job-passes-while-run-fails (the #52401 case), never-passed, absent-job skipping, manual-run exclusion, attempt dedupe, and all four budgets including the API fallback (which live verification does not exercise, since the Flux case resolves in the snapshot)
- [x] Existing `test_first_and_last_failing_link_to_jobs` fixture corrected — it previously returned a *failing* `build` job for the run it marked successful, which job-level logic would never accept
- [x] Live check against #52401 and a worst-case timing run on `merge-gate`
- [x] Dispatched `(triage) Create CI Triage Issues` end-to-end in dry-run mode against this branch ([run 31202423085](https://github.com/tenstorrent/tt-metal/actions/runs/31202423085), green in 3m12s)

## End-to-end verification

Dispatching this was not previously possible: the reusable workflow hardcoded `CREATE_ISSUES: "true"` and `ref: main`, so there was no dry-run mode and no way to exercise an unmerged branch. This PR adds `dry-run` and `auto-triage-ref` inputs (both defaulting to current behavior) to close that gap.

Running against the job from #52401:

```
Processing candidate 1/2: (Tier 1) Models Unit [scheduled] / models-unit-tests / TT-DiT Flux.1-dev unit tests [bh_quietbox_2]
  Last passing: 056c4c410df4 (2026-08-05T05:06:43Z)
```

Previously this reported `N/A`. Commit `056c4c41` belongs to [run 30977114206](https://github.com/tenstorrent/tt-metal/actions/runs/30977114206), whose overall conclusion is **failure** (2 of 36 jobs failed) while the Flux.1-dev job itself [succeeded](https://github.com/tenstorrent/tt-metal/actions/runs/30977114206/job/92218081501). The old workflow-level check skipped exactly this run, which is the whole bug.

`MAX_ISSUES` now also counts would-be creations, so `max-issues: 1` bounds a dry run — candidate 2 was correctly rejected with `max issues reached`. Without this, nothing incremented the counter in dry-run mode and every candidate would pay a full Copilot drafting call.

Note: `tt-metal`'s `triage-ci.yaml` needs a small follow-up to expose `dry-run` / `auto-triage-ref` as dispatch inputs; the verification above used a temporary branch (since deleted) to pass them through.

## Scope

`tt-auto-triage` only. No `tt-metal` changes needed — the fix uses live API lookups rather than extending the aggregate artifact.

Two related limitations left out of scope: extending `fetch-workflow-data` with per-job `last-success-timestamps` (would cut API calls but needs a tt-metal PR), and the same workflow-level assumption in `analyze-workflow-data/lib/analysis.js`, which drives the Slack regressions report.

Made with [Cursor](https://cursor.com)
